### PR TITLE
Enrichment view and snippet param

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -95,11 +95,11 @@ group :test do
   gem 'turn', '0.8.2', require: false
   gem 'simplecov', require: false
   gem 'factory_bot_rails', '~> 6.2.0', require: false
+  gem 'faker', '~> 2.19.0'
   gem 'mocha', '~> 1.13.0'
 end
 
 group :development do
-  gem 'byebug'
   gem 'web-console'
   gem "capistrano", "~> 3.11", require: false
   gem "capistrano-rails", "~> 1.4", require: false
@@ -110,4 +110,8 @@ group :development do
   gem 'bullet'
   gem 'active_record_query_trace'
   gem 'immigrant'
+end
+
+group :test, :development do
+  gem 'byebug'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -187,6 +187,8 @@ GEM
     factory_bot_rails (6.2.0)
       factory_bot (~> 6.2.0)
       railties (>= 5.0.0)
+    faker (2.19.0)
+      i18n (>= 1.6, < 2)
     faraday (1.7.0)
       faraday-em_http (~> 1.0)
       faraday-em_synchrony (~> 1.0)
@@ -612,6 +614,7 @@ DEPENDENCIES
   docx
   execjs
   factory_bot_rails (~> 6.2.0)
+  faker (~> 2.19.0)
   gared (>= 0.0.23)
   gepub
   grape (~> 1.6.0)

--- a/app/api/v1/entities/external_link.rb
+++ b/app/api/v1/entities/external_link.rb
@@ -1,0 +1,9 @@
+module V1
+  module Entities
+    class ExternalLink < Grape::Entity
+      expose :url
+      expose :linktype, as: :type
+      expose :description
+    end
+  end
+end

--- a/app/api/v1/entities/manifestation.rb
+++ b/app/api/v1/entities/manifestation.rb
@@ -1,6 +1,6 @@
 module V1
   module Entities
-    class V1::Entities::Manifestation < Grape::Entity
+    class Manifestation < Grape::Entity
       expose :id
       expose :url do |manifestation|
         Rails.application.routes.url_helpers.manifestation_read_url(manifestation)
@@ -48,11 +48,17 @@ module V1
         end
       end
 
-      expose :txt_snippet, as: :snippet, if: lambda { |_manifestation, options| options[:view] == 'basic' }
+      expose :enrichment, if: lambda { |_manifestation, options| options[:view] == 'enriched' } do |manifestation|
+        V1::Entities::ManifestationEnrichment.represent manifestation.id
+      end
+
+      expose :txt_snippet, as: :snippet, if: lambda { |_manifestation, options| options[:snippet] }
 
       expose :download_url do |manifestation|
         Rails.application.routes.url_helpers.manifestation_download_url(manifestation, format: options[:file_format])
       end
+
+
     end
   end
 end

--- a/app/api/v1/entities/manifestation_enrichment.rb
+++ b/app/api/v1/entities/manifestation_enrichment.rb
@@ -17,7 +17,9 @@ module V1
 
       expose :works_about do |manifestation_id|
         w = ::Work.joins(expressions: :manifestations).where('manifestations.id = ?', manifestation_id)
-        Aboutness.where(aboutable: w).order(:work_id).pluck(:work_id)
+        Aboutness.where(aboutable: w)
+                 .joins(work: {expressions: :manifestations})
+                 .pluck('manifestations.id').sort
       end
     end
   end

--- a/app/api/v1/entities/manifestation_enrichment.rb
+++ b/app/api/v1/entities/manifestation_enrichment.rb
@@ -1,0 +1,24 @@
+module V1
+  module Entities
+    class V1::Entities::ManifestationEnrichment < Grape::Entity
+      expose :external_links do |manifestation_id|
+        links = ::ExternalLink.where(manifestation_id: manifestation_id).status_approved.order(:id)
+        V1::Entities::ExternalLink.represent links
+      end
+
+      expose :taggings do |manifestation_id|
+        Tag.approved.joins(:taggings).merge(Tagging.where(manifestation_id: manifestation_id)).pluck(:name).sort
+      end
+
+      expose :recommendations do |manifestation_id|
+        recommendations = ::Recommendation.approved.where(manifestation_id: manifestation_id).preload(:user)
+        V1::Entities::Recommendation.represent recommendations
+      end
+
+      expose :works_about do |manifestation_id|
+        w = ::Work.joins(expressions: :manifestations).where('manifestations.id = ?', manifestation_id)
+        Aboutness.where(aboutable: w).order(:work_id).pluck(:work_id)
+      end
+    end
+  end
+end

--- a/app/api/v1/entities/manifestation_index.rb
+++ b/app/api/v1/entities/manifestation_index.rb
@@ -1,6 +1,6 @@
 module V1
   module Entities
-    class V1::Entities::ManifestationIndex < Grape::Entity
+    class ManifestationIndex < Grape::Entity
       expose :id
       expose :url do |manifestation|
         Rails.application.routes.url_helpers.manifestation_read_url(manifestation.id)
@@ -34,7 +34,10 @@ module V1
           dt.nil? ? nil : Time.parse(dt).year
         end
       end
-      expose :txt_snippet, as: :snippet, if: lambda { |_manifestation, options| options[:view] == 'basic' }
+      expose :enrichment, if: lambda { |_manifestation, options| options[:view] == 'enriched' } do |manifestation|
+        V1::Entities::ManifestationEnrichment.represent manifestation.id
+      end
+      expose :txt_snippet, as: :snippet, if: lambda { |_manifestation, options| options[:snippet] }
       expose :download_url do |manifestation|
         Rails.application.routes.url_helpers.manifestation_download_url(manifestation.id, format: options[:file_format])
       end

--- a/app/api/v1/entities/manifestations_page.rb
+++ b/app/api/v1/entities/manifestations_page.rb
@@ -1,13 +1,13 @@
 module V1
   module Entities
-    class V1::Entities::ManifestationsPage < Grape::Entity
+    class ManifestationsPage < Grape::Entity
       expose :total_count
       expose :data do |rec|
         data = rec[:data]
         if data.first.class.name == 'Manifestation'
-          V1::Entities::Manifestation.represent rec[:data], view: options[:view], file_format: options[:file_format]
+          V1::Entities::Manifestation.represent rec[:data], view: options[:view], file_format: options[:file_format], snippet: options[:snippet]
         else
-          V1::Entities::ManifestationIndex.represent rec[:data], view: options[:view], file_format: options[:file_format]
+          V1::Entities::ManifestationIndex.represent rec[:data], view: options[:view], file_format: options[:file_format], snippet: options[:snippet]
         end
       end
     end

--- a/app/api/v1/entities/recommendation.rb
+++ b/app/api/v1/entities/recommendation.rb
@@ -1,0 +1,14 @@
+module V1
+  module Entities
+    class Recommendation < Grape::Entity
+      expose :body, as: :fulltext
+      expose :user_id, as: :recommender_user_id
+      expose :recommender_home_url do |recommendation|
+        # TODO: implement when field will be added
+      end
+      expose :recommendation_date do |recommendation|
+        recommendation.created_at.to_date
+      end
+    end
+  end
+end

--- a/app/chewy/manifestations_index.rb
+++ b/app/chewy/manifestations_index.rb
@@ -1,7 +1,7 @@
 class ManifestationsIndex < Chewy::Index
 
   # works
-  define_type Manifestation.all_published.joins([expressions: :works]).includes([expressions: :works]) do
+  define_type Manifestation.all_published.includes(expressions: :works) do
 #    field :title, analyzer: 'hebrew' # from https://github.com/synhershko/elasticsearch-analysis-hebrew
 #    field :fulltext, value: ->(manifestation) {manifestation.to_plaintext}, analyzer: 'hebrew'
     field :id, type: 'integer'

--- a/app/controllers/manifestation_controller.rb
+++ b/app/controllers/manifestation_controller.rb
@@ -264,7 +264,7 @@ class ManifestationController < ApplicationController
           @links = @m.external_links.group_by {|l| l.linktype}
           @random_work = Manifestation.where(id: Manifestation.pluck(:id).sample(5), status: Manifestation.statuses[:published])[0]
           @header_partial = 'manifestation/work_top'
-          @works_about = Work.joins(:topics).where('aboutnesses.aboutable_id': @w.id, 'aboutnesses.aboutable_type': 'Work') # TODO: accommodate works about *expressions* (e.g. an article about a *translation* of Homer's Iliad, not the Iliad)
+          @works_about = @w.works_about
           @scrollspy_target = 'chapternav'
           prep_user_content(:manifestation)
         end

--- a/app/models/recommendation.rb
+++ b/app/models/recommendation.rb
@@ -5,6 +5,6 @@ class Recommendation < ApplicationRecord
 
   enum status: [:pending, :approved]
 
-  scope :all_pending, -> { where(status: Recommendation.statuses[:pending]) }
-  scope :all_approved, -> { where(status: Recommendation.statuses[:approved]) }
+  scope :all_pending, -> { pending }
+  scope :all_approved, -> { approved }
 end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -3,7 +3,4 @@ class Tag < ApplicationRecord
   has_many :manifestations, through: :taggings, class_name: 'Manifestation'
   belongs_to :creator, foreign_key: :created_by, class_name: 'User'
   enum status: [:pending, :approved]
-
-  scope :pending, -> { where(status: Tag.statuses[:pending]) }
-  scope :approved, -> { where(status: Tag.statuses[:approved]) }
 end

--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -27,6 +27,11 @@ class Work < ApplicationRecord
     return nil
   end
 
+  def works_about
+    # TODO: accommodate works about *expressions* (e.g. an article about a *translation* of Homer's Iliad, not the Iliad)
+    Work.joins(:topics).where('aboutnesses.aboutable_id': self.id, 'aboutnesses.aboutable_type': 'Work')
+  end
+
   protected
   def norm_dates
     nd = normalize_date(self.date)

--- a/app/openapi.yaml
+++ b/app/openapi.yaml
@@ -155,9 +155,9 @@ components:
       properties:
         url:
           type: string
-        link_description:
+        description:
           type: string
-        link_type:
+        type:
           type: string
           enum:
             - wikipedia

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_11_01_075649) do
+ActiveRecord::Schema.define(version: 2021_11_24_132658) do
 
   create_table "aboutnesses", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin", force: :cascade do |t|
     t.integer "work_id"
@@ -220,6 +220,7 @@ ActiveRecord::Schema.define(version: 2021_11_01_075649) do
     t.datetime "updated_at", null: false
     t.integer "manifestation_id"
     t.string "description"
+    t.index ["manifestation_id"], name: "external_links_manifestation_id_fk"
   end
 
   create_table "featured_author_features", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin", force: :cascade do |t|
@@ -721,6 +722,7 @@ ActiveRecord::Schema.define(version: 2021_11_01_075649) do
   add_foreign_key "dictionary_entries", "manifestations"
   add_foreign_key "dictionary_links", "dictionary_entries", column: "from_entry_id"
   add_foreign_key "dictionary_links", "dictionary_entries", column: "to_entry_id"
+  add_foreign_key "external_links", "manifestations", name: "external_links_manifestation_id_fk"
   add_foreign_key "featured_author_features", "featured_authors"
   add_foreign_key "featured_authors", "people"
   add_foreign_key "featured_authors", "users"

--- a/test/api/v1/api_test.rb
+++ b/test/api/v1/api_test.rb
@@ -84,7 +84,8 @@ class V1::APITest < ActiveSupport::TestCase
     assert_manifestation(json, @manifestation, 'enriched', 'pdf', false)
     # ensuring non-published tags are excluded
     assert_equal %w(popular), json['enrichment']['taggings']
-    assert_equal [@manifestation_2.expressions[0].works[0].id], json['enrichment']['works_about']
+    # checking works_about
+    assert_equal [@manifestation_2.id], json['enrichment']['works_about']
   end
 
   test 'GET /v1/api/texts/{id} fails if id not found in published manifestations' do
@@ -402,8 +403,8 @@ class V1::APITest < ActiveSupport::TestCase
         assert_nil json_recommendation['recommender_home_url']
         assert_equal r.created_at.to_date.strftime('%Y-%m-%d'), json_recommendation['recommendation_date']
       end
-
-      assert_equal manifestation.expressions[0].works[0].works_about.pluck(:id).sort, enrichment['works_about']
+      works_about = manifestation.expressions[0].works[0].works_about
+      assert_equal works_about.joins(expressions: :manifestations).pluck('manifestations.id').sort, enrichment['works_about']
     else
       assert_not json.keys.include?('enrichment')
     end

--- a/test/api/v1/api_test.rb
+++ b/test/api/v1/api_test.rb
@@ -7,9 +7,28 @@ class V1::APITest < ActiveSupport::TestCase
     @key = create(:api_key)
     @disabled_key = create(:api_key, status: :disabled)
 
+    tag_popular = create(:tag, name: :popular)
+    tag_unpopular = create(:tag, name: :unpopular)
+    tag_pending = create(:tag, name: :pending, status: :pending)
+
     Chewy.strategy(:atomic) do
-      @manifestation = create(:manifestation, title: '1st', impressions_count: 3, markdown: 'Sample Text 1')
-      @manifestation_2 = create(:manifestation, title: '2nd', impressions_count: 2, markdown: 'Sample Text 2')
+      @manifestation = create(
+        :manifestation, :with_recommendations, :with_external_links,
+        title: '1st',
+        impressions_count: 3,
+        markdown: 'Sample Text 1',
+        taggings: [ create(:tagging, tag: tag_popular),  create(:tagging, tag: tag_pending) ]
+      )
+      @manifestation_2 = create(
+        :manifestation, :with_recommendations, :with_external_links,
+        title: '2nd',
+        impressions_count: 2,
+        markdown: 'Sample Text 2',
+        taggings: [ create(:tagging, tag: tag_unpopular), create(:tagging, tag: tag_pending) ]
+      )
+
+      create(:aboutness, work: @manifestation_2.expressions[0].works[0], aboutable: @manifestation.expressions[0].works[0])
+
       @unpublished_manifestation = create(:manifestation, status: :unpublished)
     end
   end
@@ -37,25 +56,35 @@ class V1::APITest < ActiveSupport::TestCase
     assert_key_failed
   end
 
-  test 'GET /v1/api/texts/{id} with default params succeed and returns basic view in html format' do
+  test 'GET /v1/api/texts/{id} with default params succeed and returns basic view in html format without snippet' do
     get "/api/v1/texts/#{@manifestation.id}?key=#{@key.key}"
     assert last_response.successful?
     json = JSON.parse(last_response.body)
-    assert_manifestation(json, @manifestation, 'html', true)
+    assert_manifestation(json, @manifestation, 'basic', 'html', false)
   end
 
-  test 'GET /v1/api/texts/{id} with basic view and epub format succeed' do
-    get "/api/v1/texts/#{@manifestation.id}?key=#{@key.key}&view=basic&file_format=epub"
+  test 'GET /v1/api/texts/{id} with basic view, epub format and snippet succeed' do
+    get "/api/v1/texts/#{@manifestation.id}?key=#{@key.key}&view=basic&file_format=epub&snippet=true"
     assert last_response.successful?
     json = JSON.parse(last_response.body)
-    assert_manifestation(json, @manifestation, 'epub', true)
+    assert_manifestation(json, @manifestation, 'basic', 'epub', true)
   end
 
-  test 'GET /v1/api/texts/{id} with metadata view and pdf format succeed' do
-    get "/api/v1/texts/#{@manifestation.id}?key=#{@key.key}&view=metadata&file_format=pdf"
+  test 'GET /v1/api/texts/{id} with metadata view, pdf format and without snippet succeed' do
+    get "/api/v1/texts/#{@manifestation.id}?key=#{@key.key}&view=metadata&file_format=pdf&snippet=false"
     assert last_response.successful?
     json = JSON.parse(last_response.body)
-    assert_manifestation(json, @manifestation, 'pdf', false)
+    assert_manifestation(json, @manifestation, 'metadata', 'pdf', false)
+  end
+
+  test 'GET /v1/api/texts/{id} with enriched view, pdf format and without snippet succeed' do
+    get "/api/v1/texts/#{@manifestation.id}?key=#{@key.key}&view=enriched&file_format=pdf&snippet=false"
+    assert last_response.successful?
+    json = JSON.parse(last_response.body)
+    assert_manifestation(json, @manifestation, 'enriched', 'pdf', false)
+    # ensuring non-published tags are excluded
+    assert_equal %w(popular), json['enrichment']['taggings']
+    assert_equal [@manifestation_2.expressions[0].works[0].id], json['enrichment']['works_about']
   end
 
   test 'GET /v1/api/texts/{id} fails if id not found in published manifestations' do
@@ -74,22 +103,22 @@ class V1::APITest < ActiveSupport::TestCase
     assert_key_failed
   end
 
-  test 'GET /v1/api/texts/batch with default params succeed and returns basic view in html format' do
+  test 'GET /v1/api/texts/batch with default params succeed and returns basic view in html format and without snippet' do
     get "/api/v1/texts/batch?key=#{@key.key}&ids[]=#{@manifestation.id}&ids[]=#{@manifestation_2.id}"
     assert last_response.successful?
     json = JSON.parse(last_response.body)
     assert_equal 2, json.size
-    assert_manifestation(json[0], @manifestation, 'html', true)
-    assert_manifestation(json[1], @manifestation_2, 'html', true)
+    assert_manifestation(json[0], @manifestation, 'basic', 'html', false)
+    assert_manifestation(json[1], @manifestation_2, 'basic', 'html', false)
   end
 
-  test 'GET /v1/api/texts/batch with metadata view and epub format succeed' do
-    get "/api/v1/texts/batch?key=#{@key.key}&ids[]=#{@manifestation.id}&ids[]=#{@manifestation_2.id}&view=metadata&file_format=epub"
+  test 'GET /v1/api/texts/batch with enriched view, epub format and snippet succeed' do
+    get "/api/v1/texts/batch?key=#{@key.key}&ids[]=#{@manifestation.id}&ids[]=#{@manifestation_2.id}&view=enriched&file_format=epub&snippet=true"
     assert last_response.successful?
     json = JSON.parse(last_response.body)
     assert_equal 2, json.size
-    assert_manifestation(json[0], @manifestation, 'epub', false)
-    assert_manifestation(json[1], @manifestation_2, 'epub', false)
+    assert_manifestation(json[0], @manifestation, 'enriched', 'epub', true)
+    assert_manifestation(json[1], @manifestation_2, 'enriched', 'epub', true)
   end
 
   test 'GET /v1/api/texts/batch fails if more than 25 ids specified' do
@@ -130,23 +159,23 @@ class V1::APITest < ActiveSupport::TestCase
     assert_equal 2, json['total_count']
     data = json['data']
     assert_equal 2, data.size
-    assert_manifestation(data[0], @manifestation, 'html', true)
-    assert_manifestation(data[1], @manifestation_2, 'html', true)
+    assert_manifestation(data[0], @manifestation, 'basic', 'html', false)
+    assert_manifestation(data[1], @manifestation_2, 'basic', 'html', false)
   end
 
-  test 'GET /v1/api/texts returns 1st page with descending alphabetical sorting, metadata view and epub format' do
-    get "/api/v1/texts?key=#{@key.key}&page=1&sort_by=alphabetical&sort_dir=desc&view=metadata&file_format=epub"
+  test 'GET /v1/api/texts returns 1st page with descending alphabetical sorting, metadata view, epub format and snippet' do
+    get "/api/v1/texts?key=#{@key.key}&page=1&sort_by=alphabetical&sort_dir=desc&view=metadata&file_format=epub&snippet=true"
     assert last_response.successful?
     json = JSON.parse(last_response.body)
     assert_equal 2, json['total_count']
     data = json['data']
     assert_equal 2, data.size
-    assert_manifestation(data[0], @manifestation_2, 'epub', false)
-    assert_manifestation(data[1], @manifestation, 'epub', false)
+    assert_manifestation(data[0], @manifestation_2, 'metadata', 'epub', true)
+    assert_manifestation(data[1], @manifestation, 'metadata', 'epub', true)
   end
 
   test 'GET /v1/api/texts do correct paging' do
-    Manifestation.destroy_all
+    clean_tablees
     manifestations = create_list(:manifestation, 60)
     get "/api/v1/texts?key=#{@key.key}&page=1&sort_by=upload_date&sort_dir=asc"
     assert last_response.successful?
@@ -195,25 +224,25 @@ class V1::APITest < ActiveSupport::TestCase
     assert_equal 2, json['total_count']
     data = json['data']
     assert_equal 2, data.size
-    assert_manifestation(data[0], @manifestation, 'html', true)
-    assert_manifestation(data[1], @manifestation_2, 'html', true)
+    assert_manifestation(data[0], @manifestation, 'basic', 'html', false)
+    assert_manifestation(data[1], @manifestation_2, 'basic', 'html', false)
   end
 
-  test 'GET /v1/api/search returns 1st page with descending popularity sorting, metadata view and epub format' do
-    get "/api/v1/search?key=#{@key.key}&page=1&sort_by=popularity&sort_dir=asc&view=metadata&file_format=epub"
+  test 'GET /v1/api/search returns 1st page with descending popularity sorting, enriched view, epub format and snippet' do
+    get "/api/v1/search?key=#{@key.key}&page=1&sort_by=popularity&sort_dir=asc&view=enriched&file_format=epub&snippet=true"
     assert last_response.successful?
     json = JSON.parse(last_response.body)
     assert_equal 2, json['total_count']
     data = json['data']
     assert_equal 2, data.size
-    assert_manifestation(data[0], @manifestation_2, 'epub', false)
-    assert_manifestation(data[1], @manifestation, 'epub', false)
+    assert_manifestation(data[0], @manifestation_2, 'enriched', 'epub', true)
+    assert_manifestation(data[1], @manifestation, 'enriched', 'epub', true)
   end
 
   test 'GET /v1/api/search applies filters' do
     manifestations = []
     Chewy.strategy(:atomic) do
-      Manifestation.destroy_all
+      clean_tablees
       (1..60).each do |index|
         e = create(:expression, copyrighted: index%10 == 0)
         manifestations << create(:manifestation, impressions_count: Random.rand(100), expressions: [e])
@@ -274,7 +303,7 @@ class V1::APITest < ActiveSupport::TestCase
   test 'GET /v1/api/search do correct paging' do
     manifestations = []
     Chewy.strategy(:atomic) do
-      Manifestation.destroy_all
+      clean_tablees
       (1..60).each do |index|
         manifestations << create(:manifestation, impressions_count: Random.rand(100))
       end
@@ -323,7 +352,7 @@ class V1::APITest < ActiveSupport::TestCase
 
   private
 
-  def assert_manifestation(json, manifestation, format, check_snippet)
+  def assert_manifestation(json, manifestation, view, file_format, snippet)
     md = json['metadata']
     expression = manifestation.expressions[0]
     work = expression.works[0]
@@ -348,8 +377,40 @@ class V1::APITest < ActiveSupport::TestCase
     assert_equal expression.date, md['raw_publication_date']
     assert_equal normalize_date(expression.date).year, md['publication_year']
 
-    if check_snippet
+    if view == 'enriched'
+      enrichment = json['enrichment']
+      assert_not_nil enrichment
+      json_links = enrichment['external_links']
+      links = manifestation.external_links.status_approved.to_a.sort_by(&:id)
+      assert_equal links.size, json_links.size
+      links.each_with_index do |el, i|
+        json_link = json_links[i]
+        assert_equal el.url, json_link['url']
+        assert_equal el.linktype, json_link['type']
+        assert_equal el.description, json_link['description']
+      end
+
+      tags = manifestation.tags.approved.pluck(:name).sort
+      assert_equal tags, enrichment['taggings']
+
+      recommendations = manifestation.recommendations.all_approved.order(:id)
+      json_recommendations = enrichment['recommendations']
+      recommendations.each_with_index do |r, i|
+        json_recommendation = json_recommendations[i]
+        assert_equal r.body, json_recommendation['fulltext']
+        assert_equal r.user_id, json_recommendation['recommender_user_id']
+        assert_nil json_recommendation['recommender_home_url']
+        assert_equal r.created_at.to_date.strftime('%Y-%m-%d'), json_recommendation['recommendation_date']
+      end
+
+      assert_equal manifestation.expressions[0].works[0].works_about.pluck(:id).sort, enrichment['works_about']
+    else
+      assert_not json.keys.include?('enrichment')
+    end
+
+    if snippet
       snippet = json['snippet']
+      assert_not_nil snippet
       assert snippet.include? manifestation.title
       # we assume that markdown contains plain-text only
       assert snippet.include? manifestation.markdown
@@ -357,7 +418,7 @@ class V1::APITest < ActiveSupport::TestCase
       assert_not json.keys.include?('snippet')
     end
 
-    assert_equal json['download_url'], Rails.application.routes.url_helpers.manifestation_download_url(manifestation.id, format: format)
+    assert_equal json['download_url'], Rails.application.routes.url_helpers.manifestation_download_url(manifestation.id, format: file_format)
   end
 
   def last_error
@@ -366,5 +427,12 @@ class V1::APITest < ActiveSupport::TestCase
 
   def assert_key_failed
     assert_equal "key not found or disabled", last_error
+  end
+
+  def clean_tablees
+    Tagging.destroy_all
+    ExternalLink.destroy_all
+    Recommendation.destroy_all
+    Manifestation.destroy_all
   end
 end

--- a/test/factories/aboutnesses.rb
+++ b/test/factories/aboutnesses.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :aboutness do
+    user { create(:user) }
+  end
+end

--- a/test/factories/expressions.rb
+++ b/test/factories/expressions.rb
@@ -14,10 +14,13 @@ FactoryBot.define do
     comment { "Comment for #{number}" }
     copyrighted { 0 }
     copyright_expiration { nil }
-    genre { 'prose' }
+    genre { Work::GENRES.sample }
     translation {}
     source_edition {}
-    period { :modern }
+    period { Expression.periods.keys.sample }
     works { [ create(:work, genre: genre) ] }
+    realizers do
+       works[0].orig_lang == 'he' ? [] : [ create(:realizer, person: create(:person), role: :translator) ]
+    end
   end
 end

--- a/test/factories/external_links.rb
+++ b/test/factories/external_links.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :external_link do
+    url { Faker::Internet.url }
+    linktype { ExternalLink.linktypes.values.sample }
+    status { ExternalLink.statuses.values.sample }
+    description { "Description for #{url}" }
+  end
+end

--- a/test/factories/manifestations.rb
+++ b/test/factories/manifestations.rb
@@ -18,5 +18,14 @@ FactoryBot.define do
     status { :published }
 
     expressions { [ create(:expression) ] }
+
+    trait :with_external_links do
+      external_links { create_list(:external_link, 2) }
+    end
+
+    trait :with_recommendations do
+      recommendations { create_list(:recommendation, 3) }
+    end
+
   end
 end

--- a/test/factories/recommendations.rb
+++ b/test/factories/recommendations.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :recommendation do
+    status { :approved }
+    body { Faker::Quote.yoda }
+  end
+end
+

--- a/test/factories/taggings.rb
+++ b/test/factories/taggings.rb
@@ -1,0 +1,4 @@
+FactoryBot.define do
+  factory :tagging do
+  end
+end

--- a/test/factories/tags.rb
+++ b/test/factories/tags.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :tag do
+    status { :approved }
+  end
+end
+

--- a/test/factories/users.rb
+++ b/test/factories/users.rb
@@ -1,0 +1,9 @@
+FactoryBot.define do
+  factory :user do
+    name { Faker::Name.name }
+    email { Faker::Internet.email }
+    provider { 'google_oauth2' }
+    admin { 0 }
+    editor { 0 }
+  end
+end

--- a/test/factories/works.rb
+++ b/test/factories/works.rb
@@ -11,10 +11,11 @@ FactoryBot.define do
     title { "Title for #{number}" }
     date { '3 ביוני 1960' }
     comment { "Comment for #{number}" }
-    genre { 'prose' }
-    orig_lang { 'en' }
+    genre { Work::GENRES.sample }
+    orig_lang { %w(he en ru de it).sample }
     origlang_title { "Title in original language for #{number}" }
     normalized_pub_date {}
     normalized_creation_date { normalize_date(date) }
+    creations { [create(:creation, person: create(:person), role: :author)] }
   end
 end

--- a/test/models/work_test.rb
+++ b/test/models/work_test.rb
@@ -1,0 +1,13 @@
+require 'test_helper'
+
+class WorkTest < ActiveSupport::TestCase
+  test 'works_about returns all works written about given work' do
+    work = create(:work)
+    about_1 = create(:work)
+    create(:aboutness, work: about_1, aboutable: work)
+    about_2 = create(:work)
+    create(:aboutness, work: about_2, aboutable: work)
+
+    assert_equal [about_1, about_2], work.works_about.order(:id).to_a
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,6 +1,8 @@
 require 'simplecov'
 SimpleCov.start
 
+require 'faker'
+
 ENV['RAILS_ENV'] = 'test'
 require File.expand_path('../../config/environment', __FILE__)
 require 'rails/test_help'


### PR DESCRIPTION
Added Enrichment section to API response. Added separate param to manage snippet visibility.

For enrichment data I've decided not to add them into elastic search index, but fetch them from db during request.
The main reason for it is that if we want to include data in ES index it will require us to update index every time one of dependent records will be updated.

E.g. if we'll add or delete aboutness record will need to update manifestation index for referenced manifestation.
Same for recommendations, tags and external links