### PR TITLE
Manifestation safe_filename fix

### DIFF
--- a/app/models/manifestation.rb
+++ b/app/models/manifestation.rb
@@ -101,14 +101,9 @@ class Manifestation < ApplicationRecord
   end
 
   def safe_filename
-    fname = "#{title} #{I18n.t(:by)} #{author_string}"
-    fname.gsub!(/[^0-9א-תA-Za-z.\-]/, '_')
-    # Active Storage uses 255-characters column for a file name so we need to truncate filename if it is longer
-    # We also need to reserve 5 characters for extension
-    if fname.length > 250
-      fname = fname[0..249]
-    end
-    return fname
+    # Use manifestation id as a filename to prevent issues with long filename described here
+    # https://github.com/abartov/bybeconv/issues/101#issuecomment-1002994205
+    self.id.to_s
   end
 
   def to_plaintext

--- a/app/models/manifestation.rb
+++ b/app/models/manifestation.rb
@@ -102,7 +102,13 @@ class Manifestation < ApplicationRecord
 
   def safe_filename
     fname = "#{title} #{I18n.t(:by)} #{author_string}"
-    return fname.gsub(/[^0-9א-תA-Za-z.\-]/, '_')
+    fname.gsub!(/[^0-9א-תA-Za-z.\-]/, '_')
+    # Active Storage uses 255-characters column for a file name so we need to truncate filename if it is longer
+    # We also need to reserve 5 characters for extension
+    if fname.length > 250
+      fname = fname[0..249]
+    end
+    return fname
   end
 
   def to_plaintext

--- a/db/migrate/20211230111256_remove_empty_downloadables.rb
+++ b/db/migrate/20211230111256_remove_empty_downloadables.rb
@@ -1,0 +1,16 @@
+class RemoveEmptyDownloadables < ActiveRecord::Migration[5.2]
+  def change
+    execute <<~SQL
+      delete from downloadables
+      where
+        object_type = 'Manifestation'
+        and not exists (
+          select 1 from
+            active_storage_attachments a 
+          where
+            a.record_id = downloadables.id
+            and a.record_type = 'Downloadable'
+        )
+    SQL
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,9 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_12_22_122452) do
+ActiveRecord::Schema.define(version: 2021_12_30_111256) do
 
-  create_table "aboutnesses", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8_bin", force: :cascade do |t|
+  create_table "aboutnesses", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin", force: :cascade do |t|
     t.integer "work_id"
     t.integer "user_id"
     t.integer "status"
@@ -28,9 +28,9 @@ ActiveRecord::Schema.define(version: 2021_12_22_122452) do
     t.index ["work_id"], name: "index_aboutnesses_on_work_id"
   end
 
-  create_table "active_storage_attachments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8_bin", force: :cascade do |t|
-    t.string "name", limit: 191, null: false
-    t.string "record_type", limit: 191, null: false
+  create_table "active_storage_attachments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "record_type", null: false
     t.bigint "record_id", null: false
     t.bigint "blob_id", null: false
     t.datetime "created_at", null: false
@@ -38,38 +38,31 @@ ActiveRecord::Schema.define(version: 2021_12_22_122452) do
     t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
   end
 
-  create_table "active_storage_blobs", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8_bin", force: :cascade do |t|
-    t.string "key", limit: 191, null: false
-    t.string "filename", limit: 191, null: false
-    t.string "content_type", limit: 191
+  create_table "active_storage_blobs", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin", force: :cascade do |t|
+    t.string "key", null: false
+    t.string "filename", null: false
+    t.string "content_type"
     t.text "metadata"
     t.bigint "byte_size", null: false
-    t.string "checksum", limit: 191, null: false
+    t.string "checksum", null: false
     t.datetime "created_at", null: false
-    t.string "service_name", null: false
     t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
   end
 
-  create_table "active_storage_variant_records", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin", force: :cascade do |t|
-    t.bigint "blob_id", null: false
-    t.string "variation_digest", null: false
-    t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
-  end
-
-  create_table "anthologies", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8_bin", force: :cascade do |t|
+  create_table "anthologies", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin", force: :cascade do |t|
     t.string "title"
     t.integer "user_id"
     t.integer "access"
     t.integer "cached_page_count"
-    t.text "sequence"
+    t.text "sequence", limit: 16777215
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["user_id"], name: "index_anthologies_on_user_id"
   end
 
-  create_table "anthology_texts", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8_bin", force: :cascade do |t|
+  create_table "anthology_texts", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin", force: :cascade do |t|
     t.string "title"
-    t.text "body"
+    t.text "body", limit: 16777215
     t.bigint "anthology_id"
     t.integer "manifestation_id"
     t.datetime "created_at", null: false
@@ -79,7 +72,7 @@ ActiveRecord::Schema.define(version: 2021_12_22_122452) do
     t.index ["manifestation_id"], name: "index_anthology_texts_on_manifestation_id"
   end
 
-  create_table "api_keys", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8_bin", force: :cascade do |t|
+  create_table "api_keys", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin", force: :cascade do |t|
     t.string "email"
     t.string "description"
     t.string "key"
@@ -90,7 +83,7 @@ ActiveRecord::Schema.define(version: 2021_12_22_122452) do
     t.index ["key"], name: "index_api_keys_on_key", unique: true
   end
 
-  create_table "bib_sources", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8_bin", force: :cascade do |t|
+  create_table "bib_sources", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin", force: :cascade do |t|
     t.string "title"
     t.integer "source_type"
     t.string "url"
@@ -104,7 +97,7 @@ ActiveRecord::Schema.define(version: 2021_12_22_122452) do
     t.string "item_pattern", limit: 2048
   end
 
-  create_table "bookmarks", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "bookmarks", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin", force: :cascade do |t|
     t.integer "manifestation_id"
     t.integer "user_id"
     t.string "bookmark_p"
@@ -115,7 +108,7 @@ ActiveRecord::Schema.define(version: 2021_12_22_122452) do
     t.index ["user_id"], name: "index_bookmarks_on_user_id"
   end
 
-  create_table "creations", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8_bin", force: :cascade do |t|
+  create_table "creations", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin", force: :cascade do |t|
     t.integer "work_id"
     t.integer "person_id"
     t.integer "role"
@@ -125,7 +118,7 @@ ActiveRecord::Schema.define(version: 2021_12_22_122452) do
     t.index ["work_id"], name: "index_creations_on_work_id"
   end
 
-  create_table "delayed_jobs", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8_bin", force: :cascade do |t|
+  create_table "delayed_jobs", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin", force: :cascade do |t|
     t.integer "priority", default: 0, null: false
     t.integer "attempts", default: 0, null: false
     t.text "handler", null: false
@@ -175,7 +168,7 @@ ActiveRecord::Schema.define(version: 2021_12_22_122452) do
     t.index ["to_entry_id"], name: "index_dictionary_links_on_to_entry_id"
   end
 
-  create_table "downloadables", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "downloadables", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin", force: :cascade do |t|
     t.string "object_type"
     t.bigint "object_id"
     t.integer "doctype"
@@ -227,12 +220,12 @@ ActiveRecord::Schema.define(version: 2021_12_22_122452) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "description"
-    t.integer "linkable_id"
-    t.string "linkable_type"
+    t.integer "linkable_id", null: false
+    t.string "linkable_type", null: false
     t.index ["linkable_type", "linkable_id"], name: "index_external_links_on_linkable_type_and_linkable_id"
   end
 
-  create_table "featured_author_features", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8_bin", force: :cascade do |t|
+  create_table "featured_author_features", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin", force: :cascade do |t|
     t.datetime "fromdate"
     t.datetime "todate"
     t.integer "featured_author_id"
@@ -241,7 +234,7 @@ ActiveRecord::Schema.define(version: 2021_12_22_122452) do
     t.index ["featured_author_id"], name: "index_featured_author_features_on_featured_author_id"
   end
 
-  create_table "featured_authors", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8_bin", force: :cascade do |t|
+  create_table "featured_authors", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin", force: :cascade do |t|
     t.string "title"
     t.integer "user_id"
     t.integer "person_id"
@@ -252,7 +245,7 @@ ActiveRecord::Schema.define(version: 2021_12_22_122452) do
     t.index ["user_id"], name: "index_featured_authors_on_user_id"
   end
 
-  create_table "featured_content_features", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8_bin", force: :cascade do |t|
+  create_table "featured_content_features", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin", force: :cascade do |t|
     t.integer "featured_content_id"
     t.datetime "fromdate"
     t.datetime "todate"
@@ -261,7 +254,7 @@ ActiveRecord::Schema.define(version: 2021_12_22_122452) do
     t.index ["featured_content_id"], name: "index_featured_content_features_on_featured_content_id"
   end
 
-  create_table "featured_contents", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8_bin", force: :cascade do |t|
+  create_table "featured_contents", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin", force: :cascade do |t|
     t.string "title"
     t.integer "manifestation_id"
     t.integer "person_id"
@@ -269,15 +262,13 @@ ActiveRecord::Schema.define(version: 2021_12_22_122452) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "external_link"
-    t.integer "user_id_id"
     t.integer "user_id"
     t.index ["manifestation_id"], name: "index_featured_contents_on_manifestation_id"
     t.index ["person_id"], name: "index_featured_contents_on_person_id"
     t.index ["user_id"], name: "index_featured_contents_on_user_id"
-    t.index ["user_id_id"], name: "index_featured_contents_on_user_id_id"
   end
 
-  create_table "holdings", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8_bin", force: :cascade do |t|
+  create_table "holdings", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin", force: :cascade do |t|
     t.integer "publication_id"
     t.string "source_id", limit: 1024
     t.datetime "created_at", null: false
@@ -298,7 +289,6 @@ ActiveRecord::Schema.define(version: 2021_12_22_122452) do
     t.boolean "need_resequence"
     t.boolean "public_domain"
     t.integer "person_id"
-    t.index ["person_id"], name: "html_dirs_person_id_fk"
   end
 
   create_table "html_files", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin", force: :cascade do |t|
@@ -341,8 +331,6 @@ ActiveRecord::Schema.define(version: 2021_12_22_122452) do
     t.string "pub_link_text"
     t.index ["assignee_id"], name: "index_html_files_on_assignee_id"
     t.index ["path"], name: "index_html_files_on_path"
-    t.index ["person_id"], name: "html_files_person_id_fk"
-    t.index ["translator_id"], name: "html_files_translator_id_fk"
     t.index ["url"], name: "index_html_files_on_url"
   end
 
@@ -393,12 +381,9 @@ ActiveRecord::Schema.define(version: 2021_12_22_122452) do
     t.integer "html_file_id"
     t.integer "recommended_by"
     t.integer "manifestation_id"
-    t.index ["html_file_id"], name: "legacy_recommendations_html_file_id_fk"
-    t.index ["manifestation_id"], name: "legacy_recommendations_manifestation_id_fk"
-    t.index ["recommended_by"], name: "legacy_recommendations_recommended_by_fk"
   end
 
-  create_table "list_items", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8_bin", force: :cascade do |t|
+  create_table "list_items", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin", force: :cascade do |t|
     t.integer "user_id"
     t.string "listkey"
     t.integer "item_id"
@@ -451,7 +436,7 @@ ActiveRecord::Schema.define(version: 2021_12_22_122452) do
     t.index ["person_id"], name: "index_manifestations_people_on_person_id"
   end
 
-  create_table "news_items", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8_bin", force: :cascade do |t|
+  create_table "news_items", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin", force: :cascade do |t|
     t.integer "itemtype"
     t.string "title"
     t.boolean "pinned"
@@ -501,7 +486,6 @@ ActiveRecord::Schema.define(version: 2021_12_22_122452) do
     t.datetime "sidepic_updated_at"
     t.string "sort_name"
     t.index ["gender"], name: "gender_index"
-    t.index ["id"], name: "tstid"
     t.index ["impressions_count"], name: "index_people_on_impressions_count"
     t.index ["name"], name: "index_people_on_name"
     t.index ["period"], name: "index_people_on_period"
@@ -535,7 +519,7 @@ ActiveRecord::Schema.define(version: 2021_12_22_122452) do
     t.index ["resolved_by"], name: "proofs_resolved_by_fk"
   end
 
-  create_table "publications", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8_bin", force: :cascade do |t|
+  create_table "publications", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin", force: :cascade do |t|
     t.string "title", limit: 1024
     t.string "publisher_line"
     t.string "author_line", limit: 1024
@@ -554,7 +538,7 @@ ActiveRecord::Schema.define(version: 2021_12_22_122452) do
     t.index ["task_id"], name: "index_publications_on_task_id"
   end
 
-  create_table "reading_lists", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8_bin", force: :cascade do |t|
+  create_table "reading_lists", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin", force: :cascade do |t|
     t.string "title"
     t.integer "user_id"
     t.integer "access"
@@ -563,7 +547,7 @@ ActiveRecord::Schema.define(version: 2021_12_22_122452) do
     t.index ["user_id"], name: "index_reading_lists_on_user_id"
   end
 
-  create_table "realizers", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8_bin", force: :cascade do |t|
+  create_table "realizers", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin", force: :cascade do |t|
     t.integer "expression_id"
     t.integer "person_id"
     t.integer "role"
@@ -573,7 +557,7 @@ ActiveRecord::Schema.define(version: 2021_12_22_122452) do
     t.index ["person_id"], name: "index_realizers_on_person_id"
   end
 
-  create_table "recommendations", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8_bin", force: :cascade do |t|
+  create_table "recommendations", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin", force: :cascade do |t|
     t.text "body"
     t.integer "user_id"
     t.integer "approved_by"
@@ -596,7 +580,7 @@ ActiveRecord::Schema.define(version: 2021_12_22_122452) do
     t.index ["updated_at"], name: "index_sessions_on_updated_at"
   end
 
-  create_table "sitenotices", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8_bin", force: :cascade do |t|
+  create_table "sitenotices", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin", force: :cascade do |t|
     t.text "body"
     t.datetime "fromdate"
     t.datetime "todate"
@@ -608,15 +592,7 @@ ActiveRecord::Schema.define(version: 2021_12_22_122452) do
     t.index ["todate"], name: "index_sitenotices_on_todate"
   end
 
-  create_table "sitenotices_users", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8_bin", force: :cascade do |t|
-    t.bigint "sitenotice_id", null: false
-    t.bigint "user_id", null: false
-    t.string "session_id"
-    t.boolean "suppress"
-    t.index ["session_id"], name: "index_sitenotices_users_on_session_id"
-  end
-
-  create_table "static_pages", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8_bin", force: :cascade do |t|
+  create_table "static_pages", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin", force: :cascade do |t|
     t.string "tag"
     t.string "title"
     t.text "body", limit: 16777215
@@ -658,7 +634,7 @@ ActiveRecord::Schema.define(version: 2021_12_22_122452) do
     t.integer "status"
   end
 
-  create_table "user_preferences", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8_bin", force: :cascade do |t|
+  create_table "user_preferences", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin", force: :cascade do |t|
     t.string "name", null: false
     t.string "value"
     t.integer "user_id", null: false
@@ -693,7 +669,7 @@ ActiveRecord::Schema.define(version: 2021_12_22_122452) do
     t.index ["item_type", "item_id"], name: "index_versions_on_item_type_and_item_id"
   end
 
-  create_table "volunteer_profile_features", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8_bin", force: :cascade do |t|
+  create_table "volunteer_profile_features", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin", force: :cascade do |t|
     t.integer "volunteer_profile_id"
     t.datetime "fromdate"
     t.datetime "todate"
@@ -702,7 +678,7 @@ ActiveRecord::Schema.define(version: 2021_12_22_122452) do
     t.index ["volunteer_profile_id"], name: "index_volunteer_profile_features_on_volunteer_profile_id"
   end
 
-  create_table "volunteer_profiles", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8_bin", force: :cascade do |t|
+  create_table "volunteer_profiles", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin", force: :cascade do |t|
     t.string "name"
     t.text "bio"
     t.text "about"
@@ -714,7 +690,7 @@ ActiveRecord::Schema.define(version: 2021_12_22_122452) do
     t.datetime "updated_at", null: false
   end
 
-  create_table "work_likes", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8_bin", force: :cascade do |t|
+  create_table "work_likes", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin", force: :cascade do |t|
     t.integer "manifestation_id", null: false
     t.integer "user_id", null: false
     t.index ["manifestation_id", "user_id"], name: "index_work_likes_on_manifestation_id_and_user_id"
@@ -737,24 +713,17 @@ ActiveRecord::Schema.define(version: 2021_12_22_122452) do
     t.index ["normalized_pub_date"], name: "index_works_on_normalized_pub_date"
   end
 
-  add_foreign_key "aboutnesses", "users", name: "aboutnesses_user_id_fk"
-  add_foreign_key "aboutnesses", "works", name: "aboutnesses_work_id_fk"
-  add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "aboutnesses", "users"
+  add_foreign_key "aboutnesses", "works"
   add_foreign_key "anthologies", "users"
   add_foreign_key "anthology_texts", "anthologies"
   add_foreign_key "anthology_texts", "manifestations"
   add_foreign_key "bookmarks", "manifestations"
   add_foreign_key "bookmarks", "users"
-  add_foreign_key "creations", "people", name: "creations_person_id_fk"
-  add_foreign_key "creations", "works", name: "creations_work_id_fk"
   add_foreign_key "dictionary_aliases", "dictionary_entries"
   add_foreign_key "dictionary_entries", "manifestations"
   add_foreign_key "dictionary_links", "dictionary_entries", column: "from_entry_id"
   add_foreign_key "dictionary_links", "dictionary_entries", column: "to_entry_id"
-  add_foreign_key "expressions_manifestations", "expressions", name: "expressions_manifestations_expression_id_fk"
-  add_foreign_key "expressions_manifestations", "manifestations", name: "expressions_manifestations_manifestation_id_fk"
-  add_foreign_key "expressions_works", "expressions", name: "expressions_works_expression_id_fk"
-  add_foreign_key "expressions_works", "works", name: "expressions_works_work_id_fk"
   add_foreign_key "featured_author_features", "featured_authors"
   add_foreign_key "featured_authors", "people"
   add_foreign_key "featured_authors", "users"
@@ -764,15 +733,6 @@ ActiveRecord::Schema.define(version: 2021_12_22_122452) do
   add_foreign_key "featured_contents", "users"
   add_foreign_key "holdings", "bib_sources"
   add_foreign_key "holdings", "publications"
-  add_foreign_key "html_dirs", "people", name: "html_dirs_person_id_fk"
-  add_foreign_key "html_files", "people", column: "translator_id", name: "html_files_translator_id_fk"
-  add_foreign_key "html_files", "people", name: "html_files_person_id_fk"
-  add_foreign_key "html_files", "users", column: "assignee_id", name: "html_files_assignee_id_fk"
-  add_foreign_key "html_files_manifestations", "html_files", name: "html_files_manifestations_html_file_id_fk"
-  add_foreign_key "html_files_manifestations", "manifestations", name: "html_files_manifestations_manifestation_id_fk"
-  add_foreign_key "legacy_recommendations", "html_files", name: "legacy_recommendations_html_file_id_fk"
-  add_foreign_key "legacy_recommendations", "manifestations", name: "legacy_recommendations_manifestation_id_fk"
-  add_foreign_key "legacy_recommendations", "users", column: "recommended_by", name: "legacy_recommendations_recommended_by_fk"
   add_foreign_key "list_items", "users"
   add_foreign_key "manifestations_people", "manifestations", name: "manifestations_people_manifestation_id_fk"
   add_foreign_key "manifestations_people", "people", name: "manifestations_people_person_id_fk"

--- a/spec/models/manifestation_spec.rb
+++ b/spec/models/manifestation_spec.rb
@@ -1,0 +1,26 @@
+require 'rails_helper'
+
+describe Manifestation do
+  describe '.safe_filename' do
+    let(:manifestation) { Manifestation.new(title: title) }
+    let(:title) { 'Some Title' }
+    let(:author_name) { 'שאול טשרניחובסקי' }
+
+    before do
+      expect(manifestation).to receive(:author_string) { author_name }
+    end
+
+    let(:subject) { manifestation.safe_filename }
+
+    it 'builds filename from title and author_string and replaces all non-alphanumeric non-hebrew characters with underscore' do
+      expect(subject).to eq 'Some_Title_מאת_שאול_טשרניחובסקי'
+    end
+
+    context 'when resulting filename is longer than 250 characters' do
+      let(:title) { Random.hex(120) } # hex 120 produces 240 characters string
+      it 'truncates filename to 250 characters' do
+        expect(subject).to eq "#{title}_מאת_שאול_"
+      end
+    end
+  end
+end

--- a/spec/models/manifestation_spec.rb
+++ b/spec/models/manifestation_spec.rb
@@ -2,25 +2,9 @@ require 'rails_helper'
 
 describe Manifestation do
   describe '.safe_filename' do
-    let(:manifestation) { Manifestation.new(title: title) }
-    let(:title) { 'Some Title' }
-    let(:author_name) { 'שאול טשרניחובסקי' }
-
-    before do
-      expect(manifestation).to receive(:author_string) { author_name }
-    end
-
+    let(:manifestation) { create(:manifestation) }
     let(:subject) { manifestation.safe_filename }
 
-    it 'builds filename from title and author_string and replaces all non-alphanumeric non-hebrew characters with underscore' do
-      expect(subject).to eq 'Some_Title_מאת_שאול_טשרניחובסקי'
-    end
-
-    context 'when resulting filename is longer than 250 characters' do
-      let(:title) { Random.hex(120) } # hex 120 produces 240 characters string
-      it 'truncates filename to 250 characters' do
-        expect(subject).to eq "#{title}_מאת_שאול_"
-      end
-    end
+    it { is_expected.to eq manifestation.id.to_s }
   end
 end


### PR DESCRIPTION
Modified Manifestation.safe_filename method to use manifestation_id as a file name to prevent errors caused by too long filenames.

Wrapped download logic into a transaction, otherwise we got situaitons when Downloadable record exists, but not actual attachment.

Added migration to cleanup such hanging downloadable records.
