### PR TITLE
Search API enpoint

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -82,7 +82,9 @@ gem 'hebruby' # for Hebrew date handling
 
 gem 'grape', '~> 1.6.0'
 gem 'grape-entity', '~> 0.10.1'
-gem 'grape-extra_validators', '~> 2.0.0'
+
+# TODO: Replace to standard version of gem after PR will be accepted https://github.com/jagaapple/grape-extra_validators/pull/10
+gem 'grape-extra_validators', '~> 2.1.0', git: "https://github.com/damisul/grape-extra_validators"
 
 group :production do
 #  gem 'newrelic_rpm' # performance monitoring
@@ -93,6 +95,7 @@ group :test do
   gem 'turn', '0.8.2', require: false
   gem 'simplecov', require: false
   gem 'factory_bot_rails', '~> 6.2.0', require: false
+  gem 'mocha', '~> 1.13.0'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,11 @@
+GIT
+  remote: https://github.com/damisul/grape-extra_validators
+  revision: 26f125aa6d9fa85548b5724ab84d604b7151d13d
+  specs:
+    grape-extra_validators (2.1.0)
+      activesupport
+      grape (>= 1.0.0)
+
 GEM
   remote: http://rubygems.org/
   specs:
@@ -224,9 +232,6 @@ GEM
     grape-entity (0.10.1)
       activesupport (>= 3.0.0)
       multi_json (>= 1.3.2)
-    grape-extra_validators (2.0.0)
-      activesupport
-      grape (>= 1.0.0)
     haml (5.2.2)
       temple (>= 0.8.0)
       tilt
@@ -252,7 +257,7 @@ GEM
     http-accept (1.7.0)
     http-cookie (1.0.4)
       domain_name (~> 0.5)
-    i18n (1.8.10)
+    i18n (1.8.11)
       concurrent-ruby (~> 1.0)
     immigrant (0.3.6)
       activerecord (>= 3.0)
@@ -326,6 +331,7 @@ GEM
     mini_racer (0.4.0)
       libv8-node (~> 15.14.0.0)
     minitest (5.14.4)
+    mocha (1.13.0)
     moment-timezone-rails (1.0.0)
       momentjs-rails (>= 2.10.5, <= 3.0.0)
     momentjs-rails (2.20.1)
@@ -610,7 +616,7 @@ DEPENDENCIES
   gepub
   grape (~> 1.6.0)
   grape-entity (~> 0.10.1)
-  grape-extra_validators (~> 2.0.0)
+  grape-extra_validators (~> 2.1.0)!
   haml
   haml-rails
   hebrew (>= 0.2.1)
@@ -627,6 +633,7 @@ DEPENDENCIES
   marcel (~> 1)
   mini_magick (>= 4.9.4)
   mini_racer
+  mocha (~> 1.13.0)
   momentjs-rails
   mysql2
   nokogiri

--- a/app/api/v1/entities/manifestation.rb
+++ b/app/api/v1/entities/manifestation.rb
@@ -39,9 +39,7 @@ module V1
         expose :creation_date do |manifestation|
           normalize_date(manifestation.expressions[0].works[0].date)
         end
-        expose :place_and_publisher do |manifestation|
-          "#{manifestation.publication_place}, #{manifestation.publisher}"
-        end
+        expose :place_and_publisher
         expose :raw_publication_date do |manifestation|
           manifestation.expressions[0].date
         end
@@ -50,26 +48,10 @@ module V1
         end
       end
 
-      expose :snippet, if: lambda { |_manifestation, options| options[:view] == 'basic' } do |manifestation|
-        snippet = snippet(manifestation.markdown, 500)[0]
-        html = <<~HTML
-          <!DOCTYPE html PUBLIC \"-//W3C//DTD XHTML 1.0 Transitional//EN\" \"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd\">
-          <html xmlns=\"http://www.w3.org/1999/xhtml\" xml:lang=\"he\" lang=\"he\" dir=\"rtl\">
-          <head><meta http-equiv=\"Content-Type\" content=\"text/html; charset=utf-8\" /></head>
-          <body dir='rtl' align='right'><div dir=\"rtl\" align=\"right\">
-            #{manifestation.title_and_authors_html}
-            #{MultiMarkdown.new(snippet).to_html.force_encoding('UTF-8').gsub(/<figcaption>.*?<\/figcaption>/,'')}
-            </div>
-          </body>
-          </html>
-          HTML
-        txt = html2txt(html)
-        txt.gsub("\n","\r\n") # windows linebreaks
-      end
+      expose :txt_snippet, as: :snippet, if: lambda { |_manifestation, options| options[:view] == 'basic' }
 
       expose :download_url do |manifestation|
-        dl = GetFreshManifestationDownloadable.call(manifestation, options[:file_format])
-        Rails.application.routes.url_helpers.rails_blob_url(dl.stored_file)
+        Rails.application.routes.url_helpers.manifestation_download_url(manifestation, format: options[:file_format])
       end
     end
   end

--- a/app/api/v1/entities/manifestation_index.rb
+++ b/app/api/v1/entities/manifestation_index.rb
@@ -1,0 +1,43 @@
+module V1
+  module Entities
+    class V1::Entities::ManifestationIndex < Grape::Entity
+      expose :id
+      expose :url do |manifestation|
+        Rails.application.routes.url_helpers.manifestation_read_url(manifestation.id)
+      end
+      expose :metadata do
+        expose :title
+        expose :sort_title
+        expose :genre
+        expose :orig_lang
+        expose :orig_lang_title
+        expose :pby_publication_date do |manifestation|
+          manifestation.pby_publication_date.to_date
+        end
+        expose :author_string
+        expose :author_ids
+        expose :title_and_authors do |manifestation|
+          manifestation.title + ' / ' + manifestation.author_string
+        end
+        expose :impressions_count
+        expose :orig_publication_date
+        expose :author_gender
+        expose :translator_gender
+        expose :copyright_status
+        expose :period
+        expose :raw_creation_date
+        expose :creation_date
+        expose :place_and_publisher
+        expose :raw_publication_date
+        expose :publication_year do |manifestation|
+          dt = manifestation.orig_publication_date
+          dt.nil? ? nil : Time.parse(dt).year
+        end
+      end
+      expose :txt_snippet, as: :snippet, if: lambda { |_manifestation, options| options[:view] == 'basic' }
+      expose :download_url do |manifestation|
+        Rails.application.routes.url_helpers.manifestation_download_url(manifestation.id, format: options[:file_format])
+      end
+    end
+  end
+end

--- a/app/api/v1/entities/manifestations_page.rb
+++ b/app/api/v1/entities/manifestations_page.rb
@@ -3,7 +3,12 @@ module V1
     class V1::Entities::ManifestationsPage < Grape::Entity
       expose :total_count
       expose :data do |rec|
-        V1::Entities::Manifestation.represent rec[:data], view: options[:view], file_format: options[:file_format]
+        data = rec[:data]
+        if data.first.class.name == 'Manifestation'
+          V1::Entities::Manifestation.represent rec[:data], view: options[:view], file_format: options[:file_format]
+        else
+          V1::Entities::ManifestationIndex.represent rec[:data], view: options[:view], file_format: options[:file_format]
+        end
       end
     end
   end

--- a/app/chewy/manifestations_index.rb
+++ b/app/chewy/manifestations_index.rb
@@ -4,17 +4,20 @@ class ManifestationsIndex < Chewy::Index
   define_type Manifestation.all_published.joins([expressions: :works]).includes([expressions: :works]) do
 #    field :title, analyzer: 'hebrew' # from https://github.com/synhershko/elasticsearch-analysis-hebrew
 #    field :fulltext, value: ->(manifestation) {manifestation.to_plaintext}, analyzer: 'hebrew'
+    field :id, type: 'integer'
     field :title
     field :sort_title, type: 'keyword' # for sorting
     field :first_letter, value: ->(manifestation) {manifestation.first_hebrew_letter}
     field :fulltext, value: ->(manifestation) {manifestation.to_plaintext}
     field :genre, value: ->(manifestation) { manifestation.expressions[0].works[0].genre}, type: 'keyword'
     field :orig_lang, value: ->(manifestation) { manifestation.expressions[0].works[0].orig_lang}, type: 'keyword'
+    field :orig_lang_title, value: ->(manifestation) { manifestation.expressions[0].works[0].origlang_title}, type: 'keyword'
     field :pby_publication_date, type: 'date', value: ->{created_at}
     field :author_string, value: ->(manifestation) {manifestation.author_string}
     field :author_ids, type: 'integer', value: ->(manifestation) {manifestation.author_and_translator_ids}
     field :title_and_authors, value: ->(manifestation) {manifestation.title_and_authors}
     field :impressions_count, type: 'integer'
+    field :raw_publication_date, value: -> (manifestation) {manifestation.expressions[0].date}
     field :orig_publication_date, type: 'date', value: ->(manifestation) {normalize_date(manifestation.expressions[0].date)}
     # field :video_count, type: 'integer', value: ->(manifestation){ manifestation.video_count}
     # field :recommendation_count, type: 'integer', value: ->(manifestation){manifestation.recommendations.all_approved.count}
@@ -24,7 +27,10 @@ class ManifestationsIndex < Chewy::Index
     field :translator_gender, value: ->(manifestation) {manifestation.translator_gender}, type: 'keyword'
     field :copyright_status, value: ->(manifestation) {manifestation.copyright?}, type: 'keyword' # TODO: make non boolean
     field :period, value: ->(manifestation) {manifestation.expressions[0].period}, type: 'keyword'
+    field :raw_creation_date, value: ->(manifestation) {manifestation.expressions[0].works[0].date}
     field :creation_date, type: 'date', value: ->(manifestation) {normalize_date(manifestation.expressions[0].works[0].date)}
+    field :place_and_publisher
+    field :txt_snippet
   end
 
   # TODO: in future: collections/readers; users; recommendations; curated/featured content

--- a/app/models/expression.rb
+++ b/app/models/expression.rb
@@ -9,6 +9,8 @@ class Expression < ApplicationRecord
   has_many :persons, through: :realizers, class_name: 'Person'
   has_many :aboutnesses, as: :aboutable
 
+  validates_inclusion_of :genre, in: Work::GENRES
+
   def determine_is_translation?
     # determine whether this expression is a translation or not, i.e. is in a different language to the work it expresses
     return nil if works.empty?

--- a/app/models/manifestation.rb
+++ b/app/models/manifestation.rb
@@ -144,6 +144,22 @@ class Manifestation < ApplicationRecord
     # stripping tags -- return ActionController::Base.helpers.strip_tags(MultiMarkdown.new(markdown.lines[0..p_count].join("\n")).to_html.force_encoding('UTF-8').gsub(/<h1.*?<\/h1>/,'').gsub(/<figcaption>.*?<\/figcaption>/,'')) # remove MMD's automatic figcaptions, and the initial title
   end
 
+  # Snippet in TXT format
+  def txt_snippet
+    html = <<~HTML
+      <!DOCTYPE html PUBLIC \"-//W3C//DTD XHTML 1.0 Transitional//EN\" \"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd\">
+      <html xmlns=\"http://www.w3.org/1999/xhtml\" xml:lang=\"he\" lang=\"he\" dir=\"rtl\">
+      <head><meta http-equiv=\"Content-Type\" content=\"text/html; charset=utf-8\" /></head>
+      <body dir='rtl' align='right'><div dir=\"rtl\" align=\"right\">
+        #{title_and_authors_html}
+        #{snippet_paragraphs(15)}
+      </div></body>
+      </html>
+    HTML
+    txt = html2txt(html)
+    txt.gsub("\n","\r\n") # windows linebreaks
+  end
+
   def authors_string
     return I18n.t(:nil) if expressions[0].nil? or expressions[0].works[0].nil? or expressions[0].works[0].persons[0].nil?
     return expressions[0].works[0].authors.map{|x| x.name}.join(', ')
@@ -195,6 +211,10 @@ class Manifestation < ApplicationRecord
       end
       ret # TODO: be less naive
     end
+  end
+
+  def place_and_publisher
+    "#{publication_place}, #{publisher}"
   end
 
   def legacy_htmlfile

--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -1,10 +1,14 @@
 include BybeUtils
 class Work < ApplicationRecord
+  GENRES = %w(poetry prose drama fables article memoir letters reference lexicon).freeze
+
   has_and_belongs_to_many :expressions
   has_many :creations
   has_many :persons, through: :creations, class_name: 'Person'
   has_many :aboutnesses, as: :aboutable
   has_many :topics, class_name: 'Aboutness', source: :work
+
+  validates_inclusion_of :genre, in: GENRES
 
   before_save :norm_dates
   # has_and_belongs_to_many :people # superseded by creations and persons above

--- a/app/openapi.yaml
+++ b/app/openapi.yaml
@@ -338,7 +338,10 @@ paths:
       parameters:
         - $ref: '#/components/parameters/keyParam'
         - $ref: '#/components/parameters/viewParam'
+        - $ref: '#/components/parameters/formatParam'
         - $ref: '#/components/parameters/pageParam'
+        - $ref: '#/components/parameters/sortByParam'
+        - $ref: '#/components/parameters/sortDirParam'
         - name: genres
           in: query
           required: false

--- a/app/services/search_manifestations.rb
+++ b/app/services/search_manifestations.rb
@@ -1,0 +1,83 @@
+class SearchManifestations < ApplicationService
+
+  DIRECTIONS = %w(default asc desc)
+
+  SORTING_PROPERTIES = {
+    'alphabetical' => { default_dir: 'asc', column: :sort_title },
+    'popularity' => { default_dir: 'desc', column: :impressions_count },
+    'publication_date' => { default_dir: 'asc', column: :orig_publication_date },
+    'creation_date' => { default_dir: 'asc', column: :creation_date },
+    'upload_date' => { default_dir: 'desc', column: :pby_publication_date }
+  }
+
+  def call(sort_by, sort_dir, filters)
+    filter = []
+
+    add_simple_filter(filter, :genre, filters['genres'])
+    add_simple_filter(filter, :period, filters['periods'])
+    is_copyrighted = filters['is_copyrighted']
+
+    unless is_copyrighted.nil?
+      filter << { terms: { copyright_status: [is_copyrighted] } }
+    end
+
+    add_simple_filter(filter, :author_gender, filters['author_genders'])
+    add_simple_filter(filter, :translator_gender, filters['translator_genders'])
+    add_simple_filter(filter, :author_ids, filters['author_ids'])
+
+    original_language = filters['original_language']
+    if original_language.present?
+      # xlat - is a magic constant meaning 'any language except hebrew'
+      if original_language == 'xlat'
+        filter << { bool: { must_not: { terms: { orig_lang: ['he'] } } } }
+      else
+        filter << { terms: { orig_lang: [original_language] } }
+      end
+    end
+
+    add_date_range(filter, :pby_publication_date, filters['uploaded_between'])
+    add_date_range(filter, :creation_date, filters['created_between'])
+    add_date_range(filter, :orig_publication_date, filters['published_between'])
+
+    author = filters['author']
+    if author.present?
+      filter << { match: { author_string: author } }
+    end
+
+    title = filters['title']
+    if title.present?
+      filter << { match_phrase: { title: title } }
+    end
+
+    sort_props = SORTING_PROPERTIES[sort_by]
+    if sort_dir == 'default'
+      sort_dir = sort_props[:default_dir]
+    end
+
+    # We additionally sort by id to order records with equal values in main sorting column
+    order = [ { sort_props[:column] => sort_dir }, { id: sort_dir } ]
+
+    return ManifestationsIndex.filter(filter).order(order) # prepare ES query
+  end
+
+  private
+
+  def add_simple_filter(list, field, value)
+    return if value.blank?
+    list << { terms: { field => value } }
+  end
+
+  def add_date_range(list, field, range_param)
+    return if range_param.nil?
+    range_expr = {}
+    year = range_param[0]
+    # Greater than or equal to first day of from-year
+    range_expr['gte'] = Time.new(year, 1, 1, 0, 0, 0) if year.present?
+    year = range_param[1]
+    range_expr['lt'] = Time.new(year + 1, 1, 1, 0, 0, 0) if year.present?
+    # Less than first day of year next to to-year
+    unless range_expr.empty?
+      list << { range: { field => range_expr } }
+    end
+  end
+end

--- a/test/factories/creations.rb
+++ b/test/factories/creations.rb
@@ -1,0 +1,4 @@
+FactoryBot.define do
+  factory :creation do
+  end
+end

--- a/test/factories/persons.rb
+++ b/test/factories/persons.rb
@@ -1,0 +1,10 @@
+FactoryBot.define do
+  sequence :person_name do |n|
+    "Person #{n}"
+  end
+
+  factory :person do
+    name { generate(:person_name) }
+    gender { 'male' }
+  end
+end

--- a/test/factories/realizers.rb
+++ b/test/factories/realizers.rb
@@ -1,0 +1,4 @@
+FactoryBot.define do
+  factory :realizer do
+  end
+end

--- a/test/services/search_manifestations_test.rb
+++ b/test/services/search_manifestations_test.rb
@@ -1,0 +1,358 @@
+require 'test_helper'
+
+class SearchManifestationsTest < ActiveSupport::TestCase
+  REC_COUNT = 200
+
+  def setup
+    Chewy.massacre
+    Chewy.strategy(:atomic) do
+
+      authors = []
+      translators = []
+
+      # We create 25 authors and 25 translators
+      (1..25).each do |index|
+        author_name = %w(Alpha Beta Gamma Delta)[index % 4]
+        translator_name = %w(Pi Rho Sigma Tau Upsilon Phi)[index % 6]
+        gender = if index % 10 == 0
+                   'other'
+                 elsif index % 5  == 0
+                   'unknown'
+                 else
+                   index % 2 == 0 ? 'male' : 'female'
+                 end
+        authors << create(:person, name: "#{author_name} #{index}", gender: gender)
+        translators << create(:person, name: "#{translator_name} #{index}", gender: gender)
+      end
+
+      uploaded_at = Time.parse('2010-01-01 12:00:00')
+      published_at = Time.parse('1980-01-01')
+      created_at = Time.parse('1950-01-01')
+
+      (1..REC_COUNT).each do |index|
+        # generating random titles containing similar words
+        color = %w(red orange yellow green blue)[index % 5]
+        vegetable = %w(tomato lemon cucumber melon)[index % 4]
+
+        lang = %w(ru en de he)[index % 4]
+
+        genre = %w(poetry prose drama fables article)[index % 5]
+        period = %w(ancient medieval enlightenment revival modern)[index % 5]
+        copyrighted = index % 10 == 0
+
+        creations = [ create(:creation, person: authors[index % authors.length], role: :author) ]
+        realizers = []
+
+        # only translated works have translator
+        unless lang == 'he'
+          realizers << create(:realizer, person: translators[(index  + 7) % translators.length], role: :translator)
+        end
+
+        work = create(
+          :work,
+          orig_lang: lang,
+          genre: genre,
+          creations: creations,
+          date: created_at.strftime('%d.%m.%Y')
+        )
+        expression = create(
+          :expression,
+          period: period,
+          copyrighted: copyrighted,
+          realizers: realizers,
+          date: published_at.strftime('%d.%m.%Y'),
+          works: [work]
+        )
+        create(
+          :manifestation,
+          title: "#{color} #{vegetable} #{index} title",
+          impressions_count: index,
+          expressions: [expression],created_at: uploaded_at
+        )
+
+        uploaded_at += 1.week
+        published_at += 1.month
+        created_at += 3.months
+      end
+    end
+  end
+
+  test 'Filter by genres works' do
+    records = SearchManifestations.call('alphabetical', 'asc', { 'genres' => %w(poetry) })
+    assert_equal 40, records.count
+    records.limit(REC_COUNT).each do |rec|
+      assert_equal 'poetry', rec.genre
+    end
+
+    records = SearchManifestations.call('alphabetical', 'asc', { 'genres' => %w(poetry article) })
+    assert_equal 80, records.count
+    records.limit(REC_COUNT).each do |rec|
+      assert_includes %w(poetry article), rec.genre
+    end
+  end
+
+  test 'Filter by periods works' do
+    records = SearchManifestations.call('alphabetical', 'asc', { 'periods' => %w(ancient) })
+    assert_equal 40, records.count
+    records.limit(REC_COUNT).each do |rec|
+      assert_equal 'ancient', rec.period
+    end
+
+    records = SearchManifestations.call('alphabetical', 'asc', { 'periods' => %w(ancient revival) })
+    assert_equal 80, records.count
+    records.limit(REC_COUNT).each do |rec|
+      assert_includes %w(ancient revival), rec.period
+    end
+  end
+
+  test 'Filter by copyright works' do
+    records = SearchManifestations.call('alphabetical', 'asc', { 'is_copyrighted' => true })
+    assert_equal 20, records.count
+    records.limit(REC_COUNT).each do |rec|
+      assert rec.copyright_status
+    end
+
+    records = SearchManifestations.call('alphabetical', 'asc', { 'is_copyrighted' => false })
+    assert_equal 180, records.count
+    records.limit(REC_COUNT).each do |rec|
+      assert_not rec.copyright_status
+    end
+  end
+
+  test 'Filter by author_genders works' do
+    records = SearchManifestations.call('alphabetical', 'asc', { 'author_genders' => [:male] })
+    assert_equal 80, records.count
+    records.limit(REC_COUNT).each do |rec|
+      assert_equal %w(male), rec.author_gender
+    end
+
+    records = SearchManifestations.call('alphabetical', 'asc', { 'author_genders' => [:male, :female, :unknown] })
+    assert_equal 184, records.count
+    records.limit(REC_COUNT).each do |rec|
+      assert_includes [%w(male), %w(female), %w(unknown)], rec.author_gender
+    end
+  end
+
+  test 'Filter by translator_genders works' do
+    records = SearchManifestations.call('alphabetical', 'asc', { 'translator_genders' => [:female] })
+    assert_equal 60, records.count
+    records.limit(REC_COUNT).each do |rec|
+      assert_equal %w(female), rec.translator_gender
+    end
+
+    records = SearchManifestations.call('alphabetical', 'asc', { 'translator_genders' => [:male, :female, :other] })
+    assert_equal 132, records.count
+    records.limit(REC_COUNT).each do |rec|
+      assert_includes [%w(male), %w(female), %w(other)], rec.translator_gender
+    end
+  end
+
+  test 'Filter by title works' do
+    records = SearchManifestations.call('alphabetical', 'asc', { 'title' => 'orange' })
+    assert_equal 40, records.count
+    records.limit(REC_COUNT).each do |rec|
+      assert_match /orange/, rec.title
+    end
+
+    records = SearchManifestations.call('alphabetical', 'asc', { 'title' => 'orange lemon' })
+    assert_equal 10, records.count
+    records.limit(REC_COUNT).each do |rec|
+      assert_match /orange lemon/, rec.title
+    end
+
+    records = SearchManifestations.call('alphabetical', 'asc', { 'title' => 'Abrakadabra' })
+    assert_equal 0, records.count
+  end
+
+  test 'Filter by author works' do
+    # Searches by author's name
+    records = SearchManifestations.call('alphabetical', 'asc', { 'author' => 'Alpha' })
+    assert_equal 48, records.count
+    records.limit(REC_COUNT).each do |rec|
+      assert_match /Alpha/, rec.author_string
+    end
+
+    # it also searches by translator's name
+    records = SearchManifestations.call('alphabetical', 'asc', { 'author' => 'Sigma' })
+    assert_equal 24, records.count
+    records.limit(REC_COUNT).each do |rec|
+      assert_match /Sigma/, rec.author_string
+    end
+
+    # mixed search by author and translator names, returns records where any of provided words matches author
+    # or translator (or both)
+    records = SearchManifestations.call('alphabetical', 'asc', { 'author' => 'Sigma Alpha' })
+    assert_equal 66, records.count
+    records.limit(REC_COUNT).each do |rec|
+      assert rec.author_string =~ /(Sigma|Alpha)/
+    end
+
+    records = SearchManifestations.call('alphabetical', 'asc', { 'author' => 'Abrakadabra' })
+    assert_equal 0, records.count
+  end
+
+  test 'Search by both author and title works' do
+    records = SearchManifestations.call('alphabetical', 'asc', { 'author' => 'Alpha', 'title' => 'orange lemon' })
+    assert_equal 2, records.count
+
+    records.limit(REC_COUNT).each do |rec|
+      assert_match /Alpha/, rec.author_string
+      assert_match /orange lemon/, rec.title
+    end
+  end
+
+  test 'Filter by author_ids works' do
+    author_id = Person.find_by(name: 'Beta 1').id
+    records = SearchManifestations.call('alphabetical', 'asc', { 'author_ids' => [author_id] })
+    assert_equal 8, records.count
+    records.limit(REC_COUNT).each do |rec|
+      assert_includes rec.author_ids, author_id
+    end
+
+    # it also takes in account translators
+    translator_id = Person.find_by(name: 'Rho 1').id
+    records = SearchManifestations.call('alphabetical', 'asc', { 'author_ids' => [translator_id] })
+    assert_equal 6, records.count
+    records.limit(REC_COUNT).each do |rec|
+      assert_includes rec.author_ids, translator_id
+    end
+  end
+
+  test 'Filter by original_language works' do
+    # search by a single language
+    records = SearchManifestations.call('alphabetical', 'asc', { 'original_language' => 'ru' })
+    assert_equal 50, records.count
+    records.limit(REC_COUNT).each do |rec|
+      assert_equal 'ru', rec.orig_lang
+    end
+
+    # xlat means 'all translated', so we should get all works except works in Hebrew
+    records = SearchManifestations.call('alphabetical', 'asc', { 'original_language' => 'xlat' })
+    assert_equal 150, records.count
+    records.limit(REC_COUNT).each do |rec|
+      assert_includes %w(ru en de), rec.orig_lang
+    end
+  end
+
+  test 'Filter by uploaded date works' do
+    records = SearchManifestations.call('alphabetical', 'asc', { 'uploaded_between' => [2010, 2010] })
+    assert_equal 53, records.count
+    records.limit(REC_COUNT).each do |rec|
+      assert_includes Time.parse('2010-01-01')..Time.parse('2010-12-31 23:59:59'), Time.parse(rec.pby_publication_date)
+    end
+
+    records = SearchManifestations.call('alphabetical', 'asc', { 'uploaded_between' => [2010, 2011] })
+    assert_equal 105, records.count
+
+    records = SearchManifestations.call('alphabetical', 'asc', { 'uploaded_between' => [nil, 2010] })
+    assert_equal 53, records.count
+
+    records = SearchManifestations.call('alphabetical', 'asc', { 'uploaded_between' => [2012, nil] })
+    assert_equal 95, records.count
+
+    # if no limits specified, it returns all records
+    records = SearchManifestations.call('alphabetical', 'asc', { 'uploaded_between' => [nil, nil] })
+    assert_equal REC_COUNT, records.count
+  end
+
+  test 'Filter by publication date works' do
+    records = SearchManifestations.call('alphabetical', 'asc', { 'published_between' => [1980, 1980] })
+    assert_equal 12, records.count
+    records.limit(REC_COUNT).each do |rec|
+      assert_includes Time.parse('1980-01-01')..Time.parse('1980-12-31 23:59:59'), Time.parse(rec.orig_publication_date)
+    end
+
+    records = SearchManifestations.call('alphabetical', 'asc', { 'published_between' => [1990, 1992] })
+    assert_equal 36, records.count
+
+    records = SearchManifestations.call('alphabetical', 'asc', { 'published_between' => [nil, 1984] })
+    assert_equal 60, records.count
+
+    records = SearchManifestations.call('alphabetical', 'asc', { 'published_between' => [1985, nil] })
+    assert_equal 140, records.count
+  end
+
+  test 'Filter by creation date works' do
+    records = SearchManifestations.call('alphabetical', 'asc', { 'created_between' => [1950, 1950] })
+    assert_equal 4, records.count
+    records.limit(REC_COUNT).each do |rec|
+      assert_includes Time.parse('1950-01-01')..Time.parse('1950-12-31 23:59:59'), Time.parse(rec.creation_date)
+    end
+
+    records = SearchManifestations.call('alphabetical', 'asc', { 'created_between' => [1950, 1952] })
+    assert_equal 12, records.count
+
+    records = SearchManifestations.call('alphabetical', 'asc', { 'created_between' => [nil, 1952] })
+    assert_equal 12, records.count
+
+    records = SearchManifestations.call('alphabetical', 'asc', { 'created_between' => [1985, nil] })
+    assert_equal 60, records.count
+  end
+
+  test 'Alphabetical sorting works' do
+    asc_order = Manifestation.all_published.order(title: :asc).map(&:id)
+
+    records = SearchManifestations.call('alphabetical', 'default', { })
+    assert_equal asc_order, records.limit(REC_COUNT).map(&:id)
+
+    records = SearchManifestations.call('alphabetical', 'asc', { })
+    assert_equal asc_order, records.limit(REC_COUNT).map(&:id)
+
+    records = SearchManifestations.call('alphabetical', 'desc', { })
+    assert_equal asc_order.reverse, records.limit(REC_COUNT).map(&:id)
+  end
+
+  test 'Popularity sorting works' do
+    desc_order = Manifestation.all_published.order(impressions_count: :desc).map(&:id)
+
+    records = SearchManifestations.call('popularity', 'default', { })
+    assert_equal desc_order, records.limit(REC_COUNT).map(&:id)
+
+    records = SearchManifestations.call('popularity', 'asc', { })
+    assert_equal desc_order.reverse, records.limit(REC_COUNT).map(&:id)
+
+    records = SearchManifestations.call('popularity', 'desc', { })
+    assert_equal desc_order, records.limit(REC_COUNT).map(&:id)
+  end
+
+  test 'Publication date sorting works' do
+    asc_order = Manifestation.all_published.joins(:expressions).order('expressions.normalized_pub_date').map(&:id)
+
+    records = SearchManifestations.call('publication_date', 'default', { })
+    assert_equal asc_order, records.limit(REC_COUNT).map(&:id)
+
+    records = SearchManifestations.call('publication_date', 'asc', { })
+    assert_equal asc_order, records.limit(REC_COUNT).map(&:id)
+
+    records = SearchManifestations.call('publication_date', 'desc', { })
+    assert_equal asc_order.reverse, records.limit(REC_COUNT).map(&:id)
+  end
+
+  test 'Creation date sorting works' do
+    asc_order = Manifestation.all_published.joins(expressions: :works).order('works.normalized_creation_date').map(&:id)
+
+    records = SearchManifestations.call('creation_date', 'default', { })
+    assert_equal asc_order, records.limit(REC_COUNT).map(&:id)
+
+    records = SearchManifestations.call('creation_date', 'asc', { })
+    assert_equal asc_order, records.limit(REC_COUNT).map(&:id)
+
+    records = SearchManifestations.call('creation_date', 'desc', { })
+    assert_equal asc_order.reverse, records.limit(REC_COUNT).map(&:id)
+  end
+
+  test 'Upload date sorting works' do
+    desc_order = Manifestation.all_published.order(created_at: :desc).map(&:id)
+
+    records = SearchManifestations.call('upload_date', 'default', { })
+    assert_equal desc_order, records.limit(REC_COUNT).map(&:id)
+
+    records = SearchManifestations.call('upload_date', 'asc', { })
+    assert_equal desc_order.reverse, records.limit(REC_COUNT).map(&:id)
+
+    records = SearchManifestations.call('upload_date', 'desc', { })
+    assert_equal desc_order, records.limit(REC_COUNT).map(&:id)
+  end
+
+
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -7,6 +7,7 @@ require 'rails/test_help'
 
 require 'chewy/minitest'
 require 'factory_bot_rails'
+require 'mocha/minitest'
 
 Chewy.strategy(:bypass)
 


### PR DESCRIPTION
Implemented /api/v1/search enpoint

In order to do this I made some additional changes:
- added some fields to ManifestationIndex
- changed format or download_url in response from direct link to Rails Active Storage, to /download/{id} url: it allows us to avoid fetching db data for Manifestation
- added genres validation to Work and Expression models
- made some minor changes to Models to avoid code duplicaiton