### PR TITLE
Removed txt_snippet field from ManifestationIndex

### DIFF
--- a/app/api/v1/entities/manifestation_index.rb
+++ b/app/api/v1/entities/manifestation_index.rb
@@ -37,7 +37,9 @@ module V1
       expose :enrichment, if: lambda { |_manifestation, options| options[:view] == 'enriched' } do |manifestation|
         V1::Entities::ManifestationEnrichment.represent manifestation.id
       end
-      expose :txt_snippet, as: :snippet, if: lambda { |_manifestation, options| options[:snippet] }
+      expose :snippet, if: lambda { |_manifestation, options| options[:snippet] } do |manifestation|
+        snippet(manifestation.fulltext, 500)[0]
+      end
       expose :download_url do |manifestation|
         Rails.application.routes.url_helpers.manifestation_download_url(manifestation.id, format: options[:file_format])
       end

--- a/app/chewy/manifestations_index.rb
+++ b/app/chewy/manifestations_index.rb
@@ -30,7 +30,6 @@ class ManifestationsIndex < Chewy::Index
     field :raw_creation_date, value: ->(manifestation) {manifestation.expressions[0].works[0].date}
     field :creation_date, type: 'date', value: ->(manifestation) {normalize_date(manifestation.expressions[0].works[0].date)}
     field :place_and_publisher
-    field :txt_snippet
   end
 
   # TODO: in future: collections/readers; users; recommendations; curated/featured content

--- a/app/models/manifestation.rb
+++ b/app/models/manifestation.rb
@@ -142,22 +142,6 @@ class Manifestation < ApplicationRecord
     # stripping tags -- return ActionController::Base.helpers.strip_tags(MultiMarkdown.new(markdown.lines[0..p_count].join("\n")).to_html.force_encoding('UTF-8').gsub(/<h1.*?<\/h1>/,'').gsub(/<figcaption>.*?<\/figcaption>/,'')) # remove MMD's automatic figcaptions, and the initial title
   end
 
-  # Snippet in TXT format
-  def txt_snippet
-    html = <<~HTML
-      <!DOCTYPE html PUBLIC \"-//W3C//DTD XHTML 1.0 Transitional//EN\" \"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd\">
-      <html xmlns=\"http://www.w3.org/1999/xhtml\" xml:lang=\"he\" lang=\"he\" dir=\"rtl\">
-      <head><meta http-equiv=\"Content-Type\" content=\"text/html; charset=utf-8\" /></head>
-      <body dir='rtl' align='right'><div dir=\"rtl\" align=\"right\">
-        #{title_and_authors_html}
-        #{snippet_paragraphs(15)}
-      </div></body>
-      </html>
-    HTML
-    txt = html2txt(html)
-    txt.gsub("\n","\r\n") # windows linebreaks
-  end
-
   def authors_string
     return I18n.t(:nil) if expressions[0].nil? or expressions[0].works[0].nil? or expressions[0].works[0].persons[0].nil?
     return expressions[0].works[0].authors.map{|x| x.name}.join(', ')

--- a/spec/api/v1/text_api_spec.rb
+++ b/spec/api/v1/text_api_spec.rb
@@ -81,7 +81,7 @@ describe V1::TextsAPI do
     context 'when additional params given' do
       let(:additional_params) { "&view=#{view}&file_format=#{file_format}&snippet=#{snippet}" }
 
-      context 'when basic view, epub format, with snipped are requested' do
+      context 'when basic view, epub format, with snippet are requested' do
         let(:view) { :basic }
         let(:file_format) { :epub }
         let(:snippet) { true }
@@ -403,7 +403,6 @@ describe V1::TextsAPI do
     if snippet
       snippet = json['snippet']
       expect(snippet).to_not be_nil
-      expect(snippet).to include manifestation.title
       # we assume that markdown contains plain-text only
       expect(snippet).to include manifestation.markdown
     else


### PR DESCRIPTION
For API needs we can extract snippet from fulltext column already existing in index.