### PR TITLE
Docker for development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,5 +56,8 @@ bin/delayed_job
 *VBox*.log
 ubuntu-*-console.log
 
+# Docker-compose config
+docker/bybe_dev/docker-compose.override.yml
+
 # IDE files
 .idea

--- a/config/chewy.yml.docker
+++ b/config/chewy.yml.docker
@@ -1,0 +1,5 @@
+test:
+  host: 'elasticsearch:9200'
+  prefix: 'test'
+development:
+  host: 'elasticsearch:9200'

--- a/config/database.yml.docker
+++ b/config/database.yml.docker
@@ -1,0 +1,19 @@
+development:
+  host: mysql
+  adapter: mysql2
+  port: 3306
+  database: bybe_dev
+  username: root
+  password: root
+  encoding: utf8mb4
+  collation: utf8mb4_bin
+
+test:
+  host: mysql
+  adapter: mysql2
+  port: 3306
+  database: bybe_test
+  username: root
+  password: root
+  encoding: utf8mb4
+  collation: utf8mb4_bin

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -13,4 +13,4 @@ RUN apt-get update -qq && apt-get install -y \
 
 WORKDIR /app
 
-CMD bundle install && rails server -b 0.0.0.0
+CMD bundle install && rails server -b 0.0.0.0 -P /tmp/pids/server.pid

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,16 @@
+FROM ruby:2.6.10-buster
+
+RUN apt-get update -qq && apt-get install -y \
+    curl \
+    wkhtmltopdf \
+    pandoc \
+    yaz \
+    libyaz-dev \
+    libmagickwand-dev \
+    libpcap-dev \
+    && apt-get clean \
+    && rm -rf /tmp/* /var/tmp/*
+
+WORKDIR /app
+
+CMD bundle install && rails server -b 0.0.0.0

--- a/docker/bybe_dev/README.md
+++ b/docker/bybe_dev/README.md
@@ -1,0 +1,146 @@
+This folder contains docker-compose configuration for development environment
+
+## Preparing development environment for using docker
+
+NOTE: all `docker-compose` calls commands should be done from folder containing `docker-compose.yml` file.
+
+### 1 .Setting file permissions
+We mount project directory into a docker image, so it will write some files there (e.g. server pids or logs).
+By default docker would write them with root permissions and this can cause some problems.
+You can override permissions used by docker service by providing proper user and group ids to docker-compose.
+
+To achieve this simply copy `docker-compose.override.example.yml` file to `docker-compose.override.yml` and fill `user`
+attribute with `UID:GID` of desired host user, e.g.:
+```
+  app:
+    user: '1000:1000'
+```
+
+NOTE: You can find your uid and gid using `id` command:
+```
+# id
+uid=1000(myuser) gid=1000(myuser) groups=1000(myuser),1001(docker)
+```
+
+### 2. Updating memory preferences
+
+In order to use elasticsearch with docker we need to update vm memory preferences, so open as root `/etc/sysctl.conf`
+and add there a line:
+```
+vm.max_map_count=262144
+```
+
+### 3. Update configuration files
+
+You need to update set of configuration files in `config` folder:
+- `chewy.yml` - just copy content of `chewy.yml.docker`
+- `database.yml` - just copy content of `database.yml.docker`
+- `constants.yml` and `storage.yml` - simply copy content of `constants.yml.sample` and `storage.yml.sample`
+- `s3.yml` - you can copy content of `s3.yml.sample` but to have images properly loaded you'll need real keys for our server. 
+
+
+### 4. Install required gems
+
+```
+# docker-compose run --rm app bundle install
+```
+
+### 5. Prepare databases
+At first you need to create databases:
+```
+# docker-compose run --rm app rails db:create
+```
+
+You'll probably want to use snapshot of production db for development. So you need to restore it from dump:
+```
+# cat <PATH_TO_DUMP_FILE> | docker exec -i bybe_dev_mysql_1 mysql -u root --password=root bybe_dev
+```
+
+Now we need to migrate this db:
+```
+# docker-compose run --rm app rails db:migrate
+```
+And migrate test database as well:
+```
+# docker-compose run --rm app rails db:migrate RAILS_ENV=test
+```
+
+### 6. Rebuild Elasticsearch indices
+```
+# docker-compose run --rm app rake chewy:reset
+```
+
+### 7. Running tests
+
+Now you can try to run specs to check your setup 
+```
+# docker-compose run --rm app rspec
+```
+
+### 8. Staring app
+```
+# docker-compose up -d
+```
+
+App should be available at http://localhost:3001
+Also you should have kibana working at http://localhost:5602
+And you can connect to MySQL at localhost:3307, using root/root credentials
+
+## Useful hints
+
+### Starting and stopping containers
+
+To create and start containers defined in docker-compose file simply run:
+```
+# docker-compose up -d
+```
+
+If you have changed docker images config you may need to provide additional keys to force image rebuild:
+```
+# docker-compose up --build -d 
+```
+
+To stop containers temporarily run:
+```
+# docker-compose stop
+```
+
+To start stopped containers run:
+```
+# docker-compose start
+```
+
+To stop and remove all containers
+```
+# docker-compose down
+```
+
+If you also want to remove all volumes used by containers, add `-v' key:
+```
+# docker-compose down -v
+```
+NOTE: this will remove all database and elastic search data, as well as bundler cache
+
+### Getting into app's bash
+
+If you need to get bash console on app container use:
+```
+# docker-compose run --rm app bash
+```
+
+You can replace `bash`command with any other program you want to run.
+
+NOTE: `run` command creates new container, so `--rm` is added to remove this new container after command is executed.
+
+
+
+### Creating DB dump
+```
+# docker exec bybe_dev_mysql_1 mysqldump -u root --password=root <DB_NAME> | cat > <PATH_TO_DUMP_FILE>
+```
+
+### Restoring DB dump
+
+```
+# cat <PATH_TO_DUMP_FILE> | docker exec -i bybe_dev_mysql_1 mysql -u root --password=root <DB_NAME>
+```

--- a/docker/bybe_dev/docker-compose.override.example.yml
+++ b/docker/bybe_dev/docker-compose.override.example.yml
@@ -1,0 +1,4 @@
+version: '3'
+services:
+  app:
+    user: '1000:1000'

--- a/docker/bybe_dev/docker-compose.yml
+++ b/docker/bybe_dev/docker-compose.yml
@@ -1,0 +1,50 @@
+version: '3'
+
+volumes:
+  mysql_data:
+  bundler_data:
+  elasticsearch_data:
+services:
+  mysql:
+    image: mysql:5.7
+    restart: unless-stopped
+    command: --max_allowed_packet=256M      # Set max_allowed_packet to 256M (or any other value)
+    environment:
+      - MYSQL_ROOT_PASSWORD=root
+    ports:
+      - 3307:3306
+    volumes:
+      - mysql_data:/var/lib/mysql/:delegated
+  elasticsearch:
+    image: elasticsearch:6.8.23
+    restart: unless-stopped
+    volumes:
+      - elasticsearch_data:/usr/share/elasticsearch/data:delegated
+    ports:
+      - 9201:9200
+      - 9301:9300
+  kibana:
+    image: kibana:6.8.23
+    restart: unless-stopped
+    environment:
+      - ELASTICSEARCH_HOSTS=http://elasticsearch:9200
+    ports:
+      - 5602:5601
+    depends_on:
+      - elasticsearch
+  memcached:
+    image: memcached:1.6.17
+    restart: unless-stopped
+  app:
+    build: ..
+    environment:
+      - MEMCACHE_SERVERS=http://memcached:11211
+    ports:
+      - 3001:3000
+    volumes:
+      - ../..:/app
+      - bundler_data:/usr/local/bundle/:delegated
+    depends_on:
+      - mysql
+      - memcached
+      - elasticsearch

--- a/docker/bybe_dev/docker-compose.yml
+++ b/docker/bybe_dev/docker-compose.yml
@@ -16,15 +16,19 @@ services:
     volumes:
       - mysql_data:/var/lib/mysql/:delegated
   elasticsearch:
-    image: elasticsearch:6.8.23
+    image: elasticsearch:7.17.8
     restart: unless-stopped
+    environment:
+      - discovery.type=single-node
+      - xpack.security.enabled=false
+      - ingest.geoip.downloader.enabled=false
     volumes:
       - elasticsearch_data:/usr/share/elasticsearch/data:delegated
     ports:
       - 9201:9200
       - 9301:9300
   kibana:
-    image: kibana:6.8.23
+    image: kibana:7.17.8
     restart: unless-stopped
     environment:
       - ELASTICSEARCH_HOSTS=http://elasticsearch:9200
@@ -44,6 +48,8 @@ services:
     volumes:
       - ../..:/app
       - bundler_data:/usr/local/bundle/:delegated
+    tmpfs:
+      - /tmp/pids/
     depends_on:
       - mysql
       - memcached


### PR DESCRIPTION
Hi @abartov .
This PR adds docker-compose configuration for development and provides following services:
- elastic
- mysql
- memcached
- kibana

I started working on this couple of months ago, but did not completed. So yesterday I've updated it and upgraded to use ES 7.

I believe with this we can get rid of vagrant and use docker-compose instead.
There is some guide for it in /docker/bybe_dev/README.md