### PR TITLE
Updated logic of setting period in person works 

### DIFF
--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -80,12 +80,6 @@ class Person < ApplicationRecord
     self.status = :published
     self.save! # finally, set this person to published
   end
-  # set Expressions' period by author
-  def update_expressions_period
-    o = original_works.preload(:expression).map(&:expression)
-    t = translations.preload(:expression).map(&:expression)
-    (o + t).uniq.each { |e| e.update_attribute(:period, self.period) }
-  end
 
   def died_years_ago
     begin

--- a/spec/controllers/authors_controller_spec.rb
+++ b/spec/controllers/authors_controller_spec.rb
@@ -151,14 +151,16 @@ describe AuthorsController do
           }
         end
 
-        let(:works_period) { 'modern'}
-        let!(:original_work) { create(:manifestation, author: author, period: works_period) }
+        let(:works_period) { 'modern' } # intentionally use value different from author period
+        let!(:original_work) { create(:manifestation, orig_lang: 'he', author: author, period: works_period) }
+        let!(:original_foreign_work) { create(:manifestation, orig_lang: 'ru', language: 'he', author: author, period: works_period) }
         let!(:translated_work) { create(:manifestation, orig_lang: 'ru', translator: author, period: works_period) }
+        let!(:translated_to_foreign_work) { create(:manifestation, orig_lang: 'he', language: 'ru', translator: author, period: works_period) }
 
         context 'when period attribute was changed' do
           let(:new_period) { 'ancient' }
 
-          it 'updates author and his works' do
+          it 'updates author and sets period in his hebrew works and translations to hebrew' do
             expect(request).to redirect_to authors_show_path(id: author.id)
             author.reload
             expect(author).to have_attributes(name: new_name, period: new_period)
@@ -166,6 +168,14 @@ describe AuthorsController do
             expect(original_work.expression.period).to eq new_period
             translated_work.reload
             expect(translated_work.expression.period).to eq new_period
+
+            # period of original work in foreign language is not changed
+            original_foreign_work.reload
+            expect(original_foreign_work.expression.period).to eq works_period
+
+            # period of translation to foreign language is not changed
+            translated_to_foreign_work.reload
+            expect(translated_to_foreign_work.expression.period).to eq works_period
           end
         end
 
@@ -180,6 +190,10 @@ describe AuthorsController do
             expect(original_work.expression.period).to eq works_period
             translated_work.reload
             expect(translated_work.expression.period).to eq works_period
+            original_foreign_work.reload
+            expect(original_foreign_work.expression.period).to eq works_period
+            translated_to_foreign_work.reload
+            expect(translated_to_foreign_work.expression.period).to eq works_period
           end
         end
       end


### PR DESCRIPTION
When person's period was changed we previous automatically updated period in all his original and translated works.

Now we only update period in original works in hebrew or works translated to hebrew, as period should reflect period of hebrew text.

I've also removed block of code in controller method, used to process situations when wrong author id is passed, because this block was broken (it would fail because in such situations exception would be thrown). As we don't have any issues with this so far, I assume this code redundant.