### PR TITLE
Removed author and adapter roles from Realizer table

### DIFF
--- a/app/models/html_file.rb
+++ b/app/models/html_file.rb
@@ -617,9 +617,12 @@ class HtmlFile < ApplicationRecord
           w.save!
           c = Creation.new(work_id: w.id, person_id: p.id, role: :author)
           c.save!
+
+          if translator_id.present?
+            translator.realizers.create!(expression: e, role: :translator)
+          end
+
           em_author = (translator_id.nil? ? p : translator) # the author of the Expression and Manifestation is the translator, if one exists
-          r = Realizer.new(expression_id: e.id, person_id: em_author.id, role: (translator_id.nil? ? :author : :translator))
-          r.save!
           m = Manifestation.new(title: tt, responsibility_statement: em_author.name, conversion_verified: true, medium: I18n.t(:etext), publisher: AppConstants.our_publisher, publication_place: AppConstants.our_place_of_publication, publication_date: Date.today, markdown: the_markdown, comment: comments, status: Manifestation.statuses[:published])
           m.save!
           #m.people << em_author
@@ -656,9 +659,12 @@ class HtmlFile < ApplicationRecord
         w.save!
         c = Creation.new(work_id: w.id, person_id: p.id, role: :author)
         c.save!
+
+        if translator_id.present?
+          translator.realizers.create!(expression: e, role: :translator)
+        end
+
         em_author = (translator_id.nil? ? p : translator) # the author of the Expression and Manifestation is the translator, if one exists
-        r = Realizer.new(expression_id: e.id, person_id: em_author.id, role: (translator_id.nil? ? :author : :translator))
-        r.save!
         clean_utf8 = markdown.encode('utf-8') # for some reason, this string was not getting written properly to the DB
         m = Manifestation.new(title: title, responsibility_statement: em_author.name, medium: 'e-text', publisher: AppConstants.our_publisher, publication_place: AppConstants.our_place_of_publication, publication_date: Date.today, markdown: clean_utf8, comment: comments, status: Manifestation.statuses[:published])
         m.save!

--- a/app/models/realizer.rb
+++ b/app/models/realizer.rb
@@ -2,10 +2,8 @@ class Realizer < ApplicationRecord
   belongs_to :expression
   belongs_to :person
   enum role: {
-    author: 0,
     editor: 1,
     illustrator: 2,
-    translator: 3,
-    adapter: 4
+    translator: 3
   }
 end

--- a/app/views/shared/_associated_people.html.haml
+++ b/app/views/shared/_associated_people.html.haml
@@ -27,6 +27,6 @@
       = t(:add)
       = select_tag :add_person_e, options_from_collection_for_select(Person.order(:name), 'id', 'name'), include_blank: true
       = t(:in_role)
-      = select_tag :role_e, options_for_select([[t(:author), Realizer.roles[:author]], [t(:editor), Realizer.roles[:editor]], [t(:illustrator), Realizer.roles[:illustrator]], [t(:translator), Realizer.roles[:translator]], [t(:adapter), Realizer.roles[:adapter]]])
+      = select_tag :role_e, options_for_select([[t(:editor), Realizer.roles[:editor]], [t(:illustrator), Realizer.roles[:illustrator]], [t(:translator), Realizer.roles[:translator]]])
       %br
   - when :manifestation

--- a/db/migrate/20220108093736_remove_realizer_author_and_adapter_roles.rb
+++ b/db/migrate/20220108093736_remove_realizer_author_and_adapter_roles.rb
@@ -1,0 +1,7 @@
+class RemoveRealizerAuthorAndAdapterRoles < ActiveRecord::Migration[5.2]
+  def change
+    # removing author (0) and adapter (4) roles from realizers table
+    # we didn't had any adapters in db, but additing them to script for clarity
+    execute 'delete from realizers where role in (0, 4)'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_12_30_111256) do
+ActiveRecord::Schema.define(version: 2022_01_08_093736) do
 
   create_table "aboutnesses", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin", force: :cascade do |t|
     t.integer "work_id"


### PR DESCRIPTION
Decided to split https://github.com/abartov/bybeconv/issues/92 in smaller parts.

This part for cleaning realizers.author and realizers.adapter roles.
Added migration to wipe those data from db.

There were some logic in html_file.rb I don't fully understand but I've tried to fix it as well. But I'm not sure how to test it.
