### PR TITLE
API Fulltext search tweak

### DIFF
--- a/app/api/v1/texts_api.rb
+++ b/app/api/v1/texts_api.rb
@@ -84,7 +84,14 @@ class V1::TextsAPI < V1::ApplicationApi
       optional :translator_genders, type: Array[String], values: Person.genders.keys
       optional :title, type: String, desc: "a substring to match against a text's title"
       optional :author, type: String, desc: "a substring to match against the name(s) of a text's author(s)"
-      optional :fulltext, type: String, desc: "a substring to match against the work's full text (NOTE: if provided it will enforce result ordering by relevance)"
+      optional :fulltext,
+               type: String,
+               desc: <<~desc
+                 a query string to match against the work's full text, title and authors list
+                 (NOTE: if provided it will enforce result ordering by relevance).
+                 You can use complex expressions here, as documented at 
+                 https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-simple-query-string-query.html#simple-query-string-syntax"
+               desc
       optional :author_ids, type: Array[Integer]
       optional :original_language, type: String, desc: "ISO code of language, e.g. 'pl' for Polish, 'grc' for ancient Greek. Use magic constant 'xlat' to match all non-Hebrew languages"
 

--- a/app/services/search_manifestations.rb
+++ b/app/services/search_manifestations.rb
@@ -56,7 +56,7 @@ class SearchManifestations < ApplicationService
 
     fulltext = filters['fulltext']
     if fulltext.present?
-      result = result.query({ match: { fulltext: fulltext } })
+      result = result.query(simple_query_string: { fields: [:title, :author_string, :fulltext], query: fulltext, default_operator: :and })
     else
       # we're only applying sorting if no full-text search is performed, because for full-text search we want to keep
       # relevance sorting


### PR DESCRIPTION
Updated search_manifestation fulltext search to work in more similar way to website search.
Used simple_query_string query instead of simple match query used before, also make it to take in account author_string and title  way to website search.
Also used 'AND' operator by default (previously it was 'OR')

Used simple_query_string query instead of simple match query used before, also make it to take in account author_string and title

Also see details here: https://github.com/abartov/bybeconv/issues/188#issuecomment-1306106357