### PR TITLE
Swagger Docs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -86,6 +86,8 @@ gem 'grape-entity', '~> 0.10.1'
 gem 'grape-extra_validators', '~> 2.1.0', git: "https://github.com/damisul/grape-extra_validators"
 gem 'grape-swagger', '~> 1.4.2'
 gem 'grape-swagger-entity', '~> 0.5.1'
+gem 'rswag-api', '~> 2.4.0'
+gem 'rswag-ui', '~> 2.4.0'
 
 group :production do
 #  gem 'newrelic_rpm' # performance monitoring

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -61,6 +61,8 @@ GEM
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
+    addressable (2.8.0)
+      public_suffix (>= 2.0.2, < 5.0)
     airbrussh (1.4.0)
       sshkit (>= 1.6.1, != 1.7.0)
     ansi (1.5.0)
@@ -286,6 +288,8 @@ GEM
     json-ld (2.0.0.1)
       multi_json (~> 1.11)
       rdf (~> 2.0)
+    json-schema (2.8.1)
+      addressable (>= 2.4)
     jwt (2.2.3)
     kaminari (1.1.1)
       activesupport (>= 4.1.0)
@@ -409,6 +413,7 @@ GEM
     property_sets (3.7.0)
       activerecord (>= 4.2, < 6.2)
       json
+    public_suffix (4.0.6)
     raabro (1.4.0)
     racc (1.5.2)
     rack (2.2.3)
@@ -521,6 +526,15 @@ GEM
       rspec-mocks (~> 3.10)
       rspec-support (~> 3.10)
     rspec-support (3.10.3)
+    rswag-api (2.4.0)
+      railties (>= 3.1, < 7.0)
+    rswag-specs (2.4.0)
+      activesupport (>= 3.1, < 7.0)
+      json-schema (~> 2.2)
+      railties (>= 3.1, < 7.0)
+    rswag-ui (2.4.0)
+      actionpack (>= 3.1, < 7.0)
+      railties (>= 3.1, < 7.0)
     ruby-statistics (2.1.3)
     ruby2_keywords (0.0.5)
     ruby_parser (3.17.0)
@@ -682,6 +696,9 @@ DEPENDENCIES
   rmagick
   rmultimarkdown
   rspec-rails (~> 5.0.2)
+  rswag-api (~> 2.4.0)
+  rswag-specs (~> 2.4.0)
+  rswag-ui (~> 2.4.0)
   rufus-scheduler
   rvm1-capistrano3
   sass-rails

--- a/app/api/v1/entities/external_link.rb
+++ b/app/api/v1/entities/external_link.rb
@@ -2,7 +2,7 @@ module V1
   module Entities
     class ExternalLink < Grape::Entity
       expose :url
-      expose :linktype, as: :type
+      expose :linktype, as: :type, documentation: { values: ::ExternalLink.linktypes.keys }
       expose :description
     end
   end

--- a/app/api/v1/entities/manifestation_enrichment.rb
+++ b/app/api/v1/entities/manifestation_enrichment.rb
@@ -1,21 +1,19 @@
 module V1
   module Entities
     class V1::Entities::ManifestationEnrichment < Grape::Entity
-      expose :external_links do |manifestation_id|
-        links = ::ExternalLink.where(linkable_type: :Manifestation, linkable_id: manifestation_id).status_approved.order(:id)
-        V1::Entities::ExternalLink.represent links
+      expose :external_links, using: V1::Entities::ExternalLink, documentation: { is_array: true } do |manifestation_id|
+        ::ExternalLink.where(linkable_type: :Manifestation, linkable_id: manifestation_id).status_approved.order(:id)
       end
 
-      expose :taggings do |manifestation_id|
+      expose :taggings, documentation: { is_array: true } do |manifestation_id|
         Tag.approved.joins(:taggings).merge(Tagging.where(manifestation_id: manifestation_id)).pluck(:name).sort
       end
 
-      expose :recommendations do |manifestation_id|
-        recommendations = ::Recommendation.approved.where(manifestation_id: manifestation_id).preload(:user)
-        V1::Entities::Recommendation.represent recommendations
+      expose :recommendations, using: V1::Entities::Recommendation, documentation: { is_array: true } do |manifestation_id|
+        ::Recommendation.approved.where(manifestation_id: manifestation_id).preload(:user)
       end
 
-      expose :texts_about do |manifestation_id|
+      expose :texts_about, documentation: { type: 'Integer', is_array: true } do |manifestation_id|
         w = ::Work.joins(expressions: :manifestations).where('manifestations.id = ?', manifestation_id)
         Aboutness.where(aboutable: w)
                  .joins(work: {expressions: :manifestations})

--- a/app/api/v1/entities/manifestation_index.rb
+++ b/app/api/v1/entities/manifestation_index.rb
@@ -1,44 +1,45 @@
 module V1
   module Entities
     class ManifestationIndex < Grape::Entity
-      expose :id
-      expose :url do |manifestation|
+      expose :id, documentation: { type: 'Integer' }
+      expose :url, documentation: { desc: 'Canonical URL of the text at Project Ben-Yehuda (useful for giving credit and allowing users to click through)' } do |manifestation|
         Rails.application.routes.url_helpers.manifestation_read_url(manifestation.id)
       end
       expose :metadata do
         expose :title
-        expose :sort_title
-        expose :genre
+        expose :sort_title, documentation: { desc: 'version of the title more useful for alphabetical sorting' }
+        expose :genre, documentation: { values: Work::GENRES }
         expose :orig_lang
-        expose :orig_lang_title
+        expose :orig_lang_title, documentation: { desc: 'title of translated text in the original language and script' }
         expose :pby_publication_date do |manifestation|
           manifestation.pby_publication_date.to_date
         end
         expose :author_string
-        expose :author_ids
+        expose :author_ids, documentation: { type: 'Integer', is_array: true, desc: 'ID numbers of all authors involved with the text (most often only one)' }
         expose :title_and_authors do |manifestation|
           manifestation.title + ' / ' + manifestation.author_string
         end
-        expose :impressions_count
+        expose :impressions_count, documentation: { type: 'Integer', desc: 'total number of times the text was viewed or printed' }
         expose :orig_publication_date
-        expose :author_gender
-        expose :translator_gender
-        expose :copyright_status
-        expose :period
+        expose :author_gender, documentation: { values: ::Person.genders.keys, is_array: true }
+        expose :translator_gender, documentation: { values: ::Person.genders.keys, is_array: true }
+        expose :copyright_status, documentation: { type: 'Boolean' }
+        expose :period, documentation: { values: Expression.periods.keys }
         expose :raw_creation_date
         expose :creation_date
         expose :place_and_publisher
         expose :raw_publication_date
-        expose :publication_year do |manifestation|
+        expose :publication_year, documentation: { type: 'Integer' } do |manifestation|
           dt = manifestation.orig_publication_date
           dt.nil? ? nil : Time.parse(dt).year
         end
       end
-      expose :enrichment, if: lambda { |_manifestation, options| options[:view] == 'enriched' } do |manifestation|
-        V1::Entities::ManifestationEnrichment.represent manifestation.id
-      end
-      expose :txt_snippet, as: :snippet, if: lambda { |_manifestation, options| options[:snippet] }
-      expose :download_url do |manifestation|
+      expose :id, as: :enrichment, using: V1::Entities::ManifestationEnrichment, if: lambda { |_manifestation, options| options[:view] == 'enriched' }
+      expose :txt_snippet, as: :snippet,
+             documentation: { desc: 'plaintext snippet of the first few hundred characters of the text, useful for previews and search results' },
+             if: lambda { |_manifestation, options| options[:snippet] }
+      expose :download_url,
+             documentation: { desc: 'URL of the full text of the work, in the requested format (HTML by default)' } do |manifestation|
         Rails.application.routes.url_helpers.manifestation_download_url(manifestation.id, format: options[:file_format])
       end
     end

--- a/app/api/v1/entities/manifestations_page.rb
+++ b/app/api/v1/entities/manifestations_page.rb
@@ -1,10 +1,8 @@
 module V1
   module Entities
     class ManifestationsPage < Grape::Entity
-      expose :total_count
-      expose :data do |rec|
-        V1::Entities::ManifestationIndex.represent rec[:data], view: options[:view], file_format: options[:file_format], snippet: options[:snippet]
-      end
+      expose :total_count, documentation: { type: 'Integer' }
+      expose :data, using: V1::Entities::ManifestationIndex, documentation: { is_array: true }
     end
   end
 end

--- a/app/api/v1/entities/person.rb
+++ b/app/api/v1/entities/person.rb
@@ -2,19 +2,19 @@ module V1
   module Entities
     class Person < Grape::Entity
       expose :id, documentation: { type: :Integer }
-      expose :url do |person|
+      expose :url, documentation: { desc: "Canonical URL of the person at Project Ben-Yehuda (useful for giving credit and allowing users to click through)" } do |person|
         Rails.application.routes.url_helpers.bib_person_url(person)
       end
       expose :metadata do
         expose :name
-        expose :sort_name
+        expose :sort_name,  documentation: { desc: 'version of the name more useful for alphabetical sorting' }
         expose :birth_year, documentation: { type: 'Integer' }
         expose :death_year, documentation: { type: 'Integer' }
-        expose :gender
-        expose :copyright_status do |person|
+        expose :gender, documentation: { values: ::Person.genders.keys }
+        expose :copyright_status, documentation: { type: 'Boolean' } do |person|
           !person.public_domain?
         end
-        expose :period
+        expose :period, documentation: { values: ::Person.periods.keys }
         expose :text_ids, if: lambda { |_person, options| !%w(metadata enriched).include?(options[:detail]) },
                documentation: { type: 'Integer', is_array: true, desc: 'ID numbers of all texts this person is involved with, filtered per the authorDetail param' } do |person, options|
           works = []
@@ -31,7 +31,7 @@ module V1
         expose :wikipedia_snippet, as: :bio_snippet
         expose :all_languages, as: :languages,
                documentation: { type: 'String', is_array: true, desc: 'list of languages (by ISO code) this person worked in' }
-        expose :all_genres, as: :genres, documentation: { is_array: true }
+        expose :all_genres, as: :genres, documentation: { values: Work::GENRES, is_array: true }
         expose :impressions_count,
                documentation: { type: 'Integer', desc: "total number of times the person's page OR one of their texts were viewed or printed" }
       end

--- a/app/api/v1/people_api.rb
+++ b/app/api/v1/people_api.rb
@@ -1,7 +1,7 @@
 class V1::PeopleAPI < V1::ApplicationApi
   resources :people do
     route_param :id do
-      desc 'Return text by id' do
+      desc 'Return person by id' do
         success V1::Entities::Person
       end
       params do

--- a/app/openapi.yaml
+++ b/app/openapi.yaml
@@ -86,7 +86,7 @@ components:
       name: sort_by
       in: query
       required: false
-      description: desired ordering of result set
+      description: desired ordering of result set (ignored if fulltext search is used)
       schema:
         type: string
         default: alphabetical
@@ -100,7 +100,7 @@ components:
       name: sort_dir
       in: query
       required: false
-      description: desired ordering direction
+      description: desired ordering direction (ignored if fulltext search is used)
       schema:
         type: string
         default: default
@@ -404,7 +404,7 @@ paths:
         - name: original_language
           in: query
           required: false
-          description: 'ISO code of language, e.g. ''pl'' for Polish, ''grc'' for ancient Greek'
+          description: 'ISO code of language, e.g. ''pl'' for Polish, ''grc'' for ancient Greek. Use magic constant ''xlat'' to match all non-Hebrew languages'
           schema:
             type: string
         - name: uploaded_between

--- a/config/initializers/rswag-ui.rb
+++ b/config/initializers/rswag-ui.rb
@@ -1,0 +1,14 @@
+Rswag::Ui.configure do |c|
+
+  # List the Swagger endpoints that you want to be documented through the swagger-ui
+  # The first parameter is the path (absolute or relative to the UI host) to the corresponding
+  # endpoint and the second is a title that will be displayed in the document selector
+  # NOTE: If you're using rspec-api to expose Swagger files (under swagger_root) as JSON or YAML endpoints,
+  # then the list below should correspond to the relative paths for those endpoints
+
+  c.swagger_endpoint 'http://localhost:3000/api/v1/swagger_doc', 'API V1 Docs'
+
+  # Add Basic Auth in case your API is private
+  # c.basic_auth_enabled = true
+  # c.basic_auth_credentials 'username', 'password'
+end

--- a/config/initializers/rswag_api.rb
+++ b/config/initializers/rswag_api.rb
@@ -1,0 +1,14 @@
+Rswag::Api.configure do |c|
+
+  # Specify a root folder where Swagger JSON files are located
+  # This is used by the Swagger middleware to serve requests for API descriptions
+  # NOTE: If you're using rswag-specs to generate Swagger, you'll need to ensure
+  # that it's configured to generate files in the same folder
+  c.swagger_root = Rails.root.to_s + '/swagger'
+
+  # Inject a lamda function to alter the returned Swagger prior to serialization
+  # The function will have access to the rack env for the current request
+  # For example, you could leverage this to dynamically assign the "host" property
+  #
+  #c.swagger_filter = lambda { |swagger, env| swagger['host'] = env['HTTP_HOST'] }
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,7 @@
 include BybeUtils
 Bybeconv::Application.routes.draw do
+  mount Rswag::Ui::Engine => '/api-docs'
+  mount Rswag::Api::Engine => '/api-docs'
   mount V1::Api => '/'
 
   resources :anthology_texts do


### PR DESCRIPTION
Added metadata to grape code, to generate swagger documentation from the sources automatically.
Genrated swagger docs are available under http://localhost:3000/api/v1/swagger_doc
Added RSwag UI to browse and test API from this swagger docs. This UI is available under http://localhost:3000/api-docs