### PR TITLE
Author multiselect popup

### DIFF
--- a/app/views/manifestation/_authors_select.html.haml
+++ b/app/views/manifestation/_authors_select.html.haml
@@ -18,26 +18,14 @@
             %a.popup-x-v02.linkcolor.pointer{'data-dismiss'=>'modal'} -
             .by-card-content-v02.limited-height-popup-content-v02
               .authors-names-area
-                .row
-                  - unless list.empty?
-                    - tot = list.count
-                    - if tot > 5
-                      - list.order(:name).each_slice((tot/3.0).round) do |slice|
-                        .col
-                          - slice.each do |au|
-                            - attrs = {name: "ckb_authors[]", type: "checkbox", id: "au_#{au.id}", value: au.id}
-                            - attrs.merge!({checked: 'checked'}) if authors.present? && authors.include?(au.id)
-                            %input{ attrs}/
-                            %label= au.name
-                            %br/
-                    - else
-                      - list.each do |au|
-                        - attrs = {name: "ckb_authors[]", type: "checkbox", id: "au_#{au.id}", value: au.id}
-                        - attrs.merge!({checked: 'checked'}) if authors.present? && authors.include?(au.id)
-                        %input{ attrs}/
+                - list.each_slice(3) do |slice|
+                  .row
+                    - slice.each do |au|
+                      - attrs = {name: "ckb_authors[]", type: "checkbox", id: "au_#{au.id}", value: au.id}
+                      - attrs.merge!({checked: 'checked'}) if authors.present? && authors.include?(au.id)
+                      .col
+                        %input{attrs}/
                         %label= au.name
-                        %br/
-
             .bottom-left-buttons
               %button.by-button-v02#adding-authors-btn.by-button-v02{:href => "#"}= t(:add_authors_to_filter)
               %button.by-button-v02.btn-secondary-v02.desktop-only{'data-dismiss'=>'modal'}


### PR DESCRIPTION
Fixed https://github.com/abartov/bybeconv/issues/46
Author selection popup displayed only up to 10 authors if some filter was applied on works browse page.

Also I changed popup layout a bit to reduce duplication of code. Also I believe it will make navigation over longer lists easier (previously list was sorted by columns, now it is sorted by rows)
