### PR TITLE
Renamed gender fields in Text API response

### DIFF
--- a/app/api/v1/entities/manifestation_index.rb
+++ b/app/api/v1/entities/manifestation_index.rb
@@ -18,8 +18,8 @@ module V1
         expose :author_ids, documentation: { type: 'Integer', is_array: true, desc: 'ID numbers of all authors involved with the text (most often only one)' }
         expose :impressions_count, documentation: { type: 'Integer', desc: 'total number of times the text was viewed or printed' }
         expose :orig_publication_date
-        expose :author_gender, documentation: { values: ::Person.genders.keys, is_array: true }
-        expose :translator_gender, documentation: { values: ::Person.genders.keys, is_array: true }
+        expose :author_gender, as: :author_genders, documentation: { values: ::Person.genders.keys, is_array: true }
+        expose :translator_gender, as: :translator_genders, documentation: { values: ::Person.genders.keys, is_array: true }
         expose :copyright_status, documentation: { type: 'Boolean' }
         expose :period, documentation: { values: Expression.periods.keys }
         expose :raw_creation_date

--- a/app/openapi.yaml
+++ b/app/openapi.yaml
@@ -43,7 +43,7 @@ components:
       required: false
       description: 'how much detail to return: 
         `metadata` returns personal metadata;
-        `works` returns metadata and a lists of IDs of works this person was involved in with different roles; 
+        `texts` returns IDs of texts this person was involved in, with his role in each;; 
         `enriched` returns personal metadata plus list of works and works about this person (backlinks);'
       schema:
         type: string
@@ -284,10 +284,14 @@ components:
                     description: total number of times the text was viewed or printed
                   orig_publication_date:
                     type: string
-                  author_gender:
-                    $ref: '#/components/schemas/gender'
-                  translator_gender:
-                    $ref: '#/components/schemas/gender'
+                  author_genders:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/gender'
+                  translator_genders:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/gender'
                   copyright_status:
                     type: boolean
                   period:

--- a/spec/api/v1/text_api_spec.rb
+++ b/spec/api/v1/text_api_spec.rb
@@ -358,8 +358,8 @@ describe V1::TextsAPI do
     expect(md['author_ids']).to eq manifestation.author_and_translator_ids
     expect(md['impressions_count']).to eq manifestation.impressions_count
     expect(md['orig_publication_date']).to eq normalize_date(expression.date).to_s
-    expect(md['author_gender']).to eq manifestation.author_gender
-    expect(md['translator_gender']).to eq manifestation.translator_gender
+    expect(md['author_genders']).to eq manifestation.author_gender
+    expect(md['translator_genders']).to eq manifestation.translator_gender
     expect(md['copyright_status']).to eq manifestation.copyright?
     expect(md['period']).to eq expression.period
     expect(md['raw_creation_date']).to eq work.date


### PR DESCRIPTION
Renamed author_gender and translator_gender fields in TextsAPI response object to author_genders and translator_genders, as there could be several values.

Updated openapi.yaml