### PR TITLE
ManifestionIndex settings

### DIFF
--- a/app/chewy/manifestations_index.rb
+++ b/app/chewy/manifestations_index.rb
@@ -1,4 +1,5 @@
 class ManifestationsIndex < Chewy::Index
+  settings 'index.max_result_window' => 40000 # Must be set to value greater than total number of works in db
 
   # works
   define_type Manifestation.all_published.includes(expressions: :works) do


### PR DESCRIPTION
Added settings section to ManifestationIndex, to set max result window to 40000, to allow brows for pages > 100

See https://github.com/abartov/bybeconv/issues/115