### PR TITLE
people endpoint refactoring

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -61,8 +61,6 @@ GEM
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
-    addressable (2.8.0)
-      public_suffix (>= 2.0.2, < 5.0)
     airbrussh (1.4.0)
       sshkit (>= 1.6.1, != 1.7.0)
     ansi (1.5.0)
@@ -92,9 +90,6 @@ GEM
       moment-timezone-rails (~> 1.0)
       momentjs-rails (>= 2.10.5, <= 3.0.0)
     builder (3.2.4)
-    bullet (6.1.5)
-      activesupport (>= 3.0.0)
-      uniform_notifier (~> 1.11)
     byebug (11.1.3)
     capistrano (3.16.0)
       airbrussh (>= 1.0.0)
@@ -288,8 +283,6 @@ GEM
     json-ld (2.0.0.1)
       multi_json (~> 1.11)
       rdf (~> 2.0)
-    json-schema (2.8.1)
-      addressable (>= 2.4)
     jwt (2.2.3)
     kaminari (1.1.1)
       activesupport (>= 4.1.0)
@@ -413,7 +406,6 @@ GEM
     property_sets (3.7.0)
       activerecord (>= 4.2, < 6.2)
       json
-    public_suffix (4.0.6)
     raabro (1.4.0)
     racc (1.5.2)
     rack (2.2.3)
@@ -528,10 +520,6 @@ GEM
     rspec-support (3.10.3)
     rswag-api (2.4.0)
       railties (>= 3.1, < 7.0)
-    rswag-specs (2.4.0)
-      activesupport (>= 3.1, < 7.0)
-      json-schema (~> 2.2)
-      railties (>= 3.1, < 7.0)
     rswag-ui (2.4.0)
       actionpack (>= 3.1, < 7.0)
       railties (>= 3.1, < 7.0)
@@ -608,7 +596,6 @@ GEM
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.7.7)
-    uniform_notifier (1.14.2)
     watir (6.19.1)
       regexp_parser (>= 1.2, < 3)
       selenium-webdriver (>= 3.142.7)
@@ -636,7 +623,6 @@ DEPENDENCIES
   aws-sdk-s3
   better_sjr
   bootstrap4-datetime-picker-rails
-  bullet
   byebug
   capistrano (~> 3.11)
   capistrano-rails (~> 1.4)
@@ -697,7 +683,6 @@ DEPENDENCIES
   rmultimarkdown
   rspec-rails (~> 5.0.2)
   rswag-api (~> 2.4.0)
-  rswag-specs (~> 2.4.0)
   rswag-ui (~> 2.4.0)
   rufus-scheduler
   rvm1-capistrano3

--- a/app/api/v1/entities/manifestation_index.rb
+++ b/app/api/v1/entities/manifestation_index.rb
@@ -28,8 +28,8 @@ module V1
         expose :publisher
         expose :raw_publication_date
       end
-      expose :enrichment, if: lambda { |_manifestation, options| options[:view] == 'enriched' } do |manifestation|
-        V1::Entities::ManifestationEnrichment.represent manifestation.id
+      expose :enrichment, using: V1::Entities::ManifestationEnrichment, if: lambda { |_manifestation, options| options[:view] == 'enriched' } do |manifestation|
+        manifestation.id
       end
       expose :snippet, documentation: { desc: 'plaintext snippet of the first few hundred characters of the text, useful for previews and search results' }, if: lambda { |_manifestation, options| options[:snippet] } do |manifestation|
         snippet(manifestation.fulltext, 500)[0]

--- a/app/api/v1/people_api.rb
+++ b/app/api/v1/people_api.rb
@@ -7,19 +7,16 @@ class V1::PeopleAPI < V1::ApplicationApi
       params do
         use :key_param
         requires :id, type: Integer, desc: 'Person ID'
-        optional :authorDetail, type: String, default: 'metadata', values: %w(metadata enriched works original_works translations full), desc: <<~DESC
+        optional :author_detail, type: String, default: 'metadata', values: %w(metadata texts enriched), desc: <<~DESC
           how much detail to return:
-          `metadata` returns personal metadata; 
+          `metadata` returns personal metadata;
+          `texts` returns IDs of texts this person was involved in, with his role in each; 
           `enriched` returns personal metadata plus works about this person (backlinks); 
-          `works` returns a list of IDs of this works this person was involved in, with their role in each; 
-          `original_works` returns that list filtered only to works where this person is the original author; 
-          `translations` returns the works list filtered only to works where this person translated; 
-          `full` returns enriched metadata plus all works'
         DESC
       end
       get do
         person = Person.find(params[:id])
-        present person, with: V1::Entities::Person, detail: params[:authorDetail]
+        present person, with: V1::Entities::Person, detail: params[:author_detail]
       end
     end
   end

--- a/app/models/creation.rb
+++ b/app/models/creation.rb
@@ -1,5 +1,9 @@
 class Creation < ApplicationRecord
   belongs_to :work, class_name: 'Work', foreign_key: 'work_id'
   belongs_to :person, class_name: 'Person', foreign_key: 'person_id'
-  enum role: [:author, :editor, :illustrator]
+  enum role: {
+    author: 0,
+    editor: 1,
+    illustrator: 2
+  }
 end

--- a/app/models/realizer.rb
+++ b/app/models/realizer.rb
@@ -1,5 +1,11 @@
 class Realizer < ApplicationRecord
   belongs_to :expression
   belongs_to :person
-  enum role: [:author, :editor, :illustrator, :translator, :adapter]
+  enum role: {
+    author: 0,
+    editor: 1,
+    illustrator: 2,
+    translator: 3,
+    adapter: 4
+  }
 end

--- a/app/openapi.yaml
+++ b/app/openapi.yaml
@@ -38,26 +38,20 @@ components:
           - basic
           - enriched
     personDetailParam:
-      name: authorDetail
+      name: author_detail
       in: query
       required: false
-      description: 'how much detail to return: `metadata` returns personal metadata; 
-        `enriched` returns personal metadata plus works about this person (backlinks); 
-        `works` returns a list of IDs of this works this person was involved in, with their role in each; 
-        `original_works` returns that list filtered only to works where this person is the original author; 
-        `translations` returns the works list filtered only to works where this person translated; 
-        `full` returns enriched metadata plus all works'
+      description: 'how much detail to return: 
+        `metadata` returns personal metadata;
+        `works` returns metadata and a lists of IDs of works this person was involved in with different roles; 
+        `enriched` returns personal metadata plus list of works and works about this person (backlinks);'
       schema:
         type: string
         default: metadata
         enum:
           - metadata
-          - enriched
           - works
-          - original_works
-          - translations
-          - full
-
+          - enriched
     formatParam:
       name: file_format
       in: query
@@ -204,11 +198,6 @@ components:
                     type: boolean
                   period:
                     $ref: '#/components/schemas/period'
-                  text_ids:
-                    type: array
-                    description: ID numbers of all texts this person is involved with, filtered per the authorDetail param
-                    items:
-                      type: integer
                   other_designations:
                     type: string
                     description: semicolon-separated list of additional names or spellings for this person
@@ -227,6 +216,26 @@ components:
                   impressions_count:
                     type: integer
                     description: total number of times the person's page OR one of their texts were viewed or printed
+              texts:
+                type: object
+                description: ID numbers of all texts this person is involved into with role in each
+                properties:
+                  author:
+                    type: array
+                    items:
+                      type: integer
+                  translator:
+                    type: array
+                    items:
+                      type: integer
+                  editor:
+                    type: array
+                    items:
+                      type: integer
+                  illustrator:
+                    type: array
+                    items:
+                      type: integer
               enrichment:
                 type: object
                 properties:
@@ -388,8 +397,9 @@ paths:
           schema:
             type: string
         - name: fulltext
+          in: query
           required: false
-          description: a substring to match against the work's full text (NOTE: when provided it will enforce result ordering by relevance).
+          description: a substring to match against the work's full text.
           schema:
             type: string
         - name: author_ids
@@ -426,14 +436,19 @@ paths:
       summary: Query the site database for texts by a variety of parameters. See API docs for documentation of each parameter. All parameters are combined with a logical AND. Parameters accepting arrays allow a logical OR within that category.
       tags: []
       responses:
-        '200':
+        '201':
           description: OK
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  $ref: '#/components/responses/text'
+                type: object
+                properties:
+                  total_count:
+                    type: integer
+                  data:
+                    type: array
+                    items:
+                      $ref: '#/components/responses/text'
   /texts/batch:
     post:
       parameters:

--- a/spec/api/v1/people_api_spec.rb
+++ b/spec/api/v1/people_api_spec.rb
@@ -6,7 +6,7 @@ describe V1::PeopleAPI do
   describe 'GET api/v1/people/{id}' do
     let(:detail) { 'metadata' }
     let(:person_id) { -1 }
-    let(:path) { "/api/v1/people/#{person_id}?key=#{key}&authorDetail=#{detail}" }
+    let(:path) { "/api/v1/people/#{person_id}?key=#{key}&author_detail=#{detail}" }
     let(:subject) { get path }
 
     include_context 'API Key Check'
@@ -22,6 +22,8 @@ describe V1::PeopleAPI do
     context 'when correct id provided' do
       let!(:original_manifestation) { create(:manifestation, author: person) }
       let!(:translated_manifestation) { create(:manifestation, translator: person, orig_lang: 'ru') }
+      let!(:edited_manifestation) { create(:manifestation, editor: person) }
+      let!(:illustrated_manifestation) { create(:manifestation, illustrator: person) }
       let!(:manifestation_about) do
         m = create(:manifestation)
         create(:aboutness, aboutable: person, work: m.expressions[0].works[0])
@@ -46,57 +48,35 @@ describe V1::PeopleAPI do
         it "returns personal  metadata" do
           expect(subject).to eq 200
           validate_person(json_response, person, 'metadata')
-          expect(json_response['metadata']['work_ids']).to be_nil
+          expect(json_response['texts']).to be_nil
+          expect(json_response['enrichment']).to be_nil
+        end
+      end
+
+      context 'when texts details requested' do
+        let(:detail) { 'texts' }
+        it "returns a list of IDs of the works this person was involved in, with their role in each" do
+          expect(subject).to eq 200
+          validate_person(json_response, person, 'texts')
+          texts = json_response['texts']
+          expect(texts['author']).to eq([original_manifestation.id])
+          expect(texts['editor']).to eq([edited_manifestation.id])
+          expect(texts['illustrator']).to eq([illustrated_manifestation.id])
+          expect(texts['translator']).to eq([translated_manifestation.id])
           expect(json_response['enrichment']).to be_nil
         end
       end
 
       context 'when enriched details requested' do
         let(:detail) { 'enriched' }
-        it "returns personal metadata plus works about this person (backlinks)" do
+        it "returns personal metadata plus texts he was involved into, plus texts about this person (backlinks)" do
           expect(subject).to eq 200
           validate_person(json_response, person, 'enriched')
-          expect(json_response['metadata']['text_ids']).to be_nil
-          expect(json_response['enrichment']['texts_about']).to eq([manifestation_about.id])
-        end
-      end
-
-      context 'when works details requested' do
-        let(:detail) { 'works' }
-        it "returns a list of IDs of the works this person was involved in, with their role in each" do
-          expect(subject).to eq 200
-          validate_person(json_response, person, 'works')
-          expect(json_response['metadata']['text_ids']).to eq([original_manifestation.id, translated_manifestation.id])
-          expect(json_response['enrichment']).to be_nil
-        end
-      end
-
-      context 'when original_works details requested' do
-        let(:detail) { 'original_works' }
-        it "returns a list of IDs of the works where this person is the original author" do
-          expect(subject).to eq 200
-          validate_person(json_response, person, 'original_works')
-          expect(json_response['metadata']['text_ids']).to eq([original_manifestation.id])
-          expect(json_response['enrichment']).to be_nil
-        end
-      end
-
-      context 'when translations details requested' do
-        let(:detail) { 'translations' }
-        it "returns a list of IDs of the works where this person translated" do
-          expect(subject).to eq 200
-          validate_person(json_response, person, 'translations')
-          expect(json_response['metadata']['text_ids']).to eq([translated_manifestation.id])
-          expect(json_response['enrichment']).to be_nil
-        end
-      end
-
-      context 'when full details requested' do
-        let(:detail) { 'full' }
-        it "returns enriched metadata plus all works" do
-          expect(subject).to eq 200
-          validate_person(json_response, person, 'full')
-          expect(json_response['metadata']['text_ids']).to eq([original_manifestation.id, translated_manifestation.id])
+          texts = json_response['texts']
+          expect(texts['author']).to eq([original_manifestation.id])
+          expect(texts['editor']).to eq([edited_manifestation.id])
+          expect(texts['illustrator']).to eq([illustrated_manifestation.id])
+          expect(texts['translator']).to eq([translated_manifestation.id])
           expect(json_response['enrichment']['texts_about']).to eq([manifestation_about.id])
         end
       end
@@ -116,11 +96,14 @@ describe V1::PeopleAPI do
     expect(metadata['copyright_status']).to eq(!person.public_domain?)
     expect(metadata['period']).to eq(person.period)
 
-    if %w(metadata enriched).include?(detail)
-      expect(metadata).to_not have_key('text_ids')
+    if %w(texts enriched).include?(detail)
+      texts = json['texts']
+      expect(texts).to_not be_nil
+      expect(texts).to have_key('author')
+      expect(texts).to have_key('translator')
+      expect(texts).to have_key('editor')
     else
-      text_ids = metadata['text_ids']
-      expect(text_ids).to_not be_nil
+      expect(metadata).to_not have_key('texts')
     end
 
     expect(metadata['other_designations']).to eq(person.other_designation)
@@ -128,7 +111,8 @@ describe V1::PeopleAPI do
     expect(metadata['languages']).to eq(person.all_languages)
     expect(metadata['genres']).to eq(person.all_genres)
     expect(metadata['impressions_count']).to eq(person.impressions_count)
-    if %w(full enriched).include? detail
+
+    if detail == 'enriched'
       enrichment = json['enrichment']
       expect(enrichment).to_not be_nil
       expect(enrichment['texts_about']).to_not be_nil

--- a/spec/factories/expressions.rb
+++ b/spec/factories/expressions.rb
@@ -9,6 +9,8 @@ FactoryBot.define do
       author { create(:person) }
       orig_lang { %w(he en ru de it).sample }
       translator { orig_lang != 'he' ? create(:person) : nil }
+      editor { nil }
+      illustrator { nil }
     end
     title { "Title for #{number}" }
     form {}
@@ -23,7 +25,17 @@ FactoryBot.define do
     period { Expression.periods.keys.sample }
     works { [ create(:work, genre: genre, author: author, orig_lang: orig_lang) ] }
     realizers do
-       orig_lang == 'he' ? [] : [ create(:realizer, person: translator, role: :translator) ]
+      result = []
+      if orig_lang != 'he'
+        result << create(:realizer, person: translator, role: :translator)
+      end
+      if editor.present?
+        result << create(:realizer, person: editor, role: :editor)
+      end
+      if illustrator.present?
+        result << create(:realizer, person: illustrator, role: :illustrator)
+      end
+      result
     end
   end
 end

--- a/spec/factories/manifestations.rb
+++ b/spec/factories/manifestations.rb
@@ -9,6 +9,8 @@ FactoryBot.define do
       author { create(:person) }
       orig_lang { %w(he en ru de it).sample }
       translator { orig_lang != 'he' ? create(:person) : nil }
+      editor { nil }
+      illustrator { nil }
     end
 
     title { "Title for #{number}" }
@@ -20,7 +22,7 @@ FactoryBot.define do
     impressions_count { 4 }
     status { :published }
 
-    expressions { [ create(:expression, author: author, translator: translator, orig_lang: orig_lang) ] }
+    expressions { [ create(:expression, author: author, translator: translator, editor: editor, illustrator: illustrator, orig_lang: orig_lang) ] }
 
     trait :with_external_links do
       external_links { build_list(:external_link, 2) }


### PR DESCRIPTION
I've renamed authorDetail param to author_detail to match snake case convention used in other places.
Now we have three levels of detalization: 
- metadata
- texts
- enriched

For texts and enriched levels we have new root element texts with a structure like
```
  "texts": {
    "author": [ ... ],
    "translator": [ ... ],
    "editor": [ ... ],
    "illustrator": [ ... ]
  }
```