### PR TITLE
Added unique index by key column to API_KEYS table.

### DIFF
--- a/db/migrate/20211222122452_add_index_by_key_to_api_keys.rb
+++ b/db/migrate/20211222122452_add_index_by_key_to_api_keys.rb
@@ -1,0 +1,5 @@
+class AddIndexByKeyToApiKeys < ActiveRecord::Migration[5.2]
+  def change
+    add_index :api_keys, :key, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_11_28_125541) do
+ActiveRecord::Schema.define(version: 2021_12_22_122452) do
 
   create_table "aboutnesses", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin", force: :cascade do |t|
     t.integer "work_id"
@@ -80,6 +80,7 @@ ActiveRecord::Schema.define(version: 2021_11_28_125541) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["email"], name: "index_api_keys_on_email", unique: true
+    t.index ["key"], name: "index_api_keys_on_key", unique: true
   end
 
   create_table "bib_sources", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin", force: :cascade do |t|


### PR DESCRIPTION
This index should speedup API Key checks (assuming we'll have many API users).
Made this index uniq because we don't check email during authentication, so we need to clearly identify user by key.