### PR TITLE
Fixed randomly appearing failure in Person spec

### DIFF
--- a/spec/controllers/authors_controller_spec.rb
+++ b/spec/controllers/authors_controller_spec.rb
@@ -77,7 +77,7 @@ describe AuthorsController do
 
     before do
       create(:manifestation, author: author)
-      create(:manifestation, translator: author)
+      create(:manifestation, orig_lang: 'de', translator: author)
     end
 
     it { is_expected.to be_successful }

--- a/spec/factories/expressions.rb
+++ b/spec/factories/expressions.rb
@@ -24,6 +24,10 @@ FactoryBot.define do
       result = []
       if orig_lang != 'he'
         result << create(:realizer, person: translator, role: :translator)
+      else
+        if translator.present?
+          raise 'Cannot specify translator if language matches orig_lang'
+        end
       end
       if editor.present?
         result << create(:realizer, person: editor, role: :editor)

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -20,8 +20,8 @@ describe Person do
       create(:manifestation, author: person, genre: 'poetry')
       create(:manifestation, author: person, genre: 'poetry')
       create(:manifestation, illustrator: person, genre: 'fables')
-      create(:manifestation, translator: person, genre: 'article')
-      create(:manifestation, translator: person, genre: 'memoir')
+      create(:manifestation, translator: person, orig_lang: 'ru', genre: 'article')
+      create(:manifestation, translator: person, orig_lang: 'ru', genre: 'memoir')
       create(:manifestation, editor: person, genre: 'prose') # edited works should not be included
     end
 


### PR DESCRIPTION
Found and fixed randomly appearing error in Person spec

The reason was that in some tests we specified translator for manifestation, but orig_lang was selected randomly. And if orig_lang was randomly picked as hebrew, translator value was ignored.