### PR TITLE
Drop expressions_manifestation table

### DIFF
--- a/app/chewy/manifestations_index.rb
+++ b/app/chewy/manifestations_index.rb
@@ -2,7 +2,7 @@ class ManifestationsIndex < Chewy::Index
   settings 'index.max_result_window' => 40000 # Must be set to value greater than total number of works in db
 
   # works
-  define_type Manifestation.all_published.includes(expressions: :work) do
+  define_type Manifestation.all_published.includes(expression: :work) do
 #    field :title, analyzer: 'hebrew' # from https://github.com/synhershko/elasticsearch-analysis-hebrew
 #    field :fulltext, value: ->(manifestation) {manifestation.to_plaintext}, analyzer: 'hebrew'
     field :id, type: 'integer'
@@ -10,16 +10,16 @@ class ManifestationsIndex < Chewy::Index
     field :sort_title, type: 'keyword' # for sorting
     field :first_letter, value: ->(manifestation) {manifestation.first_hebrew_letter}
     field :fulltext, value: ->(manifestation) {manifestation.to_plaintext}
-    field :genre, value: ->(manifestation) { manifestation.expressions[0].work.genre}, type: 'keyword'
-    field :orig_lang, value: ->(manifestation) { manifestation.expressions[0].work.orig_lang}, type: 'keyword'
-    field :orig_lang_title, value: ->(manifestation) { manifestation.expressions[0].work.origlang_title}, type: 'keyword'
+    field :genre, value: ->(manifestation) { manifestation.expression.work.genre}, type: 'keyword'
+    field :orig_lang, value: ->(manifestation) { manifestation.expression.work.orig_lang}, type: 'keyword'
+    field :orig_lang_title, value: ->(manifestation) { manifestation.expression.work.origlang_title}, type: 'keyword'
     field :pby_publication_date, type: 'date', value: ->{created_at}
     field :author_string, value: ->(manifestation) {manifestation.author_string}
     field :author_ids, type: 'integer', value: ->(manifestation) {manifestation.author_and_translator_ids}
     field :title_and_authors, value: ->(manifestation) {manifestation.title_and_authors}
     field :impressions_count, type: 'integer'
-    field :raw_publication_date, value: -> (manifestation) {manifestation.expressions[0].date}
-    field :orig_publication_date, type: 'date', value: ->(manifestation) {normalize_date(manifestation.expressions[0].date)}
+    field :raw_publication_date, value: -> (manifestation) {manifestation.expression.date}
+    field :orig_publication_date, type: 'date', value: ->(manifestation) {normalize_date(manifestation.expression.date)}
     # field :video_count, type: 'integer', value: ->(manifestation){ manifestation.video_count}
     # field :recommendation_count, type: 'integer', value: ->(manifestation){manifestation.recommendations.all_approved.count}
     #field :curated_content_count, type: 'integer', value: ->(manifestation){ 0 } # TODO: implement
@@ -27,9 +27,9 @@ class ManifestationsIndex < Chewy::Index
     field :author_gender, value: ->(manifestation) {manifestation.author_gender }, type: 'keyword'
     field :translator_gender, value: ->(manifestation) {manifestation.translator_gender}, type: 'keyword'
     field :copyright_status, value: ->(manifestation) {manifestation.copyright?}, type: 'keyword' # TODO: make non boolean
-    field :period, value: ->(manifestation) {manifestation.expressions[0].period}, type: 'keyword'
-    field :raw_creation_date, value: ->(manifestation) {manifestation.expressions[0].work.date}
-    field :creation_date, type: 'date', value: ->(manifestation) {normalize_date(manifestation.expressions[0].work.date)}
+    field :period, value: ->(manifestation) {manifestation.expression.period}, type: 'keyword'
+    field :raw_creation_date, value: ->(manifestation) {manifestation.expression.work.date}
+    field :creation_date, type: 'date', value: ->(manifestation) {normalize_date(manifestation.expression.work.date)}
     field :publication_place
     field :publisher
   end

--- a/app/chewy/people_index.rb
+++ b/app/chewy/people_index.rb
@@ -1,7 +1,7 @@
 class PeopleIndex < Chewy::Index
 
   # people
-  define_type Person.published do #.joins([expressions: :work]).includes([expressions: :work]) do
+  define_type Person.published do
     field :name
     field :sort_name, type: 'keyword'
     field :other_designation

--- a/app/controllers/aboutnesses_controller.rb
+++ b/app/controllers/aboutnesses_controller.rb
@@ -11,7 +11,7 @@ class AboutnessesController < ApplicationController
       @ab.aboutable_type = 'Work'
       m = Manifestation.find(params['add_work_topic'])
       unless m.nil?
-        w = m.expressions[0].work
+        w = m.expression.work
         @ab.aboutable_id = w.id
       end
     when 'Wikidata'

--- a/app/controllers/anthologies_controller.rb
+++ b/app/controllers/anthologies_controller.rb
@@ -186,7 +186,7 @@ class AnthologiesController < ApplicationController
       @htmls = []
       i = 1
       @anthology.ordered_texts.each {|text|
-        @htmls << [text.title, text.render_html, text.manifestation_id.nil? ? true : false, text.manifestation_id.nil? ? nil : text.manifestation.expressions[0].work.genre ,i]
+        @htmls << [text.title, text.render_html, text.manifestation_id.nil? ? true : false, text.manifestation_id.nil? ? nil : text.manifestation.expression.work.genre ,i]
         i += 1
       }
     end

--- a/app/controllers/authors_controller.rb
+++ b/app/controllers/authors_controller.rb
@@ -54,7 +54,7 @@ class AuthorsController < ApplicationController
     pubs = @author.works_since(1.month.ago, 1000)
     @pubscoll = {}
     pubs.each {|m|
-      genre = m.expressions[0].work.genre
+      genre = m.expression.work.genre
       @pubscoll[genre] = [] if @pubscoll[genre].nil?
       @pubscoll[genre] << m
     }
@@ -67,7 +67,7 @@ class AuthorsController < ApplicationController
     pubs = @author.cached_latest_stuff
     @pubscoll = {}
     pubs.each {|m|
-      genre = m.expressions[0].work
+      genre = m.expression.work
       @pubscoll[genre] = [] if @pubscoll[genre].nil?
       @pubscoll[genre] << m
     }

--- a/app/controllers/proof_controller.rb
+++ b/app/controllers/proof_controller.rb
@@ -53,7 +53,7 @@ class ProofController < ApplicationController
     end
     unless @m.nil?
       @html = MultiMarkdown.new(@m.markdown).to_html.force_encoding('UTF-8').gsub(/<figcaption>.*?<\/figcaption>/,'') # remove MMD's automatic figcaptions
-      @translation = @m.expressions[0].translation
+      @translation = @m.expression.translation
     else
       @html =''
     end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -147,11 +147,11 @@ module ApplicationHelper
   end
 
   def authors_linked_string(m)
-    return m.expressions[0].work.authors.map{|x| "<a href=\"#{url_for(controller: :authors, action: :toc, id: x.id)}\">#{x.name}</a>"}.join(', ')
+    return m.expression.work.authors.map{|x| "<a href=\"#{url_for(controller: :authors, action: :toc, id: x.id)}\">#{x.name}</a>"}.join(', ')
   end
 
   def translators_linked_string(m)
-    return m.expressions[0].translators.map{|x| "<a href=\"#{url_for(controller: :authors, action: :toc, id: x.id)}\">#{x.name}</a>"}.join(', ')
+    return m.expression.translators.map{|x| "<a href=\"#{url_for(controller: :authors, action: :toc, id: x.id)}\">#{x.name}</a>"}.join(', ')
   end
 
   def copyright_glyph(is_copyright)

--- a/app/models/expression.rb
+++ b/app/models/expression.rb
@@ -4,7 +4,7 @@ class Expression < ApplicationRecord
   enum period: %i(ancient medieval enlightenment revival modern)
 
   belongs_to :work, inverse_of: :expressions
-  has_and_belongs_to_many :manifestations
+  has_many :manifestations, inverse_of: :expression, dependent: :destroy
   has_many :realizers, dependent: :destroy
   has_many :persons, through: :realizers, class_name: 'Person'
   has_many :aboutnesses, as: :aboutable, dependent: :destroy

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -82,14 +82,9 @@ class Person < ApplicationRecord
   end
   # set Expressions' period by author
   def update_expressions_period
-    o = original_works.joins(:expressions).includes(:expressions)
-    t = translations.joins(:expressions).includes(:expressions)
-    joint = (o+t).uniq
-    joint.each{|m|
-      e = m.expressions[0]
-      e.period = self.period
-      e.save!
-    }
+    o = original_works.preload(:expression).map(&:expression)
+    t = translations.preload(:expression).map(&:expression)
+    (o + t).uniq.each { |e| e.update_attribute(:period, self.period) }
   end
 
   def died_years_ago
@@ -139,13 +134,13 @@ class Person < ApplicationRecord
   end
 
   def has_any_hebrew_works?
-    return true if Manifestation.all_published.joins(expressions: { work: :creations }).merge(Creation.author.where(person_id: self.id)).where(works: { orig_lang: 'he' }).exists?
-    return true if Manifestation.all_published.joins(expressions: :realizers).merge(Realizer.translator.where(person_id: self.id)).where(expressions: { language: 'he' }).exists?
+    return true if Manifestation.all_published.joins(expression: { work: :creations }).merge(Creation.author.where(person_id: self.id)).where(works: { orig_lang: 'he' }).exists?
+    return true if Manifestation.all_published.joins(expression: :realizers).merge(Realizer.translator.where(person_id: self.id)).where(expressions: { language: 'he' }).exists?
     return false
   end
 
   def has_any_non_hebrew_works?
-    return Manifestation.all_published.joins(expressions: { work: :creations }).merge(Creation.author.where(person_id: self.id)).where.not(works: { orig_lang: 'he' }).exists?
+    return Manifestation.all_published.joins(expression: { work: :creations }).merge(Creation.author.where(person_id: self.id)).where.not(works: { orig_lang: 'he' }).exists?
   end
 
   def self.cached_translators_count
@@ -239,25 +234,27 @@ class Person < ApplicationRecord
   end
 
   def original_works
-    Manifestation.all_published.joins(expressions: [work: :creations]).where("creations.person_id = #{self.id}")
+    Manifestation.all_published.joins(expression: [work: :creations]).where("creations.person_id = #{self.id}")
   end
 
   def translations
-    Manifestation.all_published.joins(expressions: [:work, :realizers]).includes(expressions: [work: [creations: :person]]).where(realizers:{role: Realizer.roles[:translator], person_id: self.id})
+    Manifestation.all_published.joins(expression: [:work, :realizers]).includes(expression: [work: [creations: :person]]).where(realizers:{role: Realizer.roles[:translator], person_id: self.id})
   end
 
   def all_works_including_unpublished
-    works = Manifestation.joins(expressions: [work: :creations]).includes(:expressions).where("creations.person_id = #{self.id}").order(sort_title: :asc)
-    xlats = Manifestation.joins(expressions: :realizers).includes(expressions: [works: [creations: :person]]).where(realizers:{role: Realizer.roles[:translator], person_id: self.id}).order(sort_title: :asc)
+    works = Manifestation.joins(expression: [work: :creations]).includes(:expression).where("creations.person_id = #{self.id}").order(sort_title: :asc)
+    xlats = Manifestation.joins(expression: :realizers).includes(expression: [works: [creations: :person]]).where(realizers:{role: Realizer.roles[:translator], person_id: self.id}).order(sort_title: :asc)
     (works + xlats).uniq.sort_by{|m| m.sort_title}
   end
 
   def original_work_count_including_unpublished
-    Manifestation.joins(expressions: [work: :creations]).where("creations.person_id = #{self.id}").count
+    Manifestation.joins(expression: { work: :creations }).merge(Creation.where(person_id: self.id)).count
   end
+
   def translations_count_including_unpublished
-    Manifestation.joins(expressions: :realizers).where(realizers:{role: Realizer.roles[:translator], person_id: self.id}).count
+    Manifestation.joins(expression: :realizers).merge(Realizer.translator.where(person_id: self.id)).count
   end
+
   def all_works_title_sorted
     (original_works + translations).uniq.sort_by{|m| m.sort_title}
   end
@@ -275,8 +272,8 @@ class Person < ApplicationRecord
   def original_works_by_genre
     ret = {}
     get_genres.map{|g| ret[g] = []}
-    Manifestation.all_published.joins(expressions: [work: :creations]).includes(:expressions).where("creations.person_id = #{self.id}").each do |m|
-      ret[m.expressions[0].work.genre] << m
+    Manifestation.all_published.joins(expression: [work: :creations]).includes(:expression).where("creations.person_id = #{self.id}").each do |m|
+      ret[m.expression.work.genre] << m
     end
     return ret
   end
@@ -284,8 +281,8 @@ class Person < ApplicationRecord
   def translations_by_genre
     ret = {}
     get_genres.map{|g| ret[g] = []}
-    Manifestation.all_published.joins(expressions: :realizers).includes(expressions: :work).where(realizers:{role: Realizer.roles[:translator], person_id: self.id}).each do |m|
-      ret[m.expressions[0].work.genre] << m
+    Manifestation.all_published.joins(expression: :realizers).includes(expression: :work).where(realizers:{role: Realizer.roles[:translator], person_id: self.id}).each do |m|
+      ret[m.expression.work.genre] << m
     end
     return ret
   end
@@ -297,8 +294,8 @@ class Person < ApplicationRecord
   end
 
   def latest_stuff
-    Manifestation.all_published.left_joins(expressions: [:realizers, work: :creations]).
-      includes(:expressions).
+    Manifestation.all_published.left_joins(expression: [:realizers, work: :creations]).
+      includes(:expression).
       where("(creations.person_id = #{self.id}) or ((realizers.person_id = #{self.id}) and (realizers.role = #{Realizer.roles[:translator]}))").
       order(created_at: :desc).limit(20)
   end
@@ -323,7 +320,7 @@ class Person < ApplicationRecord
 
   def most_read(limit)
     Rails.cache.fetch("au_#{self.id}_#{limit}_most_read", expires_in: 24.hours) do
-      Manifestation.joins(expressions: { work: :creations }).
+      Manifestation.joins(expression: { work: :creations }).
         merge(Creation.author.where(person_id: self.id)).
         order(impressions_count: :desc).
         limit(limit).map do |m|
@@ -331,8 +328,8 @@ class Person < ApplicationRecord
             id: m.id,
             title: m.title,
             author: m.authors_string,
-            translation: m.expressions[0].translation,
-            genre: m.expressions[0].work.genre
+            translation: m.expression.translation,
+            genre: m.expression.work.genre
           }
         end
     end

--- a/app/views/admin/missing_languages.html.haml
+++ b/app/views/admin/missing_languages.html.haml
@@ -9,10 +9,10 @@
       %th
 
     - @mans.each do |m|
-      - xlator = m.expressions[0].realizers.where(role: Realizer.roles[:translator])[0]
+      - xlator = m.expression.realizers.where(role: Realizer.roles[:translator])[0]
       %tr
         %td= link_to m.title, manifestation_show_path(m.id)
-        - person = m.expressions[0].work.persons[0]
+        - person = m.expression.work.persons[0]
         %td= person.nil? ? '' : person.name
         %td= xlator.nil? ? '' : xlator.person.name
         %td= link_to t(:edit_metadata), manifestation_edit_metadata_path(m.id)

--- a/app/views/admin/suspicious_headings.html.haml
+++ b/app/views/admin/suspicious_headings.html.haml
@@ -13,7 +13,7 @@
       %tr
         %td= link_to m.title, manifestation_show_path(m.id)
         %td= m.author_string
-        %td= textify_genre(m.expressions[0].work.genre)
+        %td= textify_genre(m.expression.work.genre)
         %td
           %b= link_to t(:edit_markdown), manifestation_edit_path(m.id)
           = ' | '

--- a/app/views/admin/suspicious_titles.html.haml
+++ b/app/views/admin/suspicious_titles.html.haml
@@ -13,7 +13,7 @@
       %tr
         %td= link_to m.title, manifestation_show_path(m.id)
         %td= m.author_string
-        %td= textify_genre(m.expressions[0].work.genre)
+        %td= textify_genre(m.expression.work.genre)
         %td
           %b= link_to t(:edit_markdown), manifestation_edit_path(m.id)
           = ' | '

--- a/app/views/admin/suspicious_translations.html.haml
+++ b/app/views/admin/suspicious_translations.html.haml
@@ -12,8 +12,8 @@
     - @mans.each do |m|
       %tr
         %td= link_to m.title, manifestation_show_path(m.id)
-        %td!= m.expressions[0].work.persons.map{|p| link_to(p.name, authors_show_path(id: p.id))}.join(';')
-        %td!= m.expressions[0].translators.map{|p| link_to(p.name, authors_show_path(id: p.id))}.join('; ')
+        %td!= m.expression.work.persons.map{|p| link_to(p.name, authors_show_path(id: p.id))}.join(';')
+        %td!= m.expression.translators.map{|p| link_to(p.name, authors_show_path(id: p.id))}.join('; ')
         %td= link_to t(:edit_metadata), manifestation_edit_metadata_path(m.id)
 
   != paginate @mans

--- a/app/views/authors/_generated_toc.html.haml
+++ b/app/views/authors/_generated_toc.html.haml
@@ -22,9 +22,9 @@
                           - i += 1
                           - add_authors += au.name + (i == au_count ? '' : '; ')
                         = add_authors+')'
-                      - if m.expressions[0].translation
+                      - if m.expression.translation
                         = " #{t(:translated_by)} "
-                        != m.expressions[0].translators.map{|p| link_to(p.name, author_toc_path(p))}.join('; ')
+                        != m.expression.translators.map{|p| link_to(p.name, author_toc_path(p))}.join('; ')
 
           - if @translations[genre].size > 0
             .by-card-content-v02{:style => "padding-top: 12px;"}
@@ -34,4 +34,4 @@
                   %li
                     = link_to m.title, manifestation_read_path(m)
                     = t(:by)
-                    = link_to m.expressions[0].work.first_author.name, author_toc_path(m.expressions[0].work.first_author)
+                    = link_to m.expression.work.first_author.name, author_toc_path(m.expression.work.first_author)

--- a/app/views/authors/publish.html.haml
+++ b/app/views/authors/publish.html.haml
@@ -19,7 +19,7 @@
     - @manifestations.each do |m|
       %li
         = link_to m.title, manifestation_show_path(id: m.id)
-        = " (#{textify_genre(m.expressions[0].work.genre)}) "
+        = " (#{textify_genre(m.expression.work.genre)}) "
         - if m.published?
           %span{style:'color:green'}= t(:published)
         - else

--- a/app/views/bib/pubs_maybe_done.html.haml
+++ b/app/views/bib/pubs_maybe_done.html.haml
@@ -37,8 +37,8 @@
                       = link_to m.title, manifestation_read_path(m.id)
                       = ' '+t(:by)+': '
                       = m.author_string
-                      = " (#{textify_genre(m.expressions[0].work.genre)}) "
-                      = "– #{(m.expressions[0].source_edition.nil? || m.expressions[0].source_edition.empty?) ? t(:no_source_edition) : m.expressions[0].source_edition}"
+                      = " (#{textify_genre(m.expression.work.genre)}) "
+                      = "– #{(m.expression.source_edition.nil? || m.expression.source_edition.empty?) ? t(:no_source_edition) : m.expression.source_edition}"
                       %br
             %tr{class: 'pub'+pub.id.to_s}
               %td{colspan: 7}

--- a/app/views/manifestation/_list.html.haml
+++ b/app/views/manifestation/_list.html.haml
@@ -14,15 +14,15 @@
 
     - manifestations.each do |m|
       %tr
-        - p = m.expressions[0].work.persons[0]
+        - p = m.expression.work.persons[0]
         - if p.nil?
           %td= t(:error)
         - else
           %td= link_to p.name, authors_show_path(id: p)
         %td= m.title
-        - if m.expressions[0].translation
-          %td= t(:yes)+" (#{textify_lang(m.expressions[0].work.orig_lang)})"
-          - p = m.expressions[0].translators[0]
+        - if m.expression.translation
+          %td= t(:yes)+" (#{textify_lang(m.expression.work.orig_lang)})"
+          - p = m.expression.translators[0]
           - if p.nil?
             %td= t(:error)
           - else
@@ -30,7 +30,7 @@
         - else
           %td= t(:no)
           %td= ''
-        %td= textify_genre(m.expressions[0].work.genre)
+        %td= textify_genre(m.expression.work.genre)
         %td= m.updated_at.to_s
         %td= m.conversion_verified ? t(:yes) : t(:no)
         %td= t(m.status)
@@ -43,4 +43,3 @@
           = link_to t(:edit_metadata), manifestation_edit_metadata_path(m.id)
           = ' | '
           = link_to t(:edit_markdown), manifestation_edit_path(id: m.id)
-

--- a/app/views/manifestation/_surprise_work.html.haml
+++ b/app/views/manifestation/_surprise_work.html.haml
@@ -7,7 +7,7 @@
       %div{style:'margin-bottom:0.6rem'}
         %p.headline-3{style:'display:inline'}
           = link_to work.title, manifestation_read_path(work.id)
-        %p.headline-4{style:'display:inline;margin-right:1rem;'}= "#{t(:by)} #{work.author_string} (#{textify_genre(work.expressions[0].work.genre)})"
+        %p.headline-4{style:'display:inline;margin-right:1rem;'}= "#{t(:by)} #{work.author_string} (#{textify_genre(work.expression.work.genre)})"
       %div{style:'height: 12rem; overflow:hidden; text-overflow: ellipsis;'}
         - opening = MultiMarkdown.new(get_intro(work.markdown)).to_html.force_encoding('UTF-8')
         %p!= opening

--- a/app/views/manifestation/whatsnew.html.haml
+++ b/app/views/manifestation/whatsnew.html.haml
@@ -20,7 +20,7 @@
                         - next if genre[0] == :latest
                         %p
                           %b= t(genre[0])+': '
-                          - worksbuf = genre[1].map{ |m| link_to(m.expressions[0].title + (m.expressions[0].translation ? ' / '+m.authors_string : ''), url_for(controller: :manifestation, action: :read, id: m.id))}
+                          - worksbuf = genre[1].map{ |m| link_to(m.expression.title + (m.expression.translation ? ' / '+m.authors_string : ''), url_for(controller: :manifestation, action: :read, id: m.id))}
                           - worksbuf = worksbuf.join('; ')
                           != worksbuf
                   .whatsnew-pic-wide

--- a/app/views/shared/_anth_panel.html.haml
+++ b/app/views/shared/_anth_panel.html.haml
@@ -87,7 +87,7 @@
                                 .col-md-4.col-sm-12
                                   %div{:style => "padding-bottom: 12px"}
                                     %span{:style => "font-weight:bold"}= t(:genre)+': '
-                                    %span= textify_genre(text.manifestation.expressions[0].work.genre)
+                                    %span= textify_genre(text.manifestation.expression.work.genre)
                                 .col-md-4.col-sm-12
                                   %div{:style => "padding-bottom: 12px"}
                                     %span{:style => "font-weight:bold"}= t(:page_count)+': '

--- a/app/views/shared/_breadcrumbs.html.haml
+++ b/app/views/shared/_breadcrumbs.html.haml
@@ -4,7 +4,7 @@
   - if @pagetype == :manifestation
     .breadcrumbs-text= link_to t(:authors), authors_path
     .breadcrumbs-arrow= 1
-    - e = @entity.expressions[0]
+    - e = @entity.expression
     - w = e.work
     - if e.translators.count > 0
       - person = e.translators[0]

--- a/app/views/shared/_surprise_work.html.haml
+++ b/app/views/shared/_surprise_work.html.haml
@@ -1,5 +1,5 @@
 .by-card-v02#works-surprise-replaced
-  - e = manifestation.expressions[0]
+  - e = manifestation.expression
   %img.surprise-author-card-bookmark-fold-v02{src: '/assets/creator-bookmark-back2.png', width: 168, height: 6}
   .surprise-work-card-v02
     %a{href: manifestation_read_path(manifestation.id)}

--- a/db/migrate/20220518144200_replace_expressions_manifestations_table_with_foreign_key.rb
+++ b/db/migrate/20220518144200_replace_expressions_manifestations_table_with_foreign_key.rb
@@ -1,0 +1,13 @@
+class ReplaceExpressionsManifestationsTableWithForeignKey < ActiveRecord::Migration[5.2]
+  def change
+    add_belongs_to :manifestations, :expression, type: :integer
+
+    execute <<~sql
+      update manifestations m set
+        expression_id = (select em.expression_id from expressions_manifestations em where m.id = em.manifestation_id)
+    sql
+    add_foreign_key :manifestations, :expressions, index: true
+    change_column_null :manifestations, :expression_id, false
+    drop_table :expressions_manifestations
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_04_18_201702) do
+ActiveRecord::Schema.define(version: 2022_05_18_144200) do
 
   create_table "aboutnesses", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin", force: :cascade do |t|
     t.integer "work_id"
@@ -212,13 +212,6 @@ ActiveRecord::Schema.define(version: 2022_04_18_201702) do
     t.index ["normalized_pub_date"], name: "index_expressions_on_normalized_pub_date"
     t.index ["period"], name: "index_expressions_on_period"
     t.index ["work_id"], name: "index_expressions_on_work_id"
-  end
-
-  create_table "expressions_manifestations", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin", force: :cascade do |t|
-    t.integer "expression_id"
-    t.integer "manifestation_id"
-    t.index ["expression_id"], name: "index_expressions_manifestations_on_expression_id"
-    t.index ["manifestation_id"], name: "index_expressions_manifestations_on_manifestation_id"
   end
 
   create_table "external_links", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin", force: :cascade do |t|
@@ -427,8 +420,10 @@ ActiveRecord::Schema.define(version: 2022_04_18_201702) do
     t.integer "status"
     t.string "sort_title"
     t.boolean "sefaria_linker"
+    t.integer "expression_id", null: false
     t.index ["conv_counter"], name: "index_manifestations_on_conv_counter"
     t.index ["created_at"], name: "index_manifestations_on_created_at"
+    t.index ["expression_id"], name: "index_manifestations_on_expression_id"
     t.index ["impressions_count"], name: "index_manifestations_on_impressions_count"
     t.index ["sort_title"], name: "index_manifestations_on_sort_title"
     t.index ["status", "sort_title"], name: "index_manifestations_on_status_and_sort_title"
@@ -732,6 +727,7 @@ ActiveRecord::Schema.define(version: 2022_04_18_201702) do
   add_foreign_key "holdings", "bib_sources"
   add_foreign_key "holdings", "publications"
   add_foreign_key "list_items", "users"
+  add_foreign_key "manifestations", "expressions"
   add_foreign_key "people", "tocs", name: "people_toc_id_fk"
   add_foreign_key "proofs", "html_files", name: "proofs_html_file_id_fk"
   add_foreign_key "proofs", "manifestations", name: "proofs_manifestation_id_fk"

--- a/lib/bybe_utils.rb
+++ b/lib/bybe_utils.rb
@@ -402,13 +402,13 @@ module BybeUtils
     end
   end
   def apa_citation(manifestation)
-    return author_surname_and_initials(manifestation.author_string)+'. ('+citation_date(manifestation.expressions[0].date)+'). <strong>'+manifestation.title+'</strong>'+'. [גרסה אלקטרונית]. פרויקט בן־יהודה. נדלה בתאריך '+Date.today.to_s+". #{request.original_url}"
+    return author_surname_and_initials(manifestation.author_string)+'. ('+citation_date(manifestation.expression.date)+'). <strong>'+manifestation.title+'</strong>'+'. [גרסה אלקטרונית]. פרויקט בן־יהודה. נדלה בתאריך '+Date.today.to_s+". #{request.original_url}"
   end
   def mla_citation(manifestation)
-    return author_surname_and_firstname(manifestation.author_string)+". \"#{manifestation.title}\". <u>פרויקט בן־יהודה</u>. #{citation_date(manifestation.expressions[0].date)}. #{Date.today.to_s}. &lt;#{request.original_url}&gt;"
+    return author_surname_and_firstname(manifestation.author_string)+". \"#{manifestation.title}\". <u>פרויקט בן־יהודה</u>. #{citation_date(manifestation.expression.date)}. #{Date.today.to_s}. &lt;#{request.original_url}&gt;"
   end
   def asa_citation(manifestation)
-    return author_surname_and_firstname(manifestation.author_string)+'. '+citation_date(manifestation.expressions[0].date)+". \"#{manifestation.title}\". <strong>פרויקט בן־יהודה</strong>. אוחזר בתאריך #{Date.today.to_s}. (#{request.original_url})"
+    return author_surname_and_firstname(manifestation.author_string)+'. '+citation_date(manifestation.expression.date)+". \"#{manifestation.title}\". <strong>פרויקט בן־יהודה</strong>. אוחזר בתאריך #{Date.today.to_s}. (#{request.original_url})"
   end
 
   def identify_genre_by_heading(text)

--- a/lib/tasks/dump_works.rake
+++ b/lib/tasks/dump_works.rake
@@ -10,7 +10,7 @@ task :dump_works => :environment do
     Manifestation.all.each{ |m|
       i += 1
       puts "Dumping #{i}/#{total}" if i % 50 == 0
-      e = m.expressions[0]
+      e = m.expression
       w = e.work
       trstr = ''
       sl = ''

--- a/lib/tasks/mass_export.rake
+++ b/lib/tasks/mass_export.rake
@@ -23,7 +23,7 @@ task :mass_export, [:to_path] => :environment do |taskname, args|
       pseudocatalogue = []
       works.each {|m|
         begin
-          ppath = "/p#{m.expressions[0].translation ? m.expressions[0].translators[0].id : m.expressions[0].work.authors[0].id}"
+          ppath = "/p#{m.expression.translation ? m.expression.translators[0].id : m.expression.work.authors[0].id}"
           fname = "/m#{m.id}"
           print "\r#{tot[:works]} files processed. #{(tot[:works].to_f/tot[:todo]*100).round(2)}% done.                                  "
           html = "<!DOCTYPE html PUBLIC \"-//W3C//DTD XHTML 1.0 Transitional//EN\" \"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd\"><html xmlns=\"http://www.w3.org/1999/xhtml\" xml:lang=\"he\" lang=\"he\" dir=\"rtl\"><head><meta http-equiv=\"Content-Type\" content=\"text/html; charset=utf-8\" /></head><body dir='rtl' align='right'><div dir=\"rtl\" align=\"right\">"+MultiMarkdown.new(m.markdown_with_metadata).to_html.force_encoding('UTF-8')+"\n\n<hr />"+I18n.t(:download_footer_html, url: "https://benyehuda.org/read/#{m.id}")+"</div></body></html>"
@@ -38,7 +38,7 @@ task :mass_export, [:to_path] => :environment do |taskname, args|
           File.open(txt_path+ppath+fname+'.txt', 'w:utf-8'){|f| f.write(plaintext)}
           File.open(txt_stripped_path + ppath + fname+'.txt', 'w:utf-8') {|f| f.write(stripped) }
           File.open(html_path + ppath + fname+'.html', 'w:utf-8') {|f| f.write(html)}
-          pseudocatalogue << [m.id, ppath+fname, m.title, m.expressions[0].work.authors.map{|x| x.name}.join('; '), m.expressions[0].translation ? m.expressions[0].translators.map{|x| x.name}.join('; ') : '', m.expressions[0].work.authors.map{|x| x.wikidata_qid.to_s}.join('; '), m.expressions[0].work.translators.map{|x| x.wikidata_qid.to_s}.join('; '), m.expressions[0].translation ? m.expressions[0].work.orig_lang : '', I18n.t(m.expressions[0].work.genre), m.expressions[0].source_edition || '']
+          pseudocatalogue << [m.id, ppath+fname, m.title, m.expression.work.authors.map{|x| x.name}.join('; '), m.expression.translation ? m.expression.translators.map{|x| x.name}.join('; ') : '', m.expression.work.authors.map{|x| x.wikidata_qid.to_s}.join('; '), m.expression.work.translators.map{|x| x.wikidata_qid.to_s}.join('; '), m.expression.translation ? m.expression.work.orig_lang : '', I18n.t(m.expression.work.genre), m.expression.source_edition || '']
           tot[:works] += 1
         rescue StandardError => e
           tot[:errors] += 1

--- a/spec/api/v1/people_api_spec.rb
+++ b/spec/api/v1/people_api_spec.rb
@@ -26,7 +26,7 @@ describe V1::PeopleAPI do
       let!(:illustrated_manifestation) { create(:manifestation, illustrator: person) }
       let!(:manifestation_about) do
         m = create(:manifestation)
-        create(:aboutness, aboutable: person, work: m.expressions[0].work)
+        create(:aboutness, aboutable: person, work: m.expression.work)
         m
       end
       let(:person) do

--- a/spec/api/v1/text_api_spec.rb
+++ b/spec/api/v1/text_api_spec.rb
@@ -39,7 +39,7 @@ describe V1::TextsAPI do
       taggings: [ create(:tagging, tag: tag_unpopular), create(:tagging, tag: tag_pending) ]
     )
 
-    create(:aboutness, work: m.expressions[0].work, aboutable: manifestation_1.expressions[0].work)
+    create(:aboutness, work: m.expression.work, aboutable: manifestation_1.expression.work)
     m
   end
 
@@ -228,7 +228,7 @@ describe V1::TextsAPI do
         result = []
         (1..60).each do |index|
           e = create(:expression, copyrighted: index%10 == 0)
-          result << create(:manifestation, impressions_count: Random.rand(100), expressions: [e])
+          result << create(:manifestation, impressions_count: Random.rand(100), expression: e)
         end
         result
       }
@@ -356,7 +356,7 @@ describe V1::TextsAPI do
 
   def assert_manifestation(json, manifestation, view, file_format, snippet)
     md = json['metadata']
-    expression = manifestation.expressions[0]
+    expression = manifestation.expression
     work = expression.work
     expect(md['title']).to eq manifestation.title
     expect(md['sort_title']).to eq manifestation.sort_title
@@ -403,7 +403,7 @@ describe V1::TextsAPI do
         expect(json_recommendation['recommender_home_url']).to be_nil # Currently it is always nil
         expect(json_recommendation['recommendation_date']).to eq r.created_at.to_date.strftime('%Y-%m-%d')
       end
-      works_about = manifestation.expressions[0].work.works_about
+      works_about = manifestation.expression.work.works_about
       expect(enrichment['texts_about']).to eq works_about.joins(expressions: :manifestations).pluck('manifestations.id').sort
     else
       expect(json.keys).to_not include 'enrichment'

--- a/spec/controllers/aboutnesses_controller_spec.rb
+++ b/spec/controllers/aboutnesses_controller_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 describe AboutnessesController do
   let(:manifestation) { create(:manifestation) }
-  let(:work) { manifestation.expressions[0].work }
+  let(:work) { manifestation.expression.work }
   let(:editor) { create(:user, editor: true) }
 
   before do
@@ -22,7 +22,7 @@ describe AboutnessesController do
 
       it 'creates record' do
         expect { expect(request).to be_successful }.to change { Aboutness.where(work: work).count }.by(1)
-        expect(aboutness).to have_attributes(work: work, aboutable: work_about.expressions[0].work, user: suggested_by_user)
+        expect(aboutness).to have_attributes(work: work, aboutable: work_about.expression.work, user: suggested_by_user)
       end
     end
 

--- a/spec/controllers/manifestations_controller_spec.rb
+++ b/spec/controllers/manifestations_controller_spec.rb
@@ -150,7 +150,7 @@ describe ManifestationController do
     let(:title) { 'Some title' }
     let(:orig_lang) { 'he' }
     let!(:manifestation) { create(:manifestation, title: title, genre: genre, orig_lang: orig_lang) }
-    let(:expression) { manifestation.expressions[0] }
+    let(:expression) { manifestation.expression }
     let(:work) { expression.work }
 
     describe '#show' do
@@ -384,6 +384,12 @@ describe ManifestationController do
       subject { get :add_aboutnesses, params: { id: manifestation.id } }
 
       it { is_expected.to be_successful }
+    end
+
+    describe '#workshow' do
+      subject { get :workshow, params: { id: manifestation.expression.work.id} }
+
+      it { is_expected.to redirect_to manifestation_read_path(manifestation) }
     end
   end
 end

--- a/spec/controllers/proof_controller_spec.rb
+++ b/spec/controllers/proof_controller_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+describe ProofController do
+  let(:user) { create(:user, editor: true) }
+
+  before do
+    create(:list_item, item: user, listkey: :handle_proofs)
+    session[:user_id] = user.id
+  end
+
+  describe '#show' do
+    subject { get :show, params: { id: proof.id } }
+
+    context 'when proof is for manifestation' do
+      let!(:manifestation) { create(:manifestation) }
+      let!(:proof) { create(:proof, manifestation: manifestation) }
+
+      it { is_expected.to be_successful }
+    end
+  end
+end

--- a/spec/factories/html_files.rb
+++ b/spec/factories/html_files.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :html_file do
+
+  end
+end

--- a/spec/factories/manifestations.rb
+++ b/spec/factories/manifestations.rb
@@ -6,6 +6,7 @@ FactoryBot.define do
       language { 'he' }
       orig_lang { %w(he en ru de it).sample }
       genre { Work::GENRES.sample }
+      period { Expression.periods.keys.sample }
       translator { orig_lang != language ? create(:person) : nil }
       editor { nil }
       illustrator { nil }
@@ -23,23 +24,22 @@ FactoryBot.define do
     impressions_count { Random.rand(100) }
     status { :published }
 
-    expressions {
-      [
-        create(
-          :expression,
-          author: author,
-          title: expression_title,
-          work_title: work_title,
-          translator: translator,
-          editor: editor,
-          illustrator: illustrator,
-          language: language,
-          orig_lang: orig_lang,
-          genre: genre,
-          copyrighted: copyrighted
-        )
-      ]
-    }
+    expression do
+      create(
+        :expression,
+        author: author,
+        title: expression_title,
+        work_title: work_title,
+        translator: translator,
+        editor: editor,
+        illustrator: illustrator,
+        language: language,
+        orig_lang: orig_lang,
+        genre: genre,
+        period: period,
+        copyrighted: copyrighted
+      )
+    end
 
     trait :with_external_links do
       external_links { build_list(:external_link, 2) }

--- a/spec/factories/proofs.rb
+++ b/spec/factories/proofs.rb
@@ -1,0 +1,4 @@
+FactoryBot.define do
+  factory :proof do
+  end
+end

--- a/spec/models/expression_spec.rb
+++ b/spec/models/expression_spec.rb
@@ -5,10 +5,10 @@ describe Expression do
     let(:subject) { Expression.cached_work_count_by_periods }
 
     before do
-      create(:manifestation, status: :unpublished, expressions: [ create(:expression, period: :ancient) ])
-      create(:manifestation, expressions: [ create(:expression, period: :ancient) ])
-      create(:manifestation, expressions: [ create(:expression, period: :medieval) ])
-      create(:manifestation, expressions: [ create(:expression, period: :medieval) ])
+      create(:manifestation, status: :unpublished, period: :ancient)
+      create(:manifestation, period: :ancient)
+      create(:manifestation, period: :medieval)
+      create(:manifestation, period: :medieval)
     end
 
     it 'does not counts unpublished works' do

--- a/spec/models/manifestation_spec.rb
+++ b/spec/models/manifestation_spec.rb
@@ -80,7 +80,7 @@ describe Manifestation do
       let(:author_2) { create(:person, name: 'Beta') }
       let(:manifestation) { create(:manifestation, author: author_1) }
       before do
-        create(:creation, work: manifestation.expressions[0].work, role: :author, person: author_2)
+        create(:creation, work: manifestation.expression.work, role: :author, person: author_2)
       end
       it { is_expected.to eq 'Alpha, Beta' }
     end
@@ -89,7 +89,7 @@ describe Manifestation do
       let(:manifestation) { create(:manifestation) }
 
       before do
-        manifestation.expressions[0].work.creations.delete_all
+        manifestation.expression.work.creations.delete_all
       end
 
       it { is_expected.to eq I18n.t(:nil) }
@@ -103,7 +103,7 @@ describe Manifestation do
       let(:translator_2) { create(:person, name: 'Beta') }
       let(:manifestation) { create(:manifestation, orig_lang: 'de', translator: translator_1) }
       before do
-        create(:realizer, expression: manifestation.expressions[0], role: :translator, person: translator_2)
+        create(:realizer, expression: manifestation.expression, role: :translator, person: translator_2)
       end
       it { is_expected.to eq 'Alpha, Beta' }
     end
@@ -112,7 +112,7 @@ describe Manifestation do
       let(:manifestation) { create(:manifestation) }
 
       before do
-        manifestation.expressions[0].realizers.delete_all
+        manifestation.expression.realizers.delete_all
       end
 
       it { is_expected.to eq I18n.t(:nil) }
@@ -126,7 +126,7 @@ describe Manifestation do
     let(:author_2) { create(:person, name: 'Beta') }
 
     before do
-      create(:creation, work: manifestation.expressions[0].work, role: :author, person: author_2)
+      create(:creation, work: manifestation.expression.work, role: :author, person: author_2)
     end
 
     context 'when work is not a translation' do
@@ -138,10 +138,10 @@ describe Manifestation do
 
       context 'when no authors present' do
         before do
-          manifestation.expressions[0].work.creations.delete_all
-
-          it { is_expected.to eq I18n.t(:nil) }
+          manifestation.expression.work.creations.delete_all
         end
+
+        it { is_expected.to eq I18n.t(:nil) }
       end
     end
 
@@ -152,7 +152,7 @@ describe Manifestation do
       let(:manifestation) { create(:manifestation, orig_lang: 'de', author: author_1, translator: translator_1) }
 
       before do
-        create(:realizer, expression: manifestation.expressions[0], role: :translator, person: translator_2)
+        create(:realizer, expression: manifestation.expression, role: :translator, person: translator_2)
       end
 
       context 'when both authors and transaltors are present' do
@@ -161,18 +161,38 @@ describe Manifestation do
 
       context 'when no authors present' do
         before do
-          manifestation.expressions[0].work.creations.delete_all
-
-          it { is_expected.to eq I18n.t(:nil) }
+          manifestation.expression.work.creations.delete_all
         end
+
+        it { is_expected.to eq I18n.t(:nil) }
       end
 
       context 'when no translators present' do
         before do
-          manifestation.expressions[0].realizers.delete_all
+          manifestation.expression.realizers.delete_all
         end
 
         it { is_expected.to eq 'Alpha, Beta / ' + I18n.t(:unknown) }
+      end
+    end
+  end
+
+  describe '.title_and_authors_html' do
+    subject(:string) { manifestation.title_and_authors_html }
+
+    context 'when work is not a translation' do
+      let(:manifestation) { create(:manifestation, orig_lang: :he) }
+
+      it 'does not include info about translation' do
+        expect(string.include?(I18n.t(:translated_from))).to be false
+      end
+    end
+
+    context 'when work is a translation' do
+      let(:manifestation) { create(:manifestation, orig_lang: :de) }
+
+      it 'includes info about translation' do
+        expect(string.include?(I18n.t(:translated_from))).to be_truthy
       end
     end
   end

--- a/spec/services/search_manifestations_spec.rb
+++ b/spec/services/search_manifestations_spec.rb
@@ -67,7 +67,7 @@ describe SearchManifestations do
           :manifestation,
           title: "#{color} #{vegetable} #{index} title",
           impressions_count: index,
-          expressions: [expression],
+          expression: expression,
           created_at: uploaded_at
         )
 
@@ -504,7 +504,7 @@ describe SearchManifestations do
 
     describe 'publication_date' do
       let(:asc_order) do
-        Manifestation.all_published.joins(:expressions).order('expressions.normalized_pub_date').pluck(:id)
+        Manifestation.all_published.joins(:expression).order('expressions.normalized_pub_date').pluck(:id)
       end
       let(:sorting) { 'publication_date' }
       context 'when default sort direction is requested' do
@@ -523,7 +523,7 @@ describe SearchManifestations do
 
     describe 'creation_date' do
       let(:asc_order) do
-        Manifestation.all_published.joins(expressions: :work).order('works.normalized_creation_date').pluck(:id)
+        Manifestation.all_published.joins(expression: :work).order('works.normalized_creation_date').pluck(:id)
       end
       let(:sorting) { 'creation_date' }
       context 'when default sort direction is requested' do

--- a/spec/support/clean_db.rb
+++ b/spec/support/clean_db.rb
@@ -14,8 +14,6 @@ def clean_tables
   ListItem.delete_all
   User.delete_all
 
-  ActiveRecord::Base.connection.execute('delete from expressions_manifestations')
-
   Manifestation.delete_all
   Expression.delete_all
   Work.delete_all


### PR DESCRIPTION
Modified expressions <-> manifestations relation to be one-to-many instead of many-to-many.

Dropped expressions_manifestations table and added manifestations.expression_id column instead.

Updated all places where it was used and added specs to affected places.

Again, I did my best to update rake tasks, but I don't know how to test them