### PR TITLE
Batch endpoint fix

### DIFF
--- a/app/api/v1/texts_api.rb
+++ b/app/api/v1/texts_api.rb
@@ -41,6 +41,11 @@ class V1::TextsAPI < V1::ApplicationApi
       post do
         ids = params[:ids]
         records = ManifestationsIndex.find(ids)
+        # If ids contains one one value, Chewy returns single object instead of array, so explicitely convert
+        # it to single-element array
+        if ids.size == 1
+          records = [records]
+        end
         # sorting result in same order as their ids are passed in parameter
         records.sort_by! { |rec| ids.find_index(rec.id) }
         present records, with: V1::Entities::ManifestationIndex, view: params[:view], file_format: params[:file_format], snippet: params[:snippet]

--- a/spec/api/v1/text_api_spec.rb
+++ b/spec/api/v1/text_api_spec.rb
@@ -133,7 +133,17 @@ describe V1::TextsAPI do
 
     include_context 'API Key Check'
 
-    context 'when no additional_params specified' do
+    context 'when single id specified' do
+      let(:ids) { [manifestation_1.id] }
+
+      it 'succeed and returns basic view in html format and without snippet' do
+        expect(subject).to eq 201
+        assert_equal 1, json_response.size
+        assert_manifestation(json_response[0], manifestation_1, 'basic', 'html', false)
+      end
+    end
+
+    context 'when multiple ids without additional_params specified' do
       it 'succeed and returns basic view in html format and without snippet' do
         expect(subject).to eq 201
         assert_equal 2, json_response.size
@@ -142,7 +152,7 @@ describe V1::TextsAPI do
       end
     end
 
-    context 'when additional params passed' do
+    context 'when multiple ids with additional params specified' do
       let(:additional_params) {
         {
           view: :enriched,


### PR DESCRIPTION
api/v1/texts/batch endpoint failed if single id was passed in ids list

The reason was that Chewy returned single object instead of array with one element in such situation.
Fixed by explicitely converting object to array when neccessary.