### PR TITLE
Configuration to make it possible to use RubyMine's integrated debugger

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -135,7 +135,6 @@ group :test, :development do
   gem 'rspec-rails', '~> 5.0.2'
   gem 'spring'
   gem 'spring-commands-rspec'
-  gem 'debug'
 end
 
 gem "sidekiq", "~> 7.2"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -188,9 +188,6 @@ GEM
     damerau-levenshtein (1.3.3)
     date (3.3.4)
     dead_end (4.0.0)
-    debug (1.9.1)
-      irb (~> 1.10)
-      reline (>= 0.3.8)
     derailed_benchmarks (2.1.2)
       benchmark-ips (~> 2)
       dead_end
@@ -327,10 +324,6 @@ GEM
       ruby-vips (>= 2.0.17, < 3)
     immigrant (0.3.6)
       activerecord (>= 3.0)
-    io-console (0.7.2)
-    irb (1.12.0)
-      rdoc
-      reline (>= 0.4.2)
     jbuilder (2.11.5)
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
@@ -471,8 +464,6 @@ GEM
     property_sets (3.12.0)
       activerecord (>= 6.0, < 7.2)
       json
-    psych (5.1.2)
-      stringio
     puma (6.4.2)
       nio4r (~> 2.0)
     puma-daemon (0.3.2)
@@ -538,14 +529,10 @@ GEM
     rb-fsevent (0.11.2)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
-    rdoc (6.6.3.1)
-      psych (>= 4.0.0)
     redis-client (0.21.0)
       connection_pool
     regexp_parser (2.9.0)
     regexp_property_values (1.5.1)
-    reline (0.4.3)
-      io-console (~> 0.5)
     request_store (1.6.0)
       rack (>= 1.4)
     responders (3.1.1)
@@ -645,7 +632,6 @@ GEM
       net-sftp (>= 2.1.2)
       net-ssh (>= 2.8.0)
     stackprof (0.2.26)
-    stringio (3.1.0)
     temple (0.10.3)
     terrapin (1.0.1)
       climate_control
@@ -699,7 +685,6 @@ DEPENDENCIES
   coffee-script
   dalli
   damerau-levenshtein
-  debug
   derailed_benchmarks
   diffy
   docx

--- a/config/spring.rb
+++ b/config/spring.rb
@@ -1,0 +1,8 @@
+Spring.after_fork do
+  if ENV['DEBUGGER_STORED_RUBYLIB']
+    ENV['DEBUGGER_STORED_RUBYLIB'].split(File::PATH_SEPARATOR).each do |path|
+      next unless path =~ /ruby-debug-ide/
+      load path + '/ruby-debug-ide/multiprocess/starter.rb'
+    end
+  end
+end


### PR DESCRIPTION
Rubymine uses debase as debugger and it conflicts with debug gem, which is listed in Gemfile.
Also it includes some settings adjustements for Spring preloader to work with it.

@abartov if you want to keep debug in gemfile (e.g. you use it from command line or other IDE), then simply ignore this PR.