### PR TITLE
Moved linktype and link_status enums declaration from Manifestation t…

### DIFF
--- a/app/controllers/manifestation_controller.rb
+++ b/app/controllers/manifestation_controller.rb
@@ -501,9 +501,7 @@ class ManifestationController < ApplicationController
           @m.status = params[:mstatus].to_i
           @m.sefaria_linker = params[:sefaria_linker]
           unless params[:add_url].blank?
-            l = ExternalLink.new(url: params[:add_url], linktype: params[:link_type], description: params[:link_description], status: Manifestation.linkstatuses[:approved])
-            l.manifestation = @m
-            l.save!
+            @m.external_links.create!(url: params[:add_url], linktype: params[:link_type], description: params[:link_description], status: :approved)
           end
           @w.save!
           @e.save!
@@ -1114,7 +1112,6 @@ class ManifestationController < ApplicationController
           end
         end
       end
-      @ext_links = @m.external_links.load
     end
   end
 end

--- a/app/models/external_link.rb
+++ b/app/models/external_link.rb
@@ -1,8 +1,17 @@
 class ExternalLink < ApplicationRecord
   belongs_to :manifestation
 
-  scope :videos, -> { where(linktype: Manifestation.link_types[:youtube])}
-  scope :publisher_sites, -> {where(linktype: Manifestation.link_types[:publisher_site])}
-  scope :all_approved, -> { where(status: Manifestation.linkstatuses[:approved])}
-  scope :publisher_links, ->{where(linktype: Manifestation.link_types[:publisher_site])}
+  enum linktype: {
+    wikipedia: 0,
+    blog: 1,
+    youtube: 2,
+    other: 3,
+    publisher_site: 4
+  }, _prefix: true
+
+  enum status: {
+    approved: 0,
+    submitted: 1,
+    rejected: 2
+  }, _prefix: true
 end

--- a/app/models/html_file.rb
+++ b/app/models/html_file.rb
@@ -630,8 +630,7 @@ class HtmlFile < ApplicationRecord
           save!
           m.recalc_cached_people!
           unless self.pub_link.empty? or self.pub_link_text.empty?
-            el = ExternalLink.new(linktype: Manifestation.link_types[:publisher_site], url: self.pub_link, description: self.pub_link_text)
-            m.external_links << el
+            m.external_links.build(linktype: :publisher_site, url: self.pub_link, description: self.pub_link_text)
           end
         }
         return true

--- a/app/models/html_file.rb
+++ b/app/models/html_file.rb
@@ -631,6 +631,7 @@ class HtmlFile < ApplicationRecord
           m.recalc_cached_people!
           unless self.pub_link.empty? or self.pub_link_text.empty?
             m.external_links.build(linktype: :publisher_site, url: self.pub_link, description: self.pub_link_text)
+            m.save!
           end
         }
         return true

--- a/app/models/manifestation.rb
+++ b/app/models/manifestation.rb
@@ -19,8 +19,6 @@ class Manifestation < ApplicationRecord
 
   before_save :update_sort_title
 
-  enum link_type: [:wikipedia, :blog, :youtube, :other, :publisher_site]
-  enum linkstatus: [:approved, :submitted, :rejected]
   enum status: [:published, :nonpd, :unpublished, :deprecated]
 
   scope :all_published, -> { where(status: Manifestation.statuses[:published])}
@@ -50,7 +48,7 @@ class Manifestation < ApplicationRecord
   end
 
   def video_count
-    return external_links.all_approved.videos.count
+    return external_links.status_approved.linktype_youtube.count
   end
 
   # this will return the downloadable entity for the Manifestation *if* it is fresh
@@ -267,7 +265,7 @@ class Manifestation < ApplicationRecord
   end
 
   def self.add_publisher_link_to_works(worklist, url, linktext)
-    el = ExternalLink.new(linktype: Manifestation.link_types[:publisher_site], url: url, description: linktext)
+    el = ExternalLink.new(linktype: :publisher_site, url: url, description: linktext)
     works = Manifestation.find(worklist)
     works.each do |m|
       newel = el.dup

--- a/app/views/manifestation/_external_links.html.haml
+++ b/app/views/manifestation/_external_links.html.haml
@@ -2,6 +2,6 @@
   - links.each do |link|
     %li
       = link_to link.description, link.url
-      = ' ('+t(Manifestation.link_types.keys[link.linktype])+')'
+      = ' ('+t(link.linktype)+')'
       - if edit
         = link_to t(:destroy), url_for(action: :remove_link, link_id: link.id, id: @m.id), :data => { :confirm => t(:are_you_sure) }

--- a/app/views/manifestation/_metadata.html.haml
+++ b/app/views/manifestation/_metadata.html.haml
@@ -50,15 +50,16 @@
       - unless @e.date.nil? || @e.date.empty?
         - edition += '; '+@e.date
       = edition
-  - if @ext_links.publisher_sites.count > 0
+
+  - publisher_link = @m.external_links.detect(&:linktype_publisher_site?)
+  - if publisher_link.present?
     .work-details
       -# simple case: default title, link to url with description as link text
-      - el = @ext_links.publisher_sites.first
-      - if el.description.index('&&&').nil?
+      - if publisher_link.description.index('&&&').nil?
         %span{style: 'font-weight: bold'}= t(:made_available_by)
-        = link_to el.description, el.url
+        = link_to publisher_link.description, publisher_link.url
       - else # custom case: use description as raw-HTML format string, replacing &&&(.*)&&& with the link
-        != el.description.sub(/&&&(.*)&&&/, "<a href=\"#{el.url}\" target=\"_blank\">\\1</a>")
+        != publisher_link.description.sub(/&&&(.*)&&&/, "<a href=\"#{publisher_link.url}\" target=\"_blank\">\\1</a>")
   / tags and recommendations
   - if tags_etc
     .work-details.mobile-work-details

--- a/app/views/manifestation/edit_metadata.html.haml
+++ b/app/views/manifestation/edit_metadata.html.haml
@@ -77,7 +77,7 @@
     = t(:add)
     = text_field_tag :add_url
     = t(:link_type)
-    = select_tag :link_type, options_for_select(Manifestation.link_types.map {|lt| [t(lt[0]), lt[1]]})
+    = select_tag :link_type, options_for_select(ExternalLink.linktypes.map {|lt| [t(lt[0]), lt[1]]})
     %br
     = t(:description)
     = text_field_tag :link_description

--- a/app/views/manifestation/read.html.haml
+++ b/app/views/manifestation/read.html.haml
@@ -131,7 +131,7 @@
                     %span
                       != tr.translators.map{|t| link_to(t.name, author_toc_path(id: t.id))}.join(', ')
           -# External links
-          - if @m.external_links.count > 0
+          - if @m.external_links.to_a.size > 0
             .by-card-v02.left-side-card-v02
               .by-card-header-left-v02
                 %span.headline-1-v02= t(:external_links)

--- a/app/views/shared/_work_links.html.haml
+++ b/app/views/shared/_work_links.html.haml
@@ -4,9 +4,9 @@
   = link_to links[0].url do
     .icon.card-header-element
       - case linktype
-      - when Manifestation.link_types[:youtube]
+      - when ExternalLink.linktypes[:youtube]
         %i.fa.fa-youtube-play
-      - when Manifestation.link_types[:blog]
+      - when ExternalLink.linktypes[:blog]
         %i.fa.fa-pencil-square-o
     .card-header-element{style:'margin-left: 2.4rem'}
       %p= links[0].description


### PR DESCRIPTION
Moved linktype and link_status enums declaration from Manifestation to ExternalLink model.
Refactored existing code to reflect those changes. Replaced manually added scopes with automatically-generated.

@abartov , I've tested most of changes, except manifestation#update and html_file#create_WEM_new, as I'm not sure how to find those pages in UI. Could you please ensure it is working?

