### PR TITLE
 Use HTTPS for urls generated with API

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -44,6 +44,7 @@ Bybeconv::Application.configure do
   #config.force_ssl = true # to debug SSL issues
 
   routes.default_url_options[:host] = 'localhost:3000'
+  routes.default_url_options[:protocol] = 'https'
 
   # checks for the presence of an env variable called PROFILE that
   # switches several settings to a more "production-like" value for profiling

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -70,4 +70,5 @@ Bybeconv::Application.configure do
   # config.active_storage.service = :local # temporary
 
   routes.default_url_options[:host] = 'benyehuda.org'
+  routes.default_url_options[:protocol] = 'https'
 end


### PR DESCRIPTION
Modified app configuration to use https protocol by default for URLs generated with URL Helpers. This will update links generated by API
