### PR TITLE
Github Actions fix

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -28,6 +28,7 @@ jobs:
         uses: actions/checkout@v1
       - name: Install dependencies
         run: |
+          sudo apt-get update
           sudo apt-get install -y mysql-client libmysqlclient-dev wkhtmltopdf pandoc yaz libyaz-dev  libmagickwand-dev libpcap-dev memcached
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1

--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -66,8 +66,9 @@ class AdminController < ApplicationController
 
   def missing_copyright
     @authors = Person.where(public_domain: nil)
-    @total = Manifestation.joins(:expressions).where(expressions: {copyrighted: nil}).count
-    @mans = Manifestation.joins(:expressions).where(expressions: {copyrighted: nil}).page(params[:page]).per(50)
+    records = Manifestation.joins(:expression).where(expressions: {copyrighted: nil})
+    @total = records.count
+    @mans = records.page(params[:page]).per(50)
     @page_title = t(:missing_copyright_report)
     Rails.cache.write('report_missing_copyright', @total)
   end
@@ -102,7 +103,7 @@ class AdminController < ApplicationController
   end
 
   def suspicious_translations # find works where the author is also a translator -- this *may* be okay, in the case of self-translation, but probably is a mistake
-    records = Manifestation.joins(expressions: [:realizers, work: :creations]).
+    records = Manifestation.joins(expression: [:realizers, work: :creations]).
       where('realizers.person_id = creations.person_id').
       merge(Realizer.translator).
       merge(Creation.author)
@@ -199,10 +200,10 @@ class AdminController < ApplicationController
       p.original_works.each do |m|
         @tocs_missing_links[p.id][:orig] << m unless toc_items.include?(m)
       end
-      p.translations.includes(expressions: :work).each do |m|
+      p.translations.includes(expression: :work).each do |m|
         @tocs_missing_links[p.id][:xlat] << m unless toc_items.include?(m)
         # additionally, make sure they appear in the original author's ToC, if it's a manual one (relevant for translated authors who *also* wrote in Hebrew, e.g. Y. L. Perets)
-        m.expressions[0].work.authors.each do |au|
+        m.expression.work.authors.each do |au|
           unless au.toc.nil?
             unless au.toc.linked_item_ids.include?(m.id)
               @tocs_missing_links[au.id] = {orig: [], xlat: []} if @tocs_missing_links[au.id].nil?
@@ -220,17 +221,23 @@ class AdminController < ApplicationController
 
   def translated_from_multiple_languages
     @authors = []
-    translatees = Person.joins(creations: :work).includes(:works).where('works.orig_lang <> "he"').distinct
-    translatees.each {|t|
-      if t.works.pluck(:orig_lang).uniq.count > 1
-        works_by_lang = {}
-        t.works.each { |w|
-          works_by_lang[w.orig_lang] = [] if works_by_lang[w.orig_lang].nil?
-          works_by_lang[w.orig_lang] << w.expressions[0].manifestations[0] # TODO: generalize
-        }
-        @authors << [t, t.works.pluck(:orig_lang).uniq, works_by_lang]
-      end
-    }
+
+    # Getting list of authors, who wrote works in more than one language
+    translatees = Person.joins(creations: :work).
+      merge(Creation.author).
+      group('people.id').
+      select('people.id, people.name').
+      having('min(works.orig_lang) <> max(works.orig_lang)').
+      sort_by(&:name)
+
+    translatees.each do |t|
+      manifestations = Manifestation.joins(expression: { work: :creations }).
+        merge(Creation.author.where(person_id: t.id)).
+        preload(expression: :work).
+        sort_by { |m| [m.expression.work.orig_lang, m.sort_title] }.
+        group_by { |m| m.expression.work.orig_lang }
+      @authors << [t, manifestations.keys, manifestations]
+    end
     Rails.cache.write('report_translated_from_multiple_languages', @authors.length)
   end
 
@@ -243,8 +250,8 @@ class AdminController < ApplicationController
   sql
 
   def incongruous_copyright
-    @incong = Manifestation.joins(expressions: :work).
-        select('manifestations.title, manifestations.id, expressions.copyrighted').
+    @incong = Manifestation.joins(expression: :work).
+        select('manifestations.title, manifestations.id, manifestations.expression_id, expressions.copyrighted').
         select(Arel.sql("#{CALCULATED_COPYRIGHT_EXPRESSION} as calculated_copyright")).
         where("expressions.copyrighted is null or #{CALCULATED_COPYRIGHT_EXPRESSION} <> expressions.copyrighted").map do |m|
       [ m, m.title, m.author_string, m.calculated_copyright, m.copyrighted ]


### PR DESCRIPTION
Github Actions can fail while installing dependencies because of missing files in apt repo.

This PR resolves this by explicitely calling `apt-get update` before `apt-get install`

Also this PR fixes some errors in AdminController caused by this commit: https://github.com/abartov/bybeconv/commit/20b78ca55091ea29ced0b2ca9685dd41d690c1d3

Looks like it was a merge of pretty old branch and it overwritten several methods with outdated versions. So I've simply rolled back changes to those methods