### PR TITLE
Modified migrations to use pure SQL, as old code will be broken after…

### DIFF
--- a/app/models/involved_authority.rb
+++ b/app/models/involved_authority.rb
@@ -1,5 +1,14 @@
 class InvolvedAuthority < ApplicationRecord
-  enum role: { author: 0, editor: 1, illustrator: 2, translator: 3, photographer: 4, designer: 5, contributor: 6, other: 7 }
+  enum role: {
+    author: 0,
+    editor: 1,
+    illustrator: 2,
+    translator: 3,
+    photographer: 4,
+    designer: 5,
+    contributor: 6,
+    other: 7
+  }
 
   belongs_to :authority, polymorphic: true # Person or CorporateBody
   belongs_to :item, polymorphic: true # Work or Expression

--- a/db/migrate/20231231084439_creations_to_involved_authorities.rb
+++ b/db/migrate/20231231084439_creations_to_involved_authorities.rb
@@ -1,20 +1,20 @@
 class CreationsToInvolvedAuthorities < ActiveRecord::Migration[6.1]
   def change
-    puts "migrating #{Creation.count} Creations to InvolvedAuthorities..."
-    i = 0
-    stale = 0
-    Creation.all.each do |c|
-      begin
-        ia = InvolvedAuthority.create!(item_type: 'Work', item_id: c.work_id, authority_type: 'Person', authority_id: c.person_id, role: c.role)
-        ia.update!(created_at: c.created_at, updated_at: c.updated_at)
-        # when this major refactoring is done, a later migration would drop the Creations table
-        i += 1
-      rescue ActiveRecord::RecordInvalid => e
-        stale += 1
-      end
-      puts "migrated #{i} Creations to InvolvedAuthorities" if i % 200 == 0
-    end
-    puts "Skipped #{stale} stale creations no longer pointing at existing items..."
-    puts "done."
+    # Creations have only two roles: 0 - author and 2 - illustrator, which matches roles in InvolvedAuthority
+    execute <<~sql
+      insert into involved_authorities (authority_id, authority_type, role, item_id, item_type, created_at, updated_at)
+      select
+        person_id,
+        'Person',
+        role,
+        work_id,
+        'Work',
+        created_at,
+        updated_at
+      from
+        creations c
+      where
+        exists (select 1 from works w where w.id = c.work_id)
+    sql
   end
 end

--- a/db/migrate/20240101053832_realizers_to_involved_authorities.rb
+++ b/db/migrate/20240101053832_realizers_to_involved_authorities.rb
@@ -1,20 +1,21 @@
 class RealizersToInvolvedAuthorities < ActiveRecord::Migration[6.1]
   def change
-    puts "migrating #{Realizer.count} Realizers to InvolvedAuthorities..."
-    i = 0
-    stale = 0
-    Realizer.all.each do |r|
-      begin
-        ia = InvolvedAuthority.create!(item_type: 'Expression', item_id: r.expression_id, authority_type: 'Person', authority_id: r.person_id, role: r.role)
-        ia.update!(created_at: r.created_at, updated_at: r.updated_at)
-        # when this major refactoring is done, a later migration would drop the Realizers table
-        i += 1
-      rescue ActiveRecord::RecordInvalid => e
-        stale += 1
-      end
-      puts "migrated #{i} Realizers to InvolvedAuthorities" if i % 200 == 0
-    end
-    puts "Skipped #{stale} stale realizers no longer pointing at existing items..."
-    puts "done."
+    # Realizers have only two roles: 1 - editor and 3 - translator, which matches roles in InvolvedAuthority
+    execute <<~sql
+      insert into involved_authorities (authority_id, authority_type, role, item_id, item_type, created_at, updated_at)
+      select
+        person_id,
+        'Person',
+        role,
+        expression_id,
+        'Expression',
+        created_at,
+        updated_at
+      from
+        realizers r
+      where
+        exists (select 1 from expressions e where e.id = r.expression_id)
+    sql
+
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -263,7 +263,7 @@ ActiveRecord::Schema.define(version: 2024_03_31_120740) do
 
   create_table "corporate_bodies", charset: "utf8mb4", collation: "utf8mb4_bin", force: :cascade do |t|
     t.string "name"
-    t.string "alternate_names"
+    t.text "alternate_names"
     t.string "location"
     t.string "inception"
     t.integer "inception_year"


### PR DESCRIPTION
This PR (to merge_involved_authorities branch) updates two migrations to use plain SQL instead of Ruby loops.
Main reason is that old versions requires presence of Realizer and Creation models we want to drop soon.