### PR TITLE
Fix autocomplete by person name in works browse filter

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -13,6 +13,8 @@ require:
 
 Metrics/BlockLength:
   Max: 100
+  Exclude:
+    - 'config/routes.rb'
 
 Metrics/ClassLength:
   Max: 1000

--- a/app/views/manifestation/_browse_filters.html.haml
+++ b/app/views/manifestation/_browse_filters.html.haml
@@ -16,7 +16,7 @@
                        id: :search_input,
                        class: %w(field-v02 field-without-label),
                        placeholder: t(:what_to_search_for)
-      = autocomplete_field_tag :authorstr, @authorstr, autocomplete_person_name_path,
+      = autocomplete_field_tag :authorstr, @authorstr, manifestation_autocomplete_person_name_path,
                                id_element: '#author_id',
                                'data-noMatchesLabel' => t(:no_matches_found),
                                style: 'display:none',

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -200,6 +200,8 @@ Bybeconv::Application.routes.draw do
   get 'manifestation/unlike'
   get 'manifestation/surprise_work'
   get 'manifestation/autocomplete_works_by_author'
+  get 'manifestation/autocomplete_person_name' => 'manifestation#autocomplete_person_name',
+      as: 'manifestation_autocomplete_person_name'
   get 'work/show/:id' => 'manifestation#workshow', as: 'work_show' # temporary, until we have a works controller
   get 'manifestation/add_aboutnesses/:id' => 'manifestation#add_aboutnesses'
   resources :api_keys, except: :show


### PR DESCRIPTION
Autocomplete field by person name in works#browse action used endpoint from admin controller which is restricted to editors only.
The reason is that `autocomplete_person_name_path` url helper is declared in this way (points to AdminController).

There were public-available autocomplete endpoint declared in manifestation controller, but it was not mapped in routes file.

Modified it to use endpoint declared in manifestation controller snd added route for it