### PR TITLE
Fix error in API tests

### DIFF
--- a/test/factories/manifestations.rb
+++ b/test/factories/manifestations.rb
@@ -20,11 +20,11 @@ FactoryBot.define do
     expressions { [ create(:expression) ] }
 
     trait :with_external_links do
-      external_links { create_list(:external_link, 2) }
+      external_links { build_list(:external_link, 2) }
     end
 
     trait :with_recommendations do
-      recommendations { create_list(:recommendation, 3) }
+      recommendations { build_list(:recommendation, 3) }
     end
 
   end


### PR DESCRIPTION
This error in factory appeared  after I made ExternalLink.linkable_id not-nullable in last PR yesterday. 