### PR TITLE
Sprockets 4 and CoffeeScript removal

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -46,7 +46,6 @@ gem 'sqlite3' # for dictionary imports
 gem 'jquery-rails'
 gem "jquery-ui-rails", git: 'https://github.com/jquery-ui-rails/jquery-ui-rails' # v 7.0 has not been pushed to RubyGems yet
 gem 'activerecord-session_store'
-gem 'coffee-script'
 #gem "jquery-ui-rails", "~> 4.0.4"
 
 # To use ActiveModel has_secure_password

--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,10 @@ source 'http://rubygems.org'
 gem 'rails', '~> 6'
 gem 'rails-i18n' # , git: 'https://github.com/svenfuchs/rails-i18n.git' # , branch: 'rails-4-x' # For 4.x
 gem 'actionview'
-gem 'sprockets', '~> 3' # 4.x requires switching to a manifest.js for assets
+
+gem 'sass-rails', '~> 6.0.0'
+gem 'sprockets', '~> 4.2.1'
+
 gem 'rails-ujs'
 gem 'mysql2' # Rails 5.2 needs a newer one # , '~> 0.3.11'
 gem 'omniauth-google-oauth2'
@@ -43,7 +46,6 @@ gem 'sqlite3' # for dictionary imports
 gem 'jquery-rails'
 gem "jquery-ui-rails", git: 'https://github.com/jquery-ui-rails/jquery-ui-rails' # v 7.0 has not been pushed to RubyGems yet
 gem 'activerecord-session_store'
-gem 'sass-rails'
 gem 'coffee-script'
 #gem "jquery-ui-rails", "~> 4.0.4"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -428,16 +428,16 @@ GEM
       net-ssh (>= 2.6.5, < 8.0.0)
     net-sftp (4.0.0)
       net-ssh (>= 5.0.0, < 8.0.0)
-    net-smtp (0.4.0.1)
+    net-smtp (0.5.0)
       net-protocol
     net-ssh (7.2.1)
     netrc (0.11.0)
     newrelic_rpm (9.7.1)
     nio4r (2.7.0)
-    nokogiri (1.16.3)
+    nokogiri (1.16.4)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
-    nokogiri (1.16.3-x86_64-linux)
+    nokogiri (1.16.4-x86_64-linux)
       racc (~> 1.4)
     oauth (1.1.0)
       oauth-tty (~> 1.0, >= 1.0.1)
@@ -559,7 +559,7 @@ GEM
     rails-html-sanitizer (1.6.0)
       loofah (~> 2.21)
       nokogiri (~> 1.14)
-    rails-i18n (7.0.8)
+    rails-i18n (7.0.9)
       i18n (>= 0.7, < 2)
       railties (>= 6.0.0, < 8)
     rails-jquery-autocomplete (1.0.5)
@@ -573,7 +573,7 @@ GEM
       rake (>= 12.2)
       thor (~> 1.0)
     rainbow (3.1.1)
-    rake (13.1.0)
+    rake (13.2.1)
     rb-fsevent (0.11.2)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
@@ -702,9 +702,9 @@ GEM
     spring (4.1.3)
     spring-commands-rspec (1.0.4)
       spring (>= 0.9.1)
-    sprockets (3.7.2)
+    sprockets (4.2.1)
       concurrent-ruby (~> 1.0)
-      rack (> 1, < 3)
+      rack (>= 2.2.4, < 4)
     sprockets-rails (3.4.2)
       actionpack (>= 5.2)
       activesupport (>= 5.2)
@@ -846,12 +846,12 @@ DEPENDENCIES
   ruby-prof
   rufus-scheduler
   rvm1-capistrano3
-  sass-rails
+  sass-rails (~> 6.0.0)
   sidekiq (~> 7.2)
   simplecov
   spring
   spring-commands-rspec
-  sprockets (~> 3)
+  sprockets (~> 4.2.1)
   sqlite3
   stackprof
   turn (= 0.8.2)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -179,10 +179,6 @@ GEM
       js_regex (~> 3.7)
       rails (>= 6.1, < 7.2)
     climate_control (1.2.0)
-    coffee-script (2.4.1)
-      coffee-script-source
-      execjs
-    coffee-script-source (1.12.2)
     concurrent-ruby (1.2.3)
     connection_pool (2.4.1)
     crass (1.0.6)
@@ -773,7 +769,6 @@ DEPENDENCIES
   capistrano3-puma
   chewy
   client_side_validations
-  coffee-script
   dalli
   damerau-levenshtein
   debug

--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -1,0 +1,4 @@
+//= link_tree ../images
+//= link_tree ../fonts
+//= link application.css
+//= link application.js

--- a/app/assets/javascripts/aboutnesses.js
+++ b/app/assets/javascripts/aboutnesses.js
@@ -1,2 +1,0 @@
-// Place all the behaviors and hooks related to the matching controller here.
-// All this logic will automatically be available in application.js.

--- a/app/assets/javascripts/admin.js
+++ b/app/assets/javascripts/admin.js
@@ -1,2 +1,0 @@
-// Place all the behaviors and hooks related to the matching controller here.
-// All this logic will automatically be available in application.js.

--- a/app/assets/javascripts/anthologies.js
+++ b/app/assets/javascripts/anthologies.js
@@ -1,2 +1,0 @@
-// Place all the behaviors and hooks related to the matching controller here.
-// All this logic will automatically be available in application.js.

--- a/app/assets/javascripts/anthology_texts.js
+++ b/app/assets/javascripts/anthology_texts.js
@@ -1,2 +1,0 @@
-// Place all the behaviors and hooks related to the matching controller here.
-// All this logic will automatically be available in application.js.

--- a/app/assets/javascripts/api_keys.js.coffee
+++ b/app/assets/javascripts/api_keys.js.coffee
@@ -1,3 +1,0 @@
-# Place all the behaviors and hooks related to the matching controller here.
-# All this logic will automatically be available in application.js.
-# You can use CoffeeScript in this file: http://jashkenas.github.com/coffee-script/

--- a/app/assets/javascripts/authors.js
+++ b/app/assets/javascripts/authors.js
@@ -1,2 +1,0 @@
-// Place all the behaviors and hooks related to the matching controller here.
-// All this logic will automatically be available in application.js.

--- a/app/assets/javascripts/bib.js
+++ b/app/assets/javascripts/bib.js
@@ -1,2 +1,0 @@
-// Place all the behaviors and hooks related to the matching controller here.
-// All this logic will automatically be available in application.js.

--- a/app/assets/javascripts/bib_sources.js
+++ b/app/assets/javascripts/bib_sources.js
@@ -1,2 +1,0 @@
-// Place all the behaviors and hooks related to the matching controller here.
-// All this logic will automatically be available in application.js.

--- a/app/assets/javascripts/creations.js
+++ b/app/assets/javascripts/creations.js
@@ -1,2 +1,0 @@
-// Place all the behaviors and hooks related to the matching controller here.
-// All this logic will automatically be available in application.js.

--- a/app/assets/javascripts/crowd.js
+++ b/app/assets/javascripts/crowd.js
@@ -1,2 +1,0 @@
-// Place all the behaviors and hooks related to the matching controller here.
-// All this logic will automatically be available in application.js.

--- a/app/assets/javascripts/holdings.js
+++ b/app/assets/javascripts/holdings.js
@@ -1,2 +1,0 @@
-// Place all the behaviors and hooks related to the matching controller here.
-// All this logic will automatically be available in application.js.

--- a/app/assets/javascripts/html_dirs.js.coffee
+++ b/app/assets/javascripts/html_dirs.js.coffee
@@ -1,4 +1,0 @@
-# Place all the behaviors and hooks related to the matching controller here.
-# All this logic will automatically be available in application.js.
-# You can use CoffeeScript in this file: http://jashkenas.github.com/coffee-script/
-

--- a/app/assets/javascripts/html_file.js.coffee
+++ b/app/assets/javascripts/html_file.js.coffee
@@ -1,3 +1,0 @@
-# Place all the behaviors and hooks related to the matching controller here.
-# All this logic will automatically be available in application.js.
-# You can use CoffeeScript in this file: http://jashkenas.github.com/coffee-script/

--- a/app/assets/javascripts/manifestation.js.coffee
+++ b/app/assets/javascripts/manifestation.js.coffee
@@ -1,3 +1,0 @@
-# Place all the behaviors and hooks related to the matching controller here.
-# All this logic will automatically be available in application.js.
-# You can use CoffeeScript in this file: http://jashkenas.github.com/coffee-script/

--- a/app/assets/javascripts/news_items.js
+++ b/app/assets/javascripts/news_items.js
@@ -1,2 +1,0 @@
-// Place all the behaviors and hooks related to the matching controller here.
-// All this logic will automatically be available in application.js.

--- a/app/assets/javascripts/people.js.coffee
+++ b/app/assets/javascripts/people.js.coffee
@@ -1,3 +1,0 @@
-# Place all the behaviors and hooks related to the matching controller here.
-# All this logic will automatically be available in application.js.
-# You can use CoffeeScript in this file: http://jashkenas.github.com/coffee-script/

--- a/app/assets/javascripts/publications.js
+++ b/app/assets/javascripts/publications.js
@@ -1,2 +1,0 @@
-// Place all the behaviors and hooks related to the matching controller here.
-// All this logic will automatically be available in application.js.

--- a/app/assets/javascripts/realizers.js
+++ b/app/assets/javascripts/realizers.js
@@ -1,2 +1,0 @@
-// Place all the behaviors and hooks related to the matching controller here.
-// All this logic will automatically be available in application.js.

--- a/app/assets/javascripts/recommendations.js
+++ b/app/assets/javascripts/recommendations.js
@@ -1,2 +1,0 @@
-// Place all the behaviors and hooks related to the matching controller here.
-// All this logic will automatically be available in application.js.

--- a/app/assets/javascripts/search.js
+++ b/app/assets/javascripts/search.js
@@ -1,2 +1,0 @@
-// Place all the behaviors and hooks related to the matching controller here.
-// All this logic will automatically be available in application.js.

--- a/app/assets/javascripts/session.js.coffee
+++ b/app/assets/javascripts/session.js.coffee
@@ -1,3 +1,0 @@
-# Place all the behaviors and hooks related to the matching controller here.
-# All this logic will automatically be available in application.js.
-# You can use CoffeeScript in this file: http://jashkenas.github.com/coffee-script/

--- a/app/assets/javascripts/static_pages.js
+++ b/app/assets/javascripts/static_pages.js
@@ -1,2 +1,0 @@
-// Place all the behaviors and hooks related to the matching controller here.
-// All this logic will automatically be available in application.js.

--- a/app/assets/javascripts/taggings.js
+++ b/app/assets/javascripts/taggings.js
@@ -1,2 +1,0 @@
-// Place all the behaviors and hooks related to the matching controller here.
-// All this logic will automatically be available in application.js.

--- a/app/assets/javascripts/user.js.coffee
+++ b/app/assets/javascripts/user.js.coffee
@@ -1,3 +1,0 @@
-# Place all the behaviors and hooks related to the matching controller here.
-# All this logic will automatically be available in application.js.
-# You can use CoffeeScript in this file: http://jashkenas.github.com/coffee-script/

--- a/app/assets/javascripts/welcome.js
+++ b/app/assets/javascripts/welcome.js
@@ -1,0 +1,4 @@
+function is_clamped(elid) {
+  const el = document.getElementById(elid);
+  return el.scrollHeight > (el.clientHeight + 5);
+}

--- a/app/assets/javascripts/welcome.js.coffee
+++ b/app/assets/javascripts/welcome.js.coffee
@@ -1,8 +1,0 @@
-# Place all the behaviors and hooks related to the matching controller here.
-# All this logic will automatically be available in application.js.
-# You can use CoffeeScript in this file: http://jashkenas.github.com/coffee-script/
-
-@is_clamped = (elid) ->
-  el = document.getElementById(elid);
-  el.scrollHeight > (el.clientHeight + 5)
-

--- a/app/assets/stylesheets/aboutnesses.scss
+++ b/app/assets/stylesheets/aboutnesses.scss
@@ -1,3 +1,0 @@
-// Place all the styles related to the Aboutnesses controller here.
-// They will automatically be included in application.css.
-// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/assets/stylesheets/admin.scss
+++ b/app/assets/stylesheets/admin.scss
@@ -1,3 +1,0 @@
-// Place all the styles related to the Admin controller here.
-// They will automatically be included in application.css.
-// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/assets/stylesheets/anthologies.scss
+++ b/app/assets/stylesheets/anthologies.scss
@@ -1,3 +1,0 @@
-// Place all the styles related to the Anthologies controller here.
-// They will automatically be included in application.css.
-// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/assets/stylesheets/anthology_texts.scss
+++ b/app/assets/stylesheets/anthology_texts.scss
@@ -1,3 +1,0 @@
-// Place all the styles related to the AnthologyTexts controller here.
-// They will automatically be included in application.css.
-// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/assets/stylesheets/api_keys.css.scss
+++ b/app/assets/stylesheets/api_keys.css.scss
@@ -1,3 +1,0 @@
-// Place all the styles related to the ApiKeys controller here.
-// They will automatically be included in application.css.
-// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/assets/stylesheets/bib_sources.scss
+++ b/app/assets/stylesheets/bib_sources.scss
@@ -1,3 +1,0 @@
-// Place all the styles related to the bib_sources controller here.
-// They will automatically be included in application.css.
-// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/assets/stylesheets/creations.scss
+++ b/app/assets/stylesheets/creations.scss
@@ -1,3 +1,0 @@
-// Place all the styles related to the Creations controller here.
-// They will automatically be included in application.css.
-// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/assets/stylesheets/holdings.scss
+++ b/app/assets/stylesheets/holdings.scss
@@ -1,3 +1,0 @@
-// Place all the styles related to the Holdings controller here.
-// They will automatically be included in application.css.
-// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/assets/stylesheets/html_dirs.css.scss
+++ b/app/assets/stylesheets/html_dirs.css.scss
@@ -1,3 +1,0 @@
-// Place all the styles related to the HtmlDirs controller here.
-// They will automatically be included in application.css.
-// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/assets/stylesheets/news_items.scss
+++ b/app/assets/stylesheets/news_items.scss
@@ -1,3 +1,0 @@
-// Place all the styles related to the NewsItems controller here.
-// They will automatically be included in application.css.
-// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/assets/stylesheets/publications.scss
+++ b/app/assets/stylesheets/publications.scss
@@ -1,3 +1,0 @@
-// Place all the styles related to the Publications controller here.
-// They will automatically be included in application.css.
-// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/assets/stylesheets/realizers.scss
+++ b/app/assets/stylesheets/realizers.scss
@@ -1,3 +1,0 @@
-// Place all the styles related to the realizers controller here.
-// They will automatically be included in application.css.
-// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/assets/stylesheets/recommendations.scss
+++ b/app/assets/stylesheets/recommendations.scss
@@ -1,3 +1,0 @@
-// Place all the styles related to the Recommendations controller here.
-// They will automatically be included in application.css.
-// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/assets/stylesheets/search.scss
+++ b/app/assets/stylesheets/search.scss
@@ -1,3 +1,0 @@
-// Place all the styles related to the search controller here.
-// They will automatically be included in application.css.
-// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/assets/stylesheets/session.css.scss
+++ b/app/assets/stylesheets/session.css.scss
@@ -1,3 +1,0 @@
-// Place all the styles related to the SessionController controller here.
-// They will automatically be included in application.css.
-// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/assets/stylesheets/static_pages.scss
+++ b/app/assets/stylesheets/static_pages.scss
@@ -1,3 +1,0 @@
-// Place all the styles related to the StaticPages controller here.
-// They will automatically be included in application.css.
-// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/assets/stylesheets/taggings.scss
+++ b/app/assets/stylesheets/taggings.scss
@@ -1,3 +1,0 @@
-// Place all the styles related to the Taggings controller here.
-// They will automatically be included in application.css.
-// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/assets/stylesheets/user.css.scss
+++ b/app/assets/stylesheets/user.css.scss
@@ -1,3 +1,0 @@
-// Place all the styles related to the User controller here.
-// They will automatically be included in application.css.
-// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/assets/stylesheets/user_blocks.scss
+++ b/app/assets/stylesheets/user_blocks.scss
@@ -1,3 +1,0 @@
-// Place all the styles related to the UserBlocks controller here.
-// They will automatically be included in application.css.
-// You can use Sass (SCSS) here: https://sass-lang.com/

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -5,8 +5,3 @@ Rails.application.config.assets.version = '1.0'
 
 # Add additional assets to the asset load path.
 # Rails.application.config.assets.paths << Emoji.images_path
-
-# Precompile additional assets.
-# application.js, application.css, and all non-JS/CSS in the app/assets
-# folder are already added.
-# Rails.application.config.assets.precompile += %w( admin.js admin.css )


### PR DESCRIPTION
This PR updates application to use sprockets 4. This version uses manifest.js, so I've added one with same settings as was used in with sprockets 3.

Also I've removed number of empty js and css files created by rails generators.

Upd: Also I've removed coffee-script dependency from project. There were only one coffee function in whole project, so I've reimplemented it in js.

NOTE: you may need to run `rake tmp:cache:clear` if rails will argue about missing coffee-script gem (it happens due to stale sprocket's cache)