### PR TITLE
Fix wrong totals by periods in navigation

### DIFF
--- a/app/models/expression.rb
+++ b/app/models/expression.rb
@@ -43,9 +43,11 @@ class Expression < ApplicationRecord
     end
   end
 
-  def self.cached_work_count_by_period(p)
-    Rails.cache.fetch("e_works_by_period_#{p}", expires_in: 24.hours) do
-      Expression.where(period: Person.periods[p]).count
+  # Returns total count of published works by each period
+  # @return hash where keys are period names and value is a number of works from the given period
+  def self.cached_work_count_by_periods
+    Rails.cache.fetch("e_works_by_periods", expires_in: 24.hours) do
+      Expression.joins(:manifestations).merge(Manifestation.all_published).group(:period).count
     end
   end
 

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -11,6 +11,8 @@ Bybeconv::Application.configure do
   config.serve_static_files = true
   config.static_cache_control = "public, max-age=3600"
 
+  # Don't use cache in test environment
+  config.cache_store = :null_store
 
   # Show full error reports and disable caching
   config.consider_all_requests_local       = true

--- a/lib/bybe_utils.rb
+++ b/lib/bybe_utils.rb
@@ -501,7 +501,7 @@ module BybeUtils
   end
 
   def work_count_by_period(p)
-    return Expression.cached_work_count_by_period(p)
+    return Expression.cached_work_count_by_periods[p]
   end
 
   def get_total_works
@@ -523,7 +523,7 @@ module BybeUtils
   end
 
   def get_genres
-    return ['poetry', 'prose', 'drama', 'fables','article', 'memoir', 'letters', 'reference', 'lexicon'] # translations and icon-font refer to these keys!
+    return Work::GENRES # translations and icon-font refer to these keys!
   end
 
   def right_side_genres # TODO: remove if unused

--- a/spec/models/expression_spec.rb
+++ b/spec/models/expression_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+
+describe Expression do
+  describe '.cached_work_counts_by_periods' do
+    let(:subject) { Expression.cached_work_count_by_periods }
+
+    before do
+      create(:manifestation, status: :unpublished, expressions: [ create(:expression, period: :ancient) ])
+      create(:manifestation, expressions: [ create(:expression, period: :ancient) ])
+      create(:manifestation, expressions: [ create(:expression, period: :medieval) ])
+      create(:manifestation, expressions: [ create(:expression, period: :medieval) ])
+    end
+
+    it 'does not counts unpublished works' do
+      expect(subject.size).to eq 2
+      expect(subject['ancient']).to eq 1
+      expect(subject['medieval']).to eq 2
+    end
+  end
+end


### PR DESCRIPTION
Navigation dropdown by periods displayed works count including non-published works.

Fixed this and optimized count calculation to fetch totals by all periods with a single SQL query