### PR TITLE
API adjustements

### DIFF
--- a/app/api/v1/entities/manifestation_index.rb
+++ b/app/api/v1/entities/manifestation_index.rb
@@ -24,7 +24,8 @@ module V1
         expose :period, documentation: { values: Expression.periods.keys }
         expose :raw_creation_date
         expose :creation_date
-        expose :place_and_publisher
+        expose :publication_place
+        expose :publisher
         expose :raw_publication_date
       end
       expose :enrichment, if: lambda { |_manifestation, options| options[:view] == 'enriched' } do |manifestation|

--- a/app/api/v1/entities/manifestation_index.rb
+++ b/app/api/v1/entities/manifestation_index.rb
@@ -16,9 +16,6 @@ module V1
         end
         expose :author_string
         expose :author_ids, documentation: { type: 'Integer', is_array: true, desc: 'ID numbers of all authors involved with the text (most often only one)' }
-        expose :title_and_authors do |manifestation|
-          manifestation.title + ' / ' + manifestation.author_string
-        end
         expose :impressions_count, documentation: { type: 'Integer', desc: 'total number of times the text was viewed or printed' }
         expose :orig_publication_date
         expose :author_gender, documentation: { values: ::Person.genders.keys, is_array: true }
@@ -29,10 +26,6 @@ module V1
         expose :creation_date
         expose :place_and_publisher
         expose :raw_publication_date
-        expose :publication_year, documentation: { type: 'Integer' } do |manifestation|
-          dt = manifestation.orig_publication_date
-          dt.nil? ? nil : Time.parse(dt).year
-        end
       end
       expose :enrichment, if: lambda { |_manifestation, options| options[:view] == 'enriched' } do |manifestation|
         V1::Entities::ManifestationEnrichment.represent manifestation.id

--- a/app/chewy/manifestations_index.rb
+++ b/app/chewy/manifestations_index.rb
@@ -29,7 +29,8 @@ class ManifestationsIndex < Chewy::Index
     field :period, value: ->(manifestation) {manifestation.expressions[0].period}, type: 'keyword'
     field :raw_creation_date, value: ->(manifestation) {manifestation.expressions[0].works[0].date}
     field :creation_date, type: 'date', value: ->(manifestation) {normalize_date(manifestation.expressions[0].works[0].date)}
-    field :place_and_publisher
+    field :publication_place
+    field :publisher
   end
 
   # TODO: in future: collections/readers; users; recommendations; curated/featured content

--- a/app/models/manifestation.rb
+++ b/app/models/manifestation.rb
@@ -195,10 +195,6 @@ class Manifestation < ApplicationRecord
     end
   end
 
-  def place_and_publisher
-    "#{publication_place}, #{publisher}"
-  end
-
   def legacy_htmlfile
     hh = HtmlFile.joins(:manifestations).where(manifestations: {id: self.id})
     if hh.empty?

--- a/app/openapi.yaml
+++ b/app/openapi.yaml
@@ -287,7 +287,9 @@ components:
                     type: string
                   creation_date:
                     type: string
-                  place_and_publisher:
+                  publication_place:
+                    type: string
+                  publisher:
                     type: string
                   raw_publication_date:
                     type: string

--- a/app/openapi.yaml
+++ b/app/openapi.yaml
@@ -270,8 +270,6 @@ components:
                     items:
                       type: integer
                     description: ID numbers of all authors involved with the text (most often only one)
-                  title_and_authors:
-                    type: string
                   impressions_count:
                     type: integer
                     description: total number of times the text was viewed or printed
@@ -292,8 +290,6 @@ components:
                   place_and_publisher:
                     type: string
                   raw_publication_date:
-                    type: string
-                  publication_year:
                     type: string
               enrichment:
                 type: object

--- a/spec/api/v1/text_api_spec.rb
+++ b/spec/api/v1/text_api_spec.rb
@@ -364,7 +364,8 @@ describe V1::TextsAPI do
     expect(md['period']).to eq expression.period
     expect(md['raw_creation_date']).to eq work.date
     expect(md['creation_date']).to eq normalize_date(work.date).to_s
-    expect(md['place_and_publisher']).to eq "#{manifestation.publication_place}, #{manifestation.publisher}"
+    expect(md['publication_place']).to eq manifestation.publication_place
+    expect(md['publisher']).to eq manifestation.publisher
     expect(md['raw_publication_date']).to eq expression.date
 
     if view == 'enriched'

--- a/spec/api/v1/text_api_spec.rb
+++ b/spec/api/v1/text_api_spec.rb
@@ -356,7 +356,6 @@ describe V1::TextsAPI do
     expect(md['pby_publication_date']).to eq work.created_at.to_date.to_s
     expect(md['author_string']).to eq manifestation.author_string
     expect(md['author_ids']).to eq manifestation.author_and_translator_ids
-    expect(md['title_and_authors']).to eq manifestation.title_and_authors
     expect(md['impressions_count']).to eq manifestation.impressions_count
     expect(md['orig_publication_date']).to eq normalize_date(expression.date).to_s
     expect(md['author_gender']).to eq manifestation.author_gender
@@ -367,7 +366,6 @@ describe V1::TextsAPI do
     expect(md['creation_date']).to eq normalize_date(work.date).to_s
     expect(md['place_and_publisher']).to eq "#{manifestation.publication_place}, #{manifestation.publisher}"
     expect(md['raw_publication_date']).to eq expression.date
-    expect(md['publication_year']).to eq normalize_date(expression.date).year
 
     if view == 'enriched'
       enrichment = json['enrichment']

--- a/spec/factories/manifestations.rb
+++ b/spec/factories/manifestations.rb
@@ -12,8 +12,8 @@ FactoryBot.define do
     end
 
     title { "Title for #{number}" }
-    publisher { "Publisher for #{number}" }
-    publication_place { "Publication place for #{number}" }
+    publisher { Faker::Company.name }
+    publication_place { Faker::Address.city }
     publication_date { '2019-01-01' }
     comment { "Comment for #{number}" }
     markdown { "Markdown for #{number}" }


### PR DESCRIPTION
Removed fields publication_year and title_and_authors from Texts API response object.
Splitted field place_and_publisher into two fields: publication_place and publisher.