### PR TITLE
Authors search after

### DIFF
--- a/app/chewy/people_index.rb
+++ b/app/chewy/people_index.rb
@@ -2,6 +2,7 @@ class PeopleIndex < Chewy::Index
 
   # people
   index_scope  Person.published
+  field :id, type: 'integer'
   field :name
   field :sort_name, type: 'keyword'
   field :other_designation

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -64,13 +64,6 @@ class ApplicationController < ActionController::Base
   def mobile_search
     render partial: 'shared/mobile_search'
   end
-  def es_buckets_to_facet(buckets, codehash)
-    facet = {}
-    buckets.each do |facethash|
-      facet[codehash[facethash['key']]] = facethash['doc_count'] unless codehash[facethash['key']].nil?
-    end
-    return facet
-  end
 
   protected
 

--- a/app/controllers/authors_controller.rb
+++ b/app/controllers/authors_controller.rb
@@ -3,6 +3,8 @@ include BybeUtils
 include ApplicationHelper
 
 class AuthorsController < ApplicationController
+  include FilteringAndPaginationConcern
+
   before_action only: [:new, :publish, :create, :show, :edit, :list, :add_link, :delete_link, :delete_photo, :edit_toc, :update, :to_manual_toc] do |c| c.require_editor('edit_people') end
   autocomplete :tag, :name, :limit => 2
 
@@ -142,7 +144,7 @@ class AuthorsController < ApplicationController
       ret << {terms: {tags: tag_data.map(&:last)}}
       @filters += tag_data.map { |x| [x.last, "tag_#{x.first}", :checkbox] }
     end
-    
+
     # dates
     @fromdate = params['fromdate'] if params['fromdate'].present?
     @todate = params['todate'] if params['todate'].present?
@@ -158,7 +160,14 @@ class AuthorsController < ApplicationController
     end
     datefield = es_datefield_name_from_datetype(@datetype)
     ret << {range: {"#{datefield}" => range_expr }} unless range_expr.empty?
-    #     { "range": { "publish_date": { "gte": "2015-01-01" }}}
+
+    # Adding filtering by first letter
+    @to_letter = params['to_letter']
+    if @to_letter.present?
+      ret << { prefix: { sort_name: @to_letter } }
+      @filters << [I18n.t(:name_starts_with_x, x: @to_letter), :to_letter, :text]
+    end
+
     return ret
   end
   def build_es_query_from_filters
@@ -170,33 +179,8 @@ class AuthorsController < ApplicationController
     end
     return ret
   end
-  def es_prep_collection
-    @sort_dir = :default
-    if params[:sort_by].present?
-      @sort_or_filter = 'sort'
-      @sort = params[:sort_by].dup
-      params[:sort_by].sub!(/_(a|de)sc$/,'')
-      @sort_dir = $&[1..-1] unless $&.nil?
-    end
-    # figure out sort order
-    if params[:sort_by].present?
-      case params[:sort_by]
-      when 'alphabetical'
-        ord = {sort_name: (@sort_dir == :default ? :asc : @sort_dir)}
-      when 'popularity'
-        ord = {impressions_count: (@sort_dir == :default ? :desc : @sort_dir)}
-      when 'death_date'
-        ord = {death_year: (@sort_dir == :default ? 'asc' : @sort_dir)}
-      when 'birth_date'
-        ord = {birth_year: (@sort_dir == :default ? 'asc' : @sort_dir)}
-      when 'upload_date'
-        ord = {pby_publication_date: (@sort_dir == :default ? :desc : @sort_dir)}
-      end
-    else
-      sdir = (@sort_dir == :default ? :asc : @sort_dir)
-      @sort = "alphabetical_#{sdir}"
-      ord = {sort_name: sdir}
-    end
+
+  def fill_aggregated_facets(collection)
     standard_aggregations = {
       periods: {terms: {field: 'period'}},
       genres: {terms: {field: 'genre'}},
@@ -204,47 +188,67 @@ class AuthorsController < ApplicationController
       copyright_status: {terms: {field: 'copyright_status'}},
       genders: {terms: {field: 'gender'}},
     }
+
+    collection = collection.aggregations(standard_aggregations)
+
+    @gender_facet = es_buckets_to_facet(collection.aggs['genders']['buckets'], Person.genders)
+    @period_facet = es_buckets_to_facet(collection.aggs['periods']['buckets'], Expression.periods)
+    @genre_facet = es_buckets_to_facet(collection.aggs['genres']['buckets'], get_genres.to_h { |g| [g, g] })
+    @language_facet = es_buckets_to_facet(collection.aggs['languages']['buckets'], get_langs.to_h { |l| [l, l] })
+    @language_facet[:xlat] = @language_facet.reject{|k,v| k == 'he'}.values.sum
+    @copyright_facet = es_buckets_to_facet(collection.aggs['copyright_status']['buckets'], { 0 => 0, 1 => 1 })
+  end
+
+  SORTING_PROPERTIES = {
+    'alphabetical' => { default_dir: 'asc', column: :sort_name },
+    'popularity' => { default_dir: 'desc', column: :impressions_count },
+    'death_date' => { default_dir: 'asc', column: :death_year },
+    'birth_date' => { default_dir: 'asc', column: :birth_year },
+    'upload_date' => { default_dir: 'desc', column: :pby_publication_date }
+  }.freeze
+
+  def get_sort_column(sort_by)
+    SORTING_PROPERTIES[sort_by][:column]
+  end
+
+  def es_prep_collection
+    @sort_dir = 'default'
+    if params[:sort_by].present?
+      @sort_or_filter = 'sort'
+      @sort = params[:sort_by].dup
+      @sort_by = params[:sort_by].sub(/_(a|de)sc$/, '')
+      @sort_dir = Regexp.last_match(0)[1..] unless Regexp.last_match(0).nil?
+    else
+      # use alphabetical sorting by default
+      @sort = 'alphabetical_asc'
+      @sort_by = 'alphabetical'
+      @sort_dir = 'asc'
+    end
+
+    # This param means that we're getting previous page
+    # so we should revert sort ordering while quering ElasticSearch index
+    @reverse = params[:reverse] == 'true'
+    sort_dir_to_use = if @reverse
+                        @sort_dir == 'asc' ? 'desc' : 'asc'
+                      else
+                        @sort_dir
+                      end
+    ord = { SORTING_PROPERTIES[@sort_by][:column] => sort_dir_to_use, id: sort_dir_to_use }
+
     filter = build_es_filter_from_filters
     es_query = build_es_query_from_filters
-    es_query = {match_all: {}} if es_query == {}
-    @collection = PeopleIndex.query(es_query).filter(filter).aggregations(standard_aggregations).order(ord).limit(100) # prepare ES query
-    @emit_filters = true if params[:load_filters] == 'true' || params[:emit_filters] == 'true'
-    @total = @collection.count # actual query triggered here
-    @gender_facet = es_buckets_to_facet(@collection.aggs['genders']['buckets'], Person.genders)
-    @period_facet = es_buckets_to_facet(@collection.aggs['periods']['buckets'], Expression.periods)
-    @genre_facet = es_buckets_to_facet(@collection.aggs['genres']['buckets'], get_genres.to_h {|g| [g,g]})
-    @language_facet = es_buckets_to_facet(@collection.aggs['languages']['buckets'], get_langs.to_h {|l| [l,l]})
-    @language_facet[:xlat] = @language_facet.reject{|k,v| k == 'he'}.values.sum
-    @copyright_facet = es_buckets_to_facet(@collection.aggs['copyright_status']['buckets'], {0 => 0, 1 => 1})
-    if @sort[0..11] == 'alphabetical' # subset of @sort to ignore direction
-      unless params[:page].blank?
-        params[:to_letter] = nil # if page was specified, forget the to_letter directive
-      end
-      oldpage = @page
-      @authors = @collection.page(@page) # get page X of manifestations
-      @total_pages = @authors.total_pages
+    es_query = { match_all: {} } if es_query == {}
 
-      unless params[:to_letter].blank?
-        adjust_page_by_letter(@collection, params[:to_letter], :sort_name, @sort_dir, true)
-        @authors = @collection.page(@page) if oldpage != @page # re-get page X of manifestations if adjustment was made
-      end
+    @collection = PeopleIndex.query(es_query)
+                             .filter(filter)
+                             .order(ord)
 
-      # one idea is to search with the same filters AND a title match for each letter plus * (wildcard), COUNT the results, and calculate the page numbers by division with page size
-      @ab = []
-      ['א', 'ב', 'ג', 'ד', 'ה', 'ו', 'ז', 'ח', 'ט', 'י', 'כ', 'ל', 'מ', 'נ', 'ס', 'ע', 'פ', 'צ', 'ק', 'ר', 'ש', 'ת'].each{|l|
-        @ab << [l, '']
-      }
-      # @ab = prep_ab(@collection, @works, :sort_title)
-    else
-      @authors = @collection.page(@page)
-      @total_pages = @authors.total_pages
-    end
+    @authors = paginate(@collection)
   end
 
   def browse
-    @page_title = t(:authors_list)+' – '+t(:project_ben_yehuda)
+    @page_title = "#{t(:authors_list)} – #{t(:project_ben_yehuda)}"
     @pagetype = :authors
-    @page = params[:page] || 1
     @page = 1 if ['0',''].include?(@page) # slider sets page to zero, awkwardly
     es_prep_collection
     @total = @collection.count
@@ -257,6 +261,7 @@ class AuthorsController < ApplicationController
       format.js
     end
   end
+
   def all
     redirect_to '/authors'
   end

--- a/app/controllers/concerns/filtering_and_pagination_concern.rb
+++ b/app/controllers/concerns/filtering_and_pagination_concern.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+# This concern contains common logic used to organize filtering and pagination
+module FilteringAndPaginationConcern
+  extend ActiveSupport::Concern
+
+  PAGE_SIZE = 100
+
+  private
+
+  def es_buckets_to_facet(buckets, codehash)
+    facet = {}
+    buckets.each do |facethash|
+      facet[codehash[facethash['key']]] = facethash['doc_count'] unless codehash[facethash['key']].nil?
+    end
+    facet
+  end
+
+  def paginate(collection)
+    @total = collection.count
+    @total_pages = (@total / PAGE_SIZE.to_f).ceil
+
+    # After we've swtiched to search_after logic for paging, page is only used to generate proper offset of item indices
+    # in works list (e.g. to start second page from index 101)
+    @page = (params[:page] || 1).to_i
+
+    @emit_filters = params[:load_filters] == 'true' || params[:emit_filters] == 'true'
+
+    fill_aggregated_facets(collection) # This method should be implemented in controllers using this concern
+
+    # checking if non-first page should be loaded
+    search_after_id = params[:search_after_id]
+    search_after_value = params[:search_after_value]
+    if search_after_id.present?
+      collection = collection.search_after(search_after_value, search_after_id)
+    end
+
+    if @reverse
+      # Fetching previous page
+      records = collection.limit(PAGE_SIZE).to_a
+      have_more_items = true # we know that there are more items after fetched page
+      records.reverse! # reordering items to display them in proper ordering
+    else
+      # Fetching next page
+      # we're retrieving one extra item to check if we have more items after fetched page
+      records = collection.limit(PAGE_SIZE + 1).to_a
+      have_more_items = records.size == PAGE_SIZE + 1
+      records = records[0..-2] if have_more_items # removing extra item
+    end
+
+    sort_column = get_sort_column(@sort_by)
+    @search_after_for_next = search_after_for_item(records.last, sort_column, false) if have_more_items
+    @search_after_for_previous = search_after_for_item(records.first, sort_column, true) if @page > 1
+
+    records
+  end
+
+  def search_after_for_item(item, sort_column, reverse)
+    {
+      value: item.send(sort_column),
+      id: item.id,
+      page: reverse ? @page - 1 : @page + 1,
+      reverse: reverse.to_s
+    }
+  end
+end

--- a/app/controllers/manifestation_controller.rb
+++ b/app/controllers/manifestation_controller.rb
@@ -590,8 +590,6 @@ class ManifestationController < ApplicationController
   end
 
   PAGE_SIZE = 100
-  LETTERS = %w(א ב ג ד ה ו ז ח ט י כ ל מ נ ס ע פ צ ק ר ש ת).freeze
-
   def build_es_filter_from_filters
     ret = {}
     @filters = []

--- a/app/controllers/manifestation_controller.rb
+++ b/app/controllers/manifestation_controller.rb
@@ -1,6 +1,8 @@
 require 'pandoc-ruby'
 
 class ManifestationController < ApplicationController
+  include FilteringAndPaginationConcern
+
   before_action only: [:list, :show, :remove_link, :edit_metadata, :add_aboutnesses] do |c| c.require_editor('edit_catalog') end
   before_action only: [:edit, :update] do |c| c.require_editor(['edit_catalog', 'conversion_verification', 'handle_proofs']) end
   before_action only: [:all, :genre, :period, :by_tag] do |c| c.refuse_unreasonable_page end
@@ -701,6 +703,45 @@ class ManifestationController < ApplicationController
     return ret
   end
 
+  def fill_aggregated_facets(collection)
+    standard_aggregations = {
+      periods: { terms: { field: 'period' } },
+      genres: { terms: { field: 'genre' } },
+      languages: { terms: { field: 'orig_lang', size: get_langs.count + 1 } },
+      copyright_status: { terms: { field: 'copyright_status' } },
+      author_genders: { terms: { field: 'author_gender' } },
+      translator_genders: { terms: { field: 'translator_gender' } },
+      # We may need to increase `size` threshold in future if number of authors exceeds 2000
+      author_ids: { terms: { field: 'author_ids', size: 2000 } }
+    }
+
+    collection = collection.aggregations(standard_aggregations)
+
+    @gender_facet = es_buckets_to_facet(collection.aggs['author_genders']['buckets'], Person.genders)
+    @tgender_facet = es_buckets_to_facet(collection.aggs['translator_genders']['buckets'], Person.genders)
+    @period_facet = es_buckets_to_facet(collection.aggs['periods']['buckets'], Expression.periods)
+    @genre_facet = es_buckets_to_facet(collection.aggs['genres']['buckets'], get_genres.to_h { |g| [g, g] })
+    @language_facet = es_buckets_to_facet(collection.aggs['languages']['buckets'], get_langs.to_h { |l| [l, l] })
+    @language_facet[:xlat] = @language_facet.except('he').values.sum
+    @copyright_facet = es_buckets_to_facet(
+      collection.aggs['copyright_status']['buckets'],
+      { 'false' => 0, 'true' => 1 }
+    )
+
+    # Preparing list of authors to show in multiselect modal on works browse page
+    if collection.filter.present?
+      author_ids = collection.aggs['author_ids']['buckets'].pluck('key')
+      @authors_list = Person.where(id: author_ids)
+    else
+      @authors_list = Person.all
+    end
+    @authors_list = @authors_list.select(:id, :name).sort_by(&:name)
+  end
+
+  def get_sort_column(sort_by)
+    SearchManifestations::SORTING_PROPERTIES[sort_by][:column]
+  end
+
   def es_prep_collection
     @sort_dir = 'default'
     if params[:sort_by].present?
@@ -715,22 +756,12 @@ class ManifestationController < ApplicationController
       @sort_dir = 'asc'
     end
 
-    standard_aggregations = {
-      periods: {terms: {field: 'period'}},
-      genres: {terms: {field: 'genre'}},
-      languages: {terms: {field: 'orig_lang', size: get_langs.count + 1}},
-      copyright_status: {terms: {field: 'copyright_status'}},
-      author_genders: {terms: {field: 'author_gender'}},
-      translator_genders: {terms: {field: 'translator_gender'}},
-      author_ids: {terms: {field: 'author_ids', size: 2000}} # We may need to increase this threshold in future if number of authors exceeds 2000
-    }
-
     filter = build_es_filter_from_filters
 
     # This param means that we're getting previous page
     # so we should revert sort ordering while quering ElasticSearch index
-    reverse = params[:reverse] == 'true'
-    sort_dir_to_use = if reverse
+    @reverse = params[:reverse] == 'true'
+    sort_dir_to_use = if @reverse
                         @sort_dir == 'asc' ? 'desc' : 'asc'
                       else
                         @sort_dir
@@ -745,69 +776,14 @@ class ManifestationController < ApplicationController
       @filters << [I18n.t(:title_starts_with_x, x: @to_letter), :to_letter, :text]
     end
 
-    @collection = @collection.aggregations(standard_aggregations)
-    @total = @collection.count # actual query triggered here
-    @total_pages = (@total / PAGE_SIZE.to_f).ceil
-
-    # After we've swtiched to search_after logic for paging, page is only used to generate proper offset of item indices
-    # in works list (e.g. to start second page from index 101)
-    @page = (params[:page] || 1).to_i
-
-    @emit_filters = true if params[:load_filters] == 'true' || params[:emit_filters] == 'true'
-    @gender_facet = es_buckets_to_facet(@collection.aggs['author_genders']['buckets'], Person.genders)
-    @tgender_facet = es_buckets_to_facet(@collection.aggs['translator_genders']['buckets'], Person.genders)
-    @period_facet = es_buckets_to_facet(@collection.aggs['periods']['buckets'], Expression.periods)
-    @genre_facet = es_buckets_to_facet(@collection.aggs['genres']['buckets'], get_genres.to_h {|g| [g,g]})
-    @language_facet = es_buckets_to_facet(@collection.aggs['languages']['buckets'], get_langs.to_h {|l| [l,l]})
-    @language_facet[:xlat] = @language_facet.reject{|k,v| k == 'he'}.values.sum
-    @copyright_facet = es_buckets_to_facet(@collection.aggs['copyright_status']['buckets'], {'false' => 0,'true' => 1})
-    # Preparing list of authors to show in multiselect modal on works browse page
-    if filter.empty?
-      @authors_list = Person.all
-    else
-      author_ids = @collection.aggs['author_ids']['buckets'].map{|x| x['key']}
-      @authors_list = Person.where(id: author_ids)
-    end
-    @authors_list = @authors_list.select(:id, :name).sort_by(&:name)
-
-    # checking if non-first page should be loaded
-    search_after_manifestation_id = params[:search_after_manifestation_id]
-    search_after_value = params[:search_after_value]
-    if search_after_manifestation_id.present?
-      @collection = @collection.search_after(search_after_value, search_after_manifestation_id)
-    end
-
-    if reverse
-      # Fetching previous page
-      @works = @collection.limit(PAGE_SIZE).to_a
-      have_more_items = true # we know that there are more items after fetched page
-      @works.reverse! # reordering items to display them in proper ordering
-    else
-      # Fetching next page
-      # we're retrieving one extra item to check if we have more items after fetched page
-      @works = @collection.limit(PAGE_SIZE + 1).to_a
-      have_more_items = @works.size == PAGE_SIZE + 1
-      @works = @works[0..-2] if have_more_items # removing extra item
-    end
-
-    @search_after_for_next = search_after_for_item(@works.last, false) if have_more_items
-    @search_after_for_previous = search_after_for_item(@works.first, true) if @page > 1
-  end
-
-  def search_after_for_item(work, reverse)
-    {
-      value: work.send(SearchManifestations::SORTING_PROPERTIES[@sort_by][:column]),
-      manifestation_id: work.id,
-      page: reverse ? @page - 1 : @page + 1,
-      reverse: reverse.to_s
-    }
+    @works = paginate(@collection)
   end
 
   def prep_ab(whole, subset, fieldname)
     ret = []
-    abc_present = whole.pluck(fieldname).map{|t| t.nil? || t.empty? ? '' : t[0] }.uniq.sort
+    abc_present = whole.pluck(fieldname).map { |t| t.blank? ? '' : t[0] }.uniq.sort
     dummy = subset[0] # bizarrely, unless we force this query, the pluck below returns *a wrong set* (off by one page or so)
-    abc_active = subset.pluck(fieldname).map{|t| t.nil? || t.empty? ? '' : t[0] }.uniq.sort
+    abc_active = subset.pluck(fieldname).map { |t| t.blank? ? '' : t[0] }.uniq.sort
     LETTERS.each do |l|
       status = ''
       unless abc_present.include?(l)

--- a/app/views/authors/_browse_filters.html.haml
+++ b/app/views/authors/_browse_filters.html.haml
@@ -204,8 +204,10 @@
 
 
     = hidden_field_tag(:emit_filters, 'true', id: 'emit_filters')
-    = hidden_field_tag(:cur_page, @page, id: 'cur_page_tag')
-    = hidden_field_tag(:page, '', id: 'page_tag')
+    = hidden_field_tag(:search_after_value, '')
+    = hidden_field_tag(:search_after_id, '')
+    = hidden_field_tag(:page, '1')
+    = hidden_field_tag(:reverse, 'false')
     = hidden_field_tag(:to_letter, '', id: 'toletter_tag')
 
 :javascript

--- a/app/views/authors/_browse_list.html.haml
+++ b/app/views/authors/_browse_list.html.haml
@@ -17,7 +17,7 @@
         = f
         %span.pointer.tag-x{'data-ele': id, 'data-which' => which}= '-'
 .by-card-content-v02
-  = render partial: 'shared/pagination'
+  = render partial: 'shared/pagination', locals: { add_js: false }
   .select-all-with-buttons
     .headline-4-v02= t(:sort_by)
     #sort-by
@@ -49,7 +49,7 @@
           = link_to au.sort_name.presence || '_', person_path(au.id)
           .authors-list-years= decorator.call(au)
   = hidden_field_tag(:hurl, request.original_url)
-  = render partial: 'shared/pagination'
+  = render partial: 'shared/pagination', locals: { add_js: true }
 :javascript
   /**
    * Handle Animation (Start, Reset, Restart)

--- a/app/views/authors/_browse_list.html.haml
+++ b/app/views/authors/_browse_list.html.haml
@@ -17,10 +17,7 @@
         = f
         %span.pointer.tag-x{'data-ele': id, 'data-which' => which}= '-'
 .by-card-content-v02
-  - unless @total_pages <= 1
-    = render partial: 'shared/slide_pagination', locals: {collection: @authors, element: '#authors_filters', path: '/authors'}
-    -# if @sort[0..11] == 'alphabetical'
-    -#  = render partial: 'ab_pagination', locals: {filter_element: 'authors_filters'}
+  = render partial: 'shared/pagination'
   .select-all-with-buttons
     .headline-4-v02= t(:sort_by)
     #sort-by
@@ -45,19 +42,14 @@
           .btn-text-v02#current_sort_text
 
   .mainlist#browse_mainlist
-    - pg = @page.to_i
-    %ol{style:"counter-reset:li #{pg > 1 ? (pg-1)*100 : 0}"}
+    %ol{ style: "counter-reset:li #{@page > 1 ? (@page - 1) * AuthorsController::PAGE_SIZE : 0}" }
       - decorator = authorlist_decorator_by_sort_type(@sort)
       - @authors.each do |au|
         %li
-          = link_to au.sort_name, person_path(au.id)
+          = link_to au.sort_name.presence || '_', person_path(au.id)
           .authors-list-years= decorator.call(au)
-  - unless @total_pages <= 1
-    = render partial: 'shared/slide_pagination', locals: {collection: @authors, element: '#authors_filters', path: '/authors'}
-    -# if @sort[0..11] == 'alphabetical'
-    -#  = render partial: 'ab_pagination', locals: {filter_element: 'authors_filters'}
   = hidden_field_tag(:hurl, request.original_url)
-
+  = render partial: 'shared/pagination'
 :javascript
   /**
    * Handle Animation (Start, Reset, Restart)
@@ -73,50 +65,38 @@
     });
   }
   $(document).ready(function() {
-    // Instantiate a slider
-    var mySlider = $("input.slider").bootstrapSlider({
-      tooltip: 'always',
-    });
-    var url = $('#hurl').val().replace(/page=\d+/, '');
-    if(url.indexOf('?') == -1) {
-      url = url + '?'
-    }
-    $("input.slider").on('slideStop', function(slideEvt){
-      slideEvt.stopImmediatePropagation();
-      filters = #{@emit_filters == true};
-      if(filters) {
-        $('#page_tag').val(slideEvt.value.toString());
-        window.history.pushState($('#works_filters').serialize(), null, '/works');
-        submit_author_filters();
-      } else {
-        window.history.pushState($('#works_filters').serialize(), null, '/works');
-        $.get(url+'&page='+slideEvt.value.toString(),'',null, 'script');
+    $('.tag-x').click(function() {
+      const prefix = (window.innerWidth < mobileWidth) ? '#mobile_filters ' : '#works_filters ';
+      const field = $(this).data('ele');
+
+      if (field == 'to_letter') {
+        const filters = #{@emit_filters == true};
+        if(filters) {
+          submit_author_filters();
+        } else {
+          const url = urlWithoutPaging();
+          url.searchParams.delete('to_letter');
+          window.history.pushState($(prefix).serialize(), null, '/authors');
+          $.get(url.href, '', null, 'script');
+        }
+        return;
       }
-    });
-    $('.tag-x').click(function(){
+
       // uncheck/clear the appropriate field
-      prefix = '';
-      if(window.innerWidth < mobileWidth) {
-        prefix = '#mobile_filters ';
-      } else {
-        prefix = '#works_filters ';
-      }
       if($(this).attr('data-which') == 'text') {
         $(prefix + '#'+$(this).attr('data-ele')).val('');
       } else {
         $(prefix + '#'+$(this).attr('data-ele')).prop("checked", false);
       }
       // and submit the form
-      $('#page_tag').val('1'); // reset pagination
       $('input').attr('disabled', false); // re-enable checkboxes to preserve other filters
       window.history.pushState($(prefix).serialize(), null, '/authors');
       submit_author_filters();
-      });
+    });
 
     $('#sort_by_dd').change(function(){
       $('input[name=sort_by]').val($('#sort_by_dd option:selected').val());
       if($('#authors_filters').length > 0) {
-        $('#page_tag').val('1'); // reset pagination
         window.history.pushState($('#authors_filters').serialize(), null, '/authors');
         submit_author_filters();
       } else {

--- a/app/views/authors/_browse_top.html.haml
+++ b/app/views/authors/_browse_top.html.haml
@@ -11,6 +11,7 @@
             -#%a.help{:href => "#"} [?]
             .toggle-background-no
               .toggle-button-no
+              .toggle-button-yes{ style: "display:#{@filters.empty? ? 'none' : 'show'}" }
           .author-page-top-sort-mobile
             %button.btn-small-outline-v02.btn-text-v02{:href => "#"} סינון
         .author-page-top-icons-desktop

--- a/app/views/manifestation/_browse_filters.html.haml
+++ b/app/views/manifestation/_browse_filters.html.haml
@@ -233,7 +233,7 @@
 
     = hidden_field_tag(:emit_filters, 'true', id: 'emit_filters')
     = hidden_field_tag(:search_after_value, '')
-    = hidden_field_tag(:search_after_manifestation_id, '')
+    = hidden_field_tag(:search_after_id, '')
     = hidden_field_tag(:page, '1')
     = hidden_field_tag(:reverse, 'false')
     = hidden_field_tag(:to_letter, '', id: 'toletter_tag')

--- a/app/views/manifestation/_browse_list.html.haml
+++ b/app/views/manifestation/_browse_list.html.haml
@@ -17,7 +17,7 @@
         = f
         %span.pointer.tag-x{'data-ele': id, 'data-which' => which}= '-'
 .by-card-content-v02
-  = render partial: 'shared/pagination'
+  = render partial: 'shared/pagination', locals: { add_js: false }
   %hr
   .select-all-with-buttons
     .select-text-checkbox-area
@@ -58,7 +58,7 @@
           = link_to m.title_and_authors, manifestation_path(m.id)
           = decorator.call(m)
   = hidden_field_tag(:hurl, request.original_url)
-  = render partial: 'shared/pagination'
+  = render partial: 'shared/pagination', locals: { add_js: true }
 :javascript
   /**
    * Handle Animation (Start, Reset, Restart)

--- a/app/views/manifestation/_browse_list.html.haml
+++ b/app/views/manifestation/_browse_list.html.haml
@@ -17,7 +17,7 @@
         = f
         %span.pointer.tag-x{'data-ele': id, 'data-which' => which}= '-'
 .by-card-content-v02
-  = render partial: 'pagination'
+  = render partial: 'shared/pagination'
   %hr
   .select-all-with-buttons
     .select-text-checkbox-area
@@ -58,7 +58,7 @@
           = link_to m.title_and_authors, manifestation_path(m.id)
           = decorator.call(m)
   = hidden_field_tag(:hurl, request.original_url)
-  = render partial: 'pagination'
+  = render partial: 'shared/pagination'
 :javascript
   /**
    * Handle Animation (Start, Reset, Restart)
@@ -72,15 +72,6 @@
     targetElement.css('animation','');
     targetElement.off();
     });
-  }
-
-  function urlWithoutPaging() {
-    const urlObject = new URL($('#hurl').val());
-    urlObject.searchParams.delete('search_after_value');
-    urlObject.searchParams.delete('search_after_manifestation_id');
-    urlObject.searchParams.delete('page');
-    urlObject.searchParams.delete('reverse');
-    return urlObject;
   }
 
   $(document).ready(function() {

--- a/app/views/manifestation/_mobile_filters.html.haml
+++ b/app/views/manifestation/_mobile_filters.html.haml
@@ -7,7 +7,7 @@
   = hidden_field_tag(:date_type, '', id: 'date_type')
   = hidden_field_tag(:emit_filters, sortonly ? 'false' : 'true', id: 'emit_filters')
   = hidden_field_tag(:search_after_value, '')
-  = hidden_field_tag(:search_after_manifestation_id, '')
+  = hidden_field_tag(:search_after_id, '')
   = hidden_field_tag(:page, '1')
   = hidden_field_tag(:reverse, 'false')
   = hidden_field_tag(:to_letter, '', id: 'toletter_tag')

--- a/app/views/manifestation/_pagination.html.haml
+++ b/app/views/manifestation/_pagination.html.haml
@@ -15,7 +15,7 @@
       = t('.page_x_of_total', page: @page, total: @total_pages)
   %br
 .a-b-pagination-frame
-  - ManifestationController::LETTERS.each do |letter|
+  - LETTERS.each do |letter|
     = link_to letter,
               '',
               { class: (letter == @to_letter ? 'letterbutton active' : 'letterbutton'), data: { letter: letter } }

--- a/app/views/shared/_pagination.html.haml
+++ b/app/views/shared/_pagination.html.haml
@@ -21,6 +21,15 @@
               { class: (letter == @to_letter ? 'letterbutton active' : 'letterbutton'), data: { letter: letter } }
 
 :javascript
+  function urlWithoutPaging() {
+    const urlObject = new URL($('#hurl').val());
+    urlObject.searchParams.delete('search_after_value');
+    urlObject.searchParams.delete('search_after_id');
+    urlObject.searchParams.delete('page');
+    urlObject.searchParams.delete('reverse');
+    return urlObject;
+  }
+
   $(function() {
     $('.letterbutton').click(function(e) {
       e.stopImmediatePropagation();
@@ -30,7 +39,7 @@
       if(filters) {
         $('#toletter_tag').val(letter);
         $('#search_after_value').val('');
-        $('#search_after_manifestation_id').val('');
+        $('#search_after_id').val('');
         submit_filters();
       } else {
         const urlObject = urlWithoutPaging();
@@ -42,14 +51,14 @@
 
     $('.browse_paging').click(function() {
       const filters = #{@emit_filters == true};
-      const manifestation_id = $(this).data('search-after-manifestation-id') || '';
+      const id = $(this).data('search-after-id') || '';
       const value = $(this).data('search-after-value') || '';
       const page = $(this).data('search-after-page') || 1;
       const reverse = $(this).data('search-after-reverse') || false;
 
       if(filters) {
         $('#search_after_value').val(value);
-        $('#search_after_manifestation_id').val(manifestation_id);
+        $('#search_after_id').val(id);
         $('#page').val(page);
         $('#reverse').val(reverse);
         $('#toletter_tag').val('#{@to_letter}');
@@ -58,7 +67,7 @@
       } else {
         const urlObject = new URL($('#hurl').val());
         urlObject.searchParams.set('search_after_value', value);
-        urlObject.searchParams.set('search_after_manifestation_id', manifestation_id);
+        urlObject.searchParams.set('search_after_id', id);
         urlObject.searchParams.set('page', page);
         urlObject.searchParams.set('reverse', reverse);
         window.history.pushState($('#works_filters').serialize(), null, '/works');

--- a/app/views/shared/_pagination.html.haml
+++ b/app/views/shared/_pagination.html.haml
@@ -20,58 +20,59 @@
               '',
               { class: (letter == @to_letter ? 'letterbutton active' : 'letterbutton'), data: { letter: letter } }
 
-:javascript
-  function urlWithoutPaging() {
-    const urlObject = new URL($('#hurl').val());
-    urlObject.searchParams.delete('search_after_value');
-    urlObject.searchParams.delete('search_after_id');
-    urlObject.searchParams.delete('page');
-    urlObject.searchParams.delete('reverse');
-    return urlObject;
-  }
+- if add_js
+  :javascript
+    function urlWithoutPaging() {
+      const urlObject = new URL($('#hurl').val());
+      urlObject.searchParams.delete('search_after_value');
+      urlObject.searchParams.delete('search_after_id');
+      urlObject.searchParams.delete('page');
+      urlObject.searchParams.delete('reverse');
+      return urlObject;
+    }
 
-  $(function() {
-    $('.letterbutton').click(function(e) {
-      e.stopImmediatePropagation();
-      e.preventDefault();
-      const filters = #{@emit_filters == true};
-      const letter = $(this).data('letter');
-      if(filters) {
-        $('#toletter_tag').val(letter);
-        $('#search_after_value').val('');
-        $('#search_after_id').val('');
-        submit_filters();
-      } else {
-        const urlObject = urlWithoutPaging();
-        urlObject.searchParams.set('to_letter', letter);
-        window.history.pushState($('#works_filters').serialize(), null, '/works');
-        $.get(urlObject.href, '', null, 'script');
-      }
+    $(function() {
+      $('.letterbutton').click(function(e) {
+        e.stopImmediatePropagation();
+        e.preventDefault();
+        const filters = #{@emit_filters == true};
+        const letter = $(this).data('letter');
+        if(filters) {
+          $('#toletter_tag').val(letter);
+          $('#search_after_value').val('');
+          $('#search_after_id').val('');
+          submit_filters();
+        } else {
+          const urlObject = urlWithoutPaging();
+          urlObject.searchParams.set('to_letter', letter);
+          window.history.pushState($('#works_filters').serialize(), null, '/works');
+          $.get(urlObject.href, '', null, 'script');
+        }
+      });
+
+      $('.browse_paging').click(function() {
+        const filters = #{@emit_filters == true};
+        const id = $(this).data('search-after-id') || '';
+        const value = $(this).data('search-after-value') || '';
+        const page = $(this).data('search-after-page') || 1;
+        const reverse = $(this).data('search-after-reverse') || false;
+
+        if(filters) {
+          $('#search_after_value').val(value);
+          $('#search_after_id').val(id);
+          $('#page').val(page);
+          $('#reverse').val(reverse);
+          $('#toletter_tag').val('#{@to_letter}');
+          window.history.pushState($('#works_filters').serialize(), null, '/works');
+          submit_filters();
+        } else {
+          const urlObject = new URL($('#hurl').val());
+          urlObject.searchParams.set('search_after_value', value);
+          urlObject.searchParams.set('search_after_id', id);
+          urlObject.searchParams.set('page', page);
+          urlObject.searchParams.set('reverse', reverse);
+          window.history.pushState($('#works_filters').serialize(), null, '/works');
+          $.get(urlObject.href, '', null, 'script');
+        }
+      });
     });
-
-    $('.browse_paging').click(function() {
-      const filters = #{@emit_filters == true};
-      const id = $(this).data('search-after-id') || '';
-      const value = $(this).data('search-after-value') || '';
-      const page = $(this).data('search-after-page') || 1;
-      const reverse = $(this).data('search-after-reverse') || false;
-
-      if(filters) {
-        $('#search_after_value').val(value);
-        $('#search_after_id').val(id);
-        $('#page').val(page);
-        $('#reverse').val(reverse);
-        $('#toletter_tag').val('#{@to_letter}');
-        window.history.pushState($('#works_filters').serialize(), null, '/works');
-        submit_filters();
-      } else {
-        const urlObject = new URL($('#hurl').val());
-        urlObject.searchParams.set('search_after_value', value);
-        urlObject.searchParams.set('search_after_id', id);
-        urlObject.searchParams.set('page', page);
-        urlObject.searchParams.set('reverse', reverse);
-        window.history.pushState($('#works_filters').serialize(), null, '/works');
-        $.get(urlObject.href, '', null, 'script');
-      }
-    });
-  });

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,4 +1,5 @@
 en:
+  name_starts_with_x: "Name starts with: '%{x}'"
   title_starts_with_x: "Title starts with: '%{x}'"
   shared:
     pagination:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,5 +1,11 @@
 en:
   title_starts_with_x: "Title starts with: '%{x}'"
+  shared:
+    pagination:
+      page_x_of_total: Page %{page} of %{total}
+      next_page: Next page
+      previous_page: Previous page
+      first_page: First page
   welcome:
     submit_contact:
       ziburit_failed: Control question failed
@@ -16,8 +22,3 @@ en:
       ziburit_failed: Control question failed
       email_missing: Please provide an email address
   manifestation:
-    pagination:
-      page_x_of_total: Page %{page} of %{total}
-      next_page: Next page
-      previous_page: Previous page
-      first_page: First page

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -1340,6 +1340,12 @@ he:
       - "day"
       - "month"
       - "year"
+  shared:
+    pagination:
+      page_x_of_total: דף %{page} מתוך %{total}
+      next_page: לדף הבא
+      previous_page: לדף הקודם
+      first_page: לדף הראשון
   welcome:
     submit_contact:
       ziburit_failed: לא השתכנענו שאינך רובוט.
@@ -1356,8 +1362,3 @@ he:
       ziburit_failed: לא השתכנענו שאינך רובוט.
       email_missing: נא לציין כתובת דואל, כדי שנוכל להשיב לך.
   manifestation:
-    pagination:
-      page_x_of_total: דף %{page} מתוך %{total}
-      next_page: לדף הבא
-      previous_page: לדף הקודם
-      first_page: לדף הראשון

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -657,7 +657,7 @@ he:
   title_x: "כותרת: %{x}"
   author_x: "יוצר: %{x}"
   authors_xx: "יוצרים: %{xx}"
-  name_starts_with_x: "Name starts with: '%{x}'"
+  name_starts_with_x: "שם מתחיל באות '%{x}'"
   title_starts_with_x: "כותרת מתחילה באות '%{x}'"
   title_already_exists: השם כבר קיים. נא לתת שם אחר.
   text_already_in_anthology: היצירה הנוכחית כבר מופיעה במקראה הזאת.

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -657,6 +657,7 @@ he:
   title_x: "כותרת: %{x}"
   author_x: "יוצר: %{x}"
   authors_xx: "יוצרים: %{xx}"
+  name_starts_with_x: "Name starts with: '%{x}'"
   title_starts_with_x: "כותרת מתחילה באות '%{x}'"
   title_already_exists: השם כבר קיים. נא לתת שם אחר.
   text_already_in_anthology: היצירה הנוכחית כבר מופיעה במקראה הזאת.

--- a/lib/bybe_utils.rb
+++ b/lib/bybe_utils.rb
@@ -8,6 +8,8 @@ require 'rmagick'
 
 include ActionView::Helpers::SanitizeHelper
 
+LETTERS = %w(א ב ג ד ה ו ז ח ט י כ ל מ נ ס ע פ צ ק ר ש ת).freeze
+
 # temporary constants until I figure out what changed in RDF.rb's RDF::Vocab::SKOS
 SKOS_PREFLABEL = "http://www.w3.org/2004/02/skos/core#prefLabel"
 SKOS_ALTLABEL = "http://www.w3.org/2004/02/skos/core#altLabel"

--- a/spec/controllers/authors_controller_spec.rb
+++ b/spec/controllers/authors_controller_spec.rb
@@ -1,6 +1,19 @@
 require 'rails_helper'
 
 describe AuthorsController do
+  describe '#browse' do
+    subject(:call) { get :browse }
+
+    before do
+      clean_tables
+      Chewy.strategy(:atomic) do
+        create_list(:manifestation, 20)
+      end
+    end
+
+    it { is_expected.to be_successful }
+  end
+
   describe '#get_random_author' do
     before do
       create_list(:manifestation, 5)


### PR DESCRIPTION
This PR modifies authors browse page to use search_after for pagination and adds filtering by first letter of name.

Also in this PR I've started work on unifying pagination/filtering logic between authors and works pages.
I've extracted common code into FilteringAndPaginationConcern file, to reduce code duplication. This is far from being perfect for now, but I believe it is a good first step in this direction.

NOTE: for search_after functionality I had to add id column to PeopleIndex (it is used a tie-breaker when two records has same value of sort-by field)

P.S. this PR is based on works_search_after branch and is expected to be merged into it.