### PR TITLE
/texts endpoint (Paginated list)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -82,6 +82,7 @@ gem 'hebruby' # for Hebrew date handling
 
 gem 'grape', '~> 1.6.0'
 gem 'grape-entity', '~> 0.10.1'
+gem 'grape-extra_validators', '~> 2.0.0'
 
 group :production do
 #  gem 'newrelic_rpm' # performance monitoring

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -224,6 +224,9 @@ GEM
     grape-entity (0.10.1)
       activesupport (>= 3.0.0)
       multi_json (>= 1.3.2)
+    grape-extra_validators (2.0.0)
+      activesupport
+      grape (>= 1.0.0)
     haml (5.2.2)
       temple (>= 0.8.0)
       tilt
@@ -323,6 +326,7 @@ GEM
     mini_racer (0.4.0)
       libv8-node (~> 15.14.0.0)
     minitest (5.14.4)
+    mocha (1.13.0)
     moment-timezone-rails (1.0.0)
       momentjs-rails (>= 2.10.5, <= 3.0.0)
     momentjs-rails (2.20.1)
@@ -607,6 +611,7 @@ DEPENDENCIES
   gepub
   grape (~> 1.6.0)
   grape-entity (~> 0.10.1)
+  grape-extra_validators (~> 2.0.0)
   haml
   haml-rails
   hebrew (>= 0.2.1)
@@ -623,6 +628,7 @@ DEPENDENCIES
   marcel (~> 1)
   mini_magick (>= 4.9.4)
   mini_racer
+  mocha (~> 1.13.0)
   momentjs-rails
   mysql2
   nokogiri

--- a/app/api/v1/entities/manifestations_page.rb
+++ b/app/api/v1/entities/manifestations_page.rb
@@ -1,0 +1,10 @@
+module V1
+  module Entities
+    class V1::Entities::ManifestationsPage < Grape::Entity
+      expose :total_count
+      expose :data do |rec|
+        V1::Entities::Manifestation.represent rec[:data], view: options[:view], file_format: options[:file_format]
+      end
+    end
+  end
+end

--- a/app/openapi.yaml
+++ b/app/openapi.yaml
@@ -52,7 +52,32 @@ components:
       schema:
         type: integer
         minimum: 1
-
+    sortByParam:
+      name: sort_by
+      in: query
+      required: false
+      description: 'desired ordering of result set'
+      schema:
+        type: string
+        default: alphabetical
+        enum:
+          - alphabetical
+          - popularity
+          - publication_date
+          - creation_date
+          - upload_date
+    sortDirParam:
+      name: sort_dir
+      in: query
+      required: false
+      description: 'desired ordering direction'
+      schema:
+        type: string
+        default: default
+        enum:
+          - default
+          - asc
+          - desc
   schemas:
     genre:
       type: string
@@ -82,7 +107,6 @@ components:
       maxItems: 2
       items:
         type: integer
-
     gender:
       type: string
       enum:
@@ -158,6 +182,19 @@ components:
               download_url:
                 type: string
                 description: URL of the full text of the work, in the requested format (HTML by default)
+    textsPage:
+      description: "Single page of paginated texts list"
+      content:
+        application/json:
+          schema:
+            properties:
+              total_count:
+                type: integer
+              data:
+                type: array
+                items:
+                  "$ref": "#/components/responses/text"
+
 paths:
   /search:
     get:
@@ -247,24 +284,25 @@ paths:
       responses:
         '200':
           description: OK
-          schema:
-            type: array
-            items:
-              "$ref": "#/components/responses/text"
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  "$ref": "#/components/responses/text"
   /texts:
     get:
       parameters:
         - $ref: '#/components/parameters/keyParam'
         - $ref: '#/components/parameters/viewParam'
+        - $ref: '#/components/parameters/formatParam'
         - $ref: '#/components/parameters/pageParam'
+        - $ref: '#/components/parameters/sortByParam'
+        - $ref: '#/components/parameters/sortDirParam'
       summary: retrieve a specified page from the list of all texts
       responses:
         '200':
-          description: OK
-          schema:
-            type: array
-            items:
-              "$ref": "#/components/responses/text"
+          "$ref": "#/components/responses/textsPage"
   /texts/batch:
     get:
       parameters:
@@ -284,10 +322,12 @@ paths:
       responses:
         '200':
           description: OK
-          schema:
-            type: array
-            items:
-              "$ref": "#/components/responses/text"
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  "$ref": "#/components/responses/text"
   '/texts/{id}':
     get:
       parameters:

--- a/app/services/sorted_manifestations.rb
+++ b/app/services/sorted_manifestations.rb
@@ -1,0 +1,26 @@
+class SortedManifestations < ApplicationService
+  DIRECTIONS = %w(default asc desc)
+
+  SORTING_PROPERTIES = {
+    'alphabetical' => { default_dir: 'asc', column: :sort_title },
+    'popularity' => { default_dir: 'desc', column: :impressions_count },
+    'publication_date' => { default_dir: 'asc', column: 'expressions.normalized_pub_date' },
+    'creation_date' => { default_dir: 'asc', column: 'works.normalized_creation_date' },
+    'upload_date' => { default_dir: 'desc', column: :created_at }
+  }
+
+  def call(sort_by, sort_dir)
+    sort_props = SORTING_PROPERTIES[sort_by]
+    if sort_dir == 'default'
+      sort_dir = sort_props[:default_dir]
+    end
+    rel = Manifestation.all
+    if sort_by == 'publication_date'
+      rel = rel.joins(:expressions)
+    elsif sort_by == 'creation_date'
+      rel = rel.joins(expressions: :works)
+    end
+    # We additionally sort by id to order records with equal values in main sorting column
+    return rel.order("#{sort_props[:column]} #{sort_dir}, id #{sort_dir}")
+  end
+end

--- a/test/factories/expressions.rb
+++ b/test/factories/expressions.rb
@@ -18,9 +18,6 @@ FactoryBot.define do
     translation {}
     source_edition {}
     period { :modern }
-    normalized_pub_date {}
-    normalized_creation_date {}
-
     works { [ create(:work, genre: genre) ] }
   end
 end

--- a/test/services/sorted_manifestations_test.rb
+++ b/test/services/sorted_manifestations_test.rb
@@ -1,0 +1,63 @@
+require 'test_helper'
+
+class SortedManifestationsTest < ActiveSupport::TestCase
+  def setup
+    create(
+      :manifestation,
+      created_at: Time.parse('2011-03-01'),
+      title: "1st",
+      impressions_count: 200,
+      expressions: [
+        create(:expression, date: '01.01.2011', works: [ create(:work, date: '01.02.2011') ])
+      ]
+    )
+    create(
+      :manifestation,
+      created_at: Time.parse('2012-03-01'),
+      title: "2nd",
+      impressions_count: 50,
+      expressions: [
+        create(:expression, date: '01.01.2012', works: [ create(:work, date: '01.02.2012') ])
+      ]
+    )
+    create(
+      :manifestation,
+      created_at: Time.parse('2013-03-01'),
+      title: "3rd",
+      impressions_count: 100,
+      expressions: [
+        create(:expression, date: '01.01.2013', works: [ create(:work, date: '01.02.2013') ])
+      ]
+    )
+  end
+
+  test "Alphabetical sorting" do
+    assert_equal %w(1st 2nd 3rd), SortedManifestations.call('alphabetical', 'default').map(&:sort_title)
+    assert_equal %w(1st 2nd 3rd), SortedManifestations.call('alphabetical', 'asc').map(&:sort_title)
+    assert_equal %w(3rd 2nd 1st), SortedManifestations.call('alphabetical', 'desc').map(&:sort_title)
+  end
+
+  test "Popularity sorting" do
+    assert_equal [200, 100, 50], SortedManifestations.call('popularity', 'default').map(&:impressions_count)
+    assert_equal [50, 100, 200], SortedManifestations.call('popularity', 'asc').map(&:impressions_count)
+    assert_equal [200, 100, 50], SortedManifestations.call('popularity', 'desc').map(&:impressions_count)
+  end
+
+  test "Publication date sorting" do
+    assert_equal %w(2011-01-01 2012-01-01 2013-01-01), SortedManifestations.call('publication_date', 'default').map { |m| m.expressions[0].normalized_pub_date }
+    assert_equal %w(2011-01-01 2012-01-01 2013-01-01), SortedManifestations.call('publication_date', 'asc').map { |m| m.expressions[0].normalized_pub_date }
+    assert_equal %w(2013-01-01 2012-01-01 2011-01-01), SortedManifestations.call('publication_date', 'desc').map { |m| m.expressions[0].normalized_pub_date }
+  end
+
+  test 'Creation date sorting' do
+    assert_equal %w(2011-02-01 2012-02-01 2013-02-01), SortedManifestations.call('creation_date', 'default').map { |m| m.expressions[0].works[0].normalized_creation_date }
+    assert_equal %w(2011-02-01 2012-02-01 2013-02-01), SortedManifestations.call('creation_date', 'asc').map { |m| m.expressions[0].works[0].normalized_creation_date }
+    assert_equal %w(2013-02-01 2012-02-01 2011-02-01), SortedManifestations.call('creation_date', 'desc').map { |m| m.expressions[0].works[0].normalized_creation_date }
+  end
+
+  test 'Upload date sorting' do
+    assert_equal [Time.parse('2013-03-01'), Time.parse('2012-03-01'), Time.parse('2011-03-01')], SortedManifestations.call('upload_date', 'default').map { |m| m.created_at }
+    assert_equal [Time.parse('2011-03-01'), Time.parse('2012-03-01'), Time.parse('2013-03-01')], SortedManifestations.call('upload_date', 'asc').map { |m| m.created_at }
+    assert_equal [Time.parse('2013-03-01'), Time.parse('2012-03-01'), Time.parse('2011-03-01')], SortedManifestations.call('upload_date', 'desc').map { |m| m.created_at }
+  end
+end


### PR DESCRIPTION
- updated /texts/{id} and /texts/batch endpoints to only return published records
- implemented /texts endpoint returning paginated list of published texts

As we discussed I've added additional params to endpoint spec:
- file_format
- sort_by
- sort_dir

Also response returns total number of records in separate field