### PR TITLE
updated welcome/contact form to make email field mandatory

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -538,7 +538,7 @@ GEM
     rb-fsevent (0.11.2)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
-    rdoc (6.6.2)
+    rdoc (6.6.3.1)
       psych (>= 4.0.0)
     redis-client (0.21.0)
       connection_pool

--- a/app/controllers/welcome_controller.rb
+++ b/app/controllers/welcome_controller.rb
@@ -59,11 +59,16 @@ class WelcomeController < ApplicationController
   end
 
   def submit_contact
-    if params['ziburit'] =~ /ביאליק/
+    @errors = []
+    unless params[:ziburit] =~ /ביאליק/
+      @errors << t('.ziburit_failed')
+    end
+    if params[:email].blank?
+      @errors << t('.email_missing')
+    end
+
+    if @errors.empty?
       Notifications.contact_form_submitted(params.permit(:name, :phone, :email, :topic, :body, :rtopic)).deliver
-      respond_to do |format|
-        format.js
-      end
     end
   end
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -124,7 +124,7 @@
                 <!-- <span class="pointer" id="visit_info">😃</span> -->
                 <% if current_user %>
                   <div class="collapsed" data-toggle="collapse" data-target="#user_collapsible" style="display:inline-block;" title="<%= t(:usermenu_tt) %>">
-                    <div style="padding-left: 0.6rem"><%= t(:welcome) %> <strong><%= current_user.name %></strong>!</div>
+                    <div style="padding-left: 0.6rem"><%= t(:welcome_heading) %> <strong><%= current_user.name %></strong>!</div>
                     <div class="dropdown-arrow pointer" style="top: 0.1rem; left: 0"><i class="fa chevron"></i></div>
                   </div>
                   <div id="user_collapsible" class="collapse"><span id="sign_in" class="linkcolor pointer notyet">כניסה לאזור האישי</a><br/>

--- a/app/views/welcome/_contact.html.haml
+++ b/app/views/welcome/_contact.html.haml
@@ -23,7 +23,7 @@
               #volunteer-name.field-label= t(:contact_name)
               %input.field-v02{name: :name, :type => "text"}/
               #volunteer-email.field-label= t(:contact_email)
-              %input.field-v02{name: :email, :type => "text"}/
+              %input.field-v02{name: :email, required: true, :type => "email"}/
               #volunteer-phone.field-label= t(:contact_phone)
               %input.field-v02{name: :phone, :type => "text"}/
               .contact-message

--- a/app/views/welcome/submit_contact.js.erb
+++ b/app/views/welcome/submit_contact.js.erb
@@ -1,1 +1,5 @@
-$('#contact_content').replaceWith("<%= j(render partial: 'contact_thankyou') %>");
+<% if @errors.empty? %>
+  $('#contact_content').replaceWith("<%= j(render partial: 'contact_thankyou') %>");
+<% else %>
+  alert('<%= escape_javascript(@errors.join("\n")) %>');
+<% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,33 +1,6 @@
-# Files in the config/locales directory are used for internationalization
-# and are automatically loaded by Rails. If you want to use locales other
-# than English, add the necessary files in this directory.
-#
-# To use the locales, use `I18n.t`:
-#
-#     I18n.t 'hello'
-#
-# In views, this is aliased to just `t`:
-#
-#     <%= t('hello') %>
-#
-# To use a different locale, set it with `I18n.locale`:
-#
-#     I18n.locale = :es
-#
-# This would use the information in config/locales/es.yml.
-#
-# The following keys must be escaped otherwise they will not be retrieved by
-# the default I18n backend:
-#
-# true, false, on, off, yes, no
-#
-# Instead, surround them with single quotes.
-#
-# en:
-#   'true': 'foo'
-#
-# To learn more, please read the Rails Internationalization guide
-# available at https://guides.rubyonrails.org/i18n.html.
-
 en:
-  hello: "Hello world"
+  welcome:
+    contact:
+    submit_contact:
+      ziburit_failed: Control question failed
+      email_missing: Please provide an email address

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -1079,7 +1079,7 @@ he:
   purge_spam_proofs: מחק הגהות זבל
   all_proofs: כל ההגהות
   proofs_by_status: הגהות לפי סטטוס %{status}
-  welcome: 'שלום '
+  welcome_heading: 'שלום '
   please_log_in: אין מה לראות לפני התחברות למערכת.
   user_management: ניהול משתמשים
   editor_actions: פעולות עורך
@@ -1343,3 +1343,7 @@ he:
       - "day"
       - "month"
       - "year"
+  welcome:
+    submit_contact:
+      ziburit_failed: Control question failed
+      email_missing: Please provide an email address

--- a/spec/controllers/welcome_controller_spec.rb
+++ b/spec/controllers/welcome_controller_spec.rb
@@ -17,5 +17,57 @@ describe WelcomeController do
 
     it { is_expected.to be_successful }
   end
-end
 
+  describe '#contact' do
+    subject { get :contact }
+
+    it { is_expected.to be_successful }
+  end
+
+  describe '#submit_contact' do
+    let(:email) { 'john.doe@test.com' }
+    let(:ziburit) { 'ביאליק' }
+    let(:errors) { assigns(:errors) }
+
+    let(:params) do
+      {
+        name: 'John Doe',
+        phone: '123456789',
+        email: email,
+        topic: 'other',
+        body: 'Topic',
+        rtopic: 'other',
+        ziburit: ziburit
+      }
+    end
+
+    subject(:request) { post :submit_contact, params: params, format: :js }
+
+    before do
+      allow(Notifications).to receive(:contact_form_submitted).and_call_original
+      request
+    end
+
+    context 'when everything is OK' do
+      it { is_expected.to be_successful }
+      it { expect(errors).to be_empty }
+      it { expect(Notifications).to have_received(:contact_form_submitted).once }
+    end
+
+    context 'when email is missing' do
+      let(:email) { ' ' }
+
+      it { is_expected.to be_successful }
+      it { expect(errors).to eq([I18n.t('welcome.submit_contact.email_missing')]) }
+      it { expect(Notifications).not_to have_received(:contact_form_submitted) }
+    end
+
+    context 'when control question failed' do
+      let(:ziburit) { 'WRONG' }
+
+      it { is_expected.to be_successful }
+      it { expect(errors).to eq([I18n.t('welcome.submit_contact.ziburit_failed')]) }
+      it { expect(Notifications).not_to have_received(:contact_form_submitted) }
+    end
+  end
+end


### PR DESCRIPTION
Also fixed an error: if ziburit check failed, it did not send an email, but showed 'Thank you' modal to user, as if it was successful.
Now it will alert an error message.

Note: I've added i18n resources for error messages, but we need to translate them to hebrew.

Also I propose to use Rails convention for i18n resources and group them by controllers and actions, so we can use shortended [lazy lookup](https://guides.rubyonrails.org/i18n.html#lazy-lookup)