### PR TITLE
Fulltext search

### DIFF
--- a/app/openapi.yaml
+++ b/app/openapi.yaml
@@ -389,6 +389,11 @@ paths:
           description: a substring to match against the name(s) of a text's author(s)
           schema:
             type: string
+        - name: fulltext
+          required: false
+          description: a substring to match against the work's full text (NOTE: when provided it will enforce result ordering by relevance).
+          schema:
+            type: string
         - name: author_ids
           in: query
           required: false

--- a/spec/support/clean_db.rb
+++ b/spec/support/clean_db.rb
@@ -10,9 +10,15 @@ def clean_tables
 
   Aboutness.delete_all
 
-  Work.destroy_all
-  Expression.destroy_all
-  Manifestation.destroy_all
+  ListItem.delete_all
+  User.delete_all
+
+  ActiveRecord::Base.connection.execute('delete from expressions_manifestations')
+  ActiveRecord::Base.connection.execute('delete from expressions_works')
+
+  Work.delete_all
+  Expression.delete_all
+  Manifestation.delete_all
 
   # Cleaning-up ElasticSearch indices
   Chewy.massacre


### PR DESCRIPTION
Added ability to search by full work text to /search API endpoint.
If fulltext param is provided it will ignore all sorting and will return results sorted by relevance.