### PR TITLE
Intellectual property enum for Person

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -149,7 +149,6 @@ group :test, :development do
   gem 'rspec-rails', '~> 5.0.2'
   gem 'spring'
   gem 'spring-commands-rspec'
-  gem 'debug'
 end
 
 gem "sidekiq", "~> 7.2"

--- a/Gemfile
+++ b/Gemfile
@@ -149,6 +149,7 @@ group :test, :development do
   gem 'rspec-rails', '~> 5.0.2'
   gem 'spring'
   gem 'spring-commands-rspec'
+  gem 'debug'
 end
 
 gem "sidekiq", "~> 7.2"

--- a/app/api/v1/entities/person.rb
+++ b/app/api/v1/entities/person.rb
@@ -11,9 +11,7 @@ module V1
         expose :birth_year, documentation: { type: 'Integer' }
         expose :death_year, documentation: { type: 'Integer' }
         expose :gender, documentation: { values: ::Person.genders.keys }
-        expose :copyright_status, documentation: { type: 'Boolean' } do |person|
-          !person.public_domain?
-        end
+        expose :intellectual_property, documentation: { values: ::Person.intellectual_properties.keys }
         expose :period, documentation: { values: ::Person.periods.keys }
         expose :other_designation, as: :other_designations,
                documentation: { desc: 'semicolon-separated list of additional names or spellings for this person' }

--- a/app/chewy/manifestations_index.rb
+++ b/app/chewy/manifestations_index.rb
@@ -1,6 +1,6 @@
 class ManifestationsIndex < Chewy::Index
   # works
-  index_scope Manifestation.all_published.with_involved_authorities
+  index_scope Manifestation.all_published.with_involved_authorities.preload(taggings: :tag)
 #    field :title, analyzer: 'hebrew' # from https://github.com/synhershko/elasticsearch-analysis-hebrew
 #    field :fulltext, value: ->(manifestation) {manifestation.to_plaintext}, analyzer: 'hebrew'
   field :id, type: 'integer'

--- a/app/chewy/manifestations_index.rb
+++ b/app/chewy/manifestations_index.rb
@@ -1,6 +1,6 @@
 class ManifestationsIndex < Chewy::Index
   # works
-  index_scope Manifestation.all_published.includes(expression: :work)
+  index_scope Manifestation.all_published.with_involved_authorities
 #    field :title, analyzer: 'hebrew' # from https://github.com/synhershko/elasticsearch-analysis-hebrew
 #    field :fulltext, value: ->(manifestation) {manifestation.to_plaintext}, analyzer: 'hebrew'
   field :id, type: 'integer'

--- a/app/chewy/people_index.rb
+++ b/app/chewy/people_index.rb
@@ -13,7 +13,7 @@ class PeopleIndex < Chewy::Index
   field :impressions_count, type: 'integer'
   field :language, value: ->(person) { person.all_languages}, type: 'keyword'
   field :genre, value: ->(person) { person.all_genres }, type: 'keyword'
-  field :copyright_status, value: ->(person) {person.public_domain ? false : true}, type: 'boolean' # TODO: make non boolean
+  field :intellectual_property, type: 'keyword'
   field :pby_publication_date, type: 'date', value: ->(person){person.published_at}
   #field :pby_publication_date, type: 'integer', value: ->(person){ person.works.count == 0 ? nil : person.works.order('created_at').first.created_at.year}
   field :birth_year, type: 'integer', value: ->(person){ person.birth_year == '?' ? nil : person.birth_year.to_i}

--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -285,6 +285,7 @@ class AdminController < ApplicationController
 
   def incongruous_copyright
     @incong = Manifestation.joins(expression: :work)
+                           .with_involved_authorities
                            .select('expressions.id as expression_id, expressions.intellectual_property')
                            .select('manifestations.title, manifestations.id as id')
                            .select(Arel.sql("#{HAS_NON_PUBLIC_DOMAIN_AUTHORITY} as has_non_pd_authority"))

--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -77,7 +77,7 @@ class AdminController < ApplicationController
   end
 
   def missing_copyright
-    @authors = Person.where(public_domain: nil)
+    @authors = Person.intellectual_property_unknown
     records = Manifestation.joins(:expression).merge(Expression.intellectual_property_unknown)
     @total = records.count
     @mans = records.page(params[:page]).per(50)

--- a/app/helpers/admin_helper.rb
+++ b/app/helpers/admin_helper.rb
@@ -1,2 +1,9 @@
 module AdminHelper
+  INTELLECTUAL_PROPERTIES_ID_TO_TEXT = Expression.intellectual_properties.to_h do |code, id|
+    [id, I18n.t(code, scope: 'intellectual_property')]
+  end
+
+  def textify_intellectual_property_id(id)
+    INTELLECTUAL_PROPERTIES_ID_TO_TEXT[id]
+  end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -65,11 +65,6 @@ module ApplicationHelper
     t(value, scope: 'intellectual_property')
   end
 
-  # TODO: remove
-  def textify_copyright_status(copyrighted)
-    copyrighted ? t(:by_permission) : t(:public_domain)
-  end
-
   def textify_boolean(bool)
     bool ? t(:yes) : t(:no)
   end
@@ -164,7 +159,7 @@ module ApplicationHelper
     case intellectual_property
     when 'public_domain'
       return 'm'
-    when 'copyrighted', 'by_permission'
+    when 'copyrighted', 'by_permission', 'permission_for_all', 'permission_for_selected'
       return 'x'
     end
   end

--- a/app/models/expression.rb
+++ b/app/models/expression.rb
@@ -23,11 +23,11 @@ class Expression < ApplicationRecord
   validates :intellectual_property, presence: true
 
   def editors
-    return realizers.includes(:person).where(role: Realizer.roles[:editor]).map{|x| x.person}
+    realizers.to_a.select(&:editor?).map(&:person)
   end
 
   def translators
-    return realizers.includes(:person).where(role: Realizer.roles[:translator]).map {|x| x.person}
+    realizers.to_a.select(&:translator?).map(&:person)
   end
 
   def self.cached_translations_count

--- a/app/models/manifestation.rb
+++ b/app/models/manifestation.rb
@@ -33,6 +33,7 @@ class Manifestation < ApplicationRecord
   scope :translations, -> { joins(:expression).includes(:expression).where(expressions: {translation: true})}
   scope :genre, -> (genre) { joins(expression: :work).where(works: {genre: genre})}
   scope :tagged_with, ->(tag_id) {joins(:taggings).where(taggings: {tag_id: tag_id, status: Tagging.statuses[:approved]}).distinct}
+  scope :with_involved_authorities, -> { preload(expression: { realizers: :person, work: { creations: :person } }) }
 
   SHORT_LENGTH = 1500 # kind of arbitrary...
   LONG_LENGTH = 15000 # kind of arbitrary...

--- a/app/models/manifestation.rb
+++ b/app/models/manifestation.rb
@@ -98,12 +98,7 @@ class Manifestation < ApplicationRecord
   end
 
   def approved_tags
-    # tags.joins(:taggings).where(taggings: {status: Tagging.statuses[:approved], taggable: self})
-    approved_taggings.joins(:tag).where(tag: {status: Tag.statuses[:approved]} ).map{|x| x.tag}
-  end
-  
-  def approved_taggings
-    taggings.where(status: Tagging.statuses[:approved])
+    taggings.to_a.select { |t| t.approved? && t.tag.approved? }.map(&:tag)
   end
 
   def as_prose?

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -30,8 +30,6 @@ class Person < ApplicationRecord
     unknown: 100
   }, _prefix: true
 
-  validates :intellectual_property, presence: true
-
   # scopes
   scope :has_toc, -> { where.not(toc_id: nil) }
   scope :no_toc, -> { where(toc_id: nil) }
@@ -53,7 +51,8 @@ class Person < ApplicationRecord
   include CompactedImpressions
 
   # validations
-  validates :name, presence: true
+  validates :name, :intellectual_property, presence: true
+
   validates_attachment_content_type :profile_image, content_type: /\Aimage\/.*\z/
 
   update_index('people'){self} # update PeopleIndex when entity is updated

--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -18,11 +18,11 @@ class Work < ApplicationRecord
   # has_and_belongs_to_many :people # superseded by creations and persons above
 
   def authors
-    return creations.author.includes(:person).map(&:person)
+    return creations.to_a.select(&:author?).map(&:person)
   end
 
   def illustrators
-    return creations.illustrator.includes(:person).map(&:person)
+    return creations.to_a.select(&:illustrator?).map(&:person)
   end
 
   def first_author

--- a/app/views/admin/incongruous_copyright.html.haml
+++ b/app/views/admin/incongruous_copyright.html.haml
@@ -1,18 +1,18 @@
 .backend
-  %h2= t(:incongruous_copyright_report)
+  %h2= t('.title')
   %h3= t(:total_manifestations, total: @incong.length)
   %table{style: 'cell-spacing: 10;'}
     %tr
       %th= t(:title)
       %th= t(:author)
-      %th= t(:calculated_copyright)
-      %th= t(:db_copyright)
+      %th= t('.columns.has_non_public_domain_authority')
+      %th= t('.columns.db_intellectual_property')
       %th
 
-    - @incong.each do |m, title, author, calculated, db|
+    - @incong.each do |m|
       %tr
-        %td= link_to title, manifestation_show_path(m.id)
-        %td= author
-        %td= calculated ? t(:no) : t(:yes)
-        %td= db == true ? t(:no) : (db.nil? ? t(:unknown) : t(:yes))
+        %td= link_to m.title, manifestation_show_path(m.id)
+        %td= m.author_string
+        %td= m.has_non_pd_authority? ? t(:yes) : t(:no)
+        %td= textify_intellectual_property_id(m.intellectual_property)
         %td= link_to t(:edit_metadata), manifestation_edit_metadata_path(m.id)

--- a/app/views/admin/index.html.haml
+++ b/app/views/admin/index.html.haml
@@ -119,9 +119,9 @@
         = ' ('+Rails.cache.read('report_similar_titles').to_s+')'
       %p
         = link_to admin_incongruous_copyright_path do
-          = t(:incongruous_copyright_report)+' '
-          %b= t(:takes_long_time)
-        = ' ('+Rails.cache.read('report_incongruous_copyright').to_s+')'
+          = t('admin.incongruous_copyright.title')
+          %b= t('.takes_long_time')
+        (#{Rails.cache.read('report_incongruous_copyright')})
       %p
         = link_to t(:missing_images), admin_missing_images_path
         = ' ('+Rails.cache.read('report_missing_images').to_s+')'

--- a/app/views/authors/_author_top.html.haml
+++ b/app/views/authors/_author_top.html.haml
@@ -9,7 +9,7 @@
       .author-top-second-line
         .author-page-top-rights
           = render partial: 'shared/intellectual_property',
-                   locals: { intellectual_property: @author.public_domain ? :public_domain : :by_permission }
+                   locals: { intellectual_property: @author.intellectual_property }
         .author-sort-area
           .author-page-top-sort-desktop.notyet
             = t(:sort_and_filter)

--- a/app/views/authors/_browse_filters.html.haml
+++ b/app/views/authors/_browse_filters.html.haml
@@ -20,15 +20,17 @@
                        selected_values: @genders,
                        facet: @gender_facet }
 
+    - labels = Person.intellectual_properties.keys.index_with { |key| textify_intellectual_property(key) }
+    - icons = Person.intellectual_properties.keys.index_with { |key| intellectual_property_glyph(key) }
     = render partial: 'shared/filters/checkbox_group',
-             locals: { group_name: :copyright,
-                       title: t(:copyright_status),
-                       field_name: :ckb_copyright,
-                       all_values: [0, 1],
-                       labels: { 0 => t(:public_domain), 1 => t(:by_permission) },
-                       selected_values: @copyright,
-                       facet: @copyright_facet,
-                       icons: { 0 => 'm', 1 => 'x' } }
+             locals: { group_name: :intellectual_property,
+                       title: Person.human_attribute_name(:intellectual_property),
+                       field_name: :ckb_intellectual_property,
+                       all_values: Person.intellectual_properties.keys,
+                       labels: labels,
+                       selected_values: @intellectual_property_types,
+                       facet: @intellectual_property_facet,
+                       icons: icons }
 
     = render partial: 'shared/filters/checkbox_group',
              locals: { group_name: :genre,

--- a/app/views/authors/_form.html.haml
+++ b/app/views/authors/_form.html.haml
@@ -36,7 +36,7 @@
   .backend-field
     = f.label Person.human_attribute_name(:intellectual_property)
     - options = Person.intellectual_properties.keys.map { |ip| [textify_intellectual_property(ip), ip] }
-    = f.select :intellectual_property, options_for_select(options, @author.intellectual_property)
+    = f.select :intellectual_property, options_for_select(options, person.intellectual_property)
   .backend-field
     = f.label t(:bib_done)
     %br

--- a/app/views/authors/_form.html.haml
+++ b/app/views/authors/_form.html.haml
@@ -34,12 +34,9 @@
     = f.label t(:unknown)
 
   .backend-field
-    = f.label t(:copyright_status)
-    %br
-    = f.radio_button(:public_domain, true, checked: person.public_domain && (not person.public_domain.nil?))
-    = f.label t(:public_domain)
-    = f.radio_button(:public_domain, false, checked: (not person.public_domain) && (not person.public_domain.nil?))
-    = f.label t(:by_permission)
+    = f.label Person.human_attribute_name(:intellectual_property)
+    - options = Person.intellectual_properties.keys.map { |ip| [textify_intellectual_property(ip), ip] }
+    = f.select :intellectual_property, options_for_select(options, @author.intellectual_property)
   .backend-field
     = f.label t(:bib_done)
     %br

--- a/app/views/authors/show.html.haml
+++ b/app/views/authors/show.html.haml
@@ -33,14 +33,17 @@
         != @author.life_years
         = '('+t(:x_years_ago, years: @author.died_years_ago)+')'
         %br
-        %b= t(:copyright_status)
-        - if @author.public_domain.nil?
-          %span{style: 'color:red'}= t(:unknown)
-        - else
-          - if @author.public_domain
-            %span{style: 'color:green'}= t(:public_domain)
-          - else
-            %span{style: (@author.died_years_ago > 70 ? 'color:red' : 'color:green')}= t(:by_permission)
+        %b= Person.human_attribute_name(:intellectual_property)
+        :ruby
+          color = case @author.intellectual_property
+          when 'unknown'
+            'red'
+          when 'permission_for_all', 'permission_for_selected', 'copyrighted'
+            @author.died_years_ago > 70 ? 'red' : 'green'
+          else
+            'green'
+          end
+        %span{ style: "color:#{color};" }= textify_intellectual_property(@author.intellectual_property)
         %br
         %b= t(:gender)
         = t(@author.gender.nil? ? :unknown : @author.gender)

--- a/app/views/shared/_author_popup.html.haml
+++ b/app/views/shared/_author_popup.html.haml
@@ -29,9 +29,8 @@
                 .metadata
                   %span
                     %a.by-icon-v02{id: "heart_#{author.id}", style:'float:right'}= 5
-                  %span.by-icon-v02.copyright-icon= author.rights_icon
-                  = author.copyright_as_string
-                  %span.help{ 'data-toggle' => 'tooltip', title: author.public_domain? ? t(:pd_explain): t(:permission_explain)}= '[?]'
+                  = render partial: 'shared/intellectual_property',
+                           locals: { intellectual_property: author.intellectual_property }
                 %div
                   - unless author.wikipedia_snippet.nil? or author.wikipedia_snippet.length < 10
                     = author.wikipedia_snippet

--- a/app/views/shared/_intellectual_property.html.haml
+++ b/app/views/shared/_intellectual_property.html.haml
@@ -1,6 +1,7 @@
-%span.by-icon-v02= intellectual_property_glyph(intellectual_property)
+%span.by-icon-v02.copyright-icon= intellectual_property_glyph(intellectual_property)
 = textify_intellectual_property(intellectual_property)
 = link_to '[?]', '#',
           class: :help,
+          onclick: 'return false;',
           data: { toggle: :popover, trigger: :focus, content: t(".popover.#{intellectual_property}") },
           title: t(".about.#{intellectual_property}")

--- a/app/views/shared/_surprise_author.html.haml
+++ b/app/views/shared/_surprise_author.html.haml
@@ -15,9 +15,8 @@
         .metadata
           %span.by-icon-v02
             = favorite_glyph(author.favorite_of_user)
-          %span.by-icon-v02= author.rights_icon
-          = textify_copyright_status(! author.public_domain)
-          %span.help{ 'data-toggle' => 'tooltip', title: author.public_domain? ? t(:pd_explain): t(:permission_explain)}= '[?]'
+          = render partial: 'shared/intellectual_property',
+                   locals: { intellectual_property: author.intellectual_property }
 
         - unless author.wikipedia_snippet.nil?
           .surprise-text-container

--- a/config/locales/active_record.en.yml
+++ b/config/locales/active_record.en.yml
@@ -3,3 +3,5 @@ en:
     attributes:
       expression:
         intellectual_property: Type of intellectual property
+      person:
+        intellectual_property: Type of intellectual property

--- a/config/locales/active_record.he.yml
+++ b/config/locales/active_record.he.yml
@@ -3,3 +3,5 @@ he:
     attributes:
       expression:
         intellectual_property: מצב זכויות יוצרים
+      person:
+        intellectual_property: מצב זכויות יוצרים

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -21,12 +21,16 @@ en:
         by_permission: what does it means 'by permission'?
         copyrighted: what does it means 'copyrighted'?
         orphan: what does it means 'orphan'?
+        permission_for_all: what does it means 'permission for all'?
+        permission_for_selected: what does it means 'permission for selected'?
         unknown: what does it means 'unknown'?
       popover:
         public_domain: Copyright Law protects against unauthorized use of works for the duration of its validity (in Israel, seventy years from the end of the year of the creator's death). With the expiry of the rights, the creation becomes 'public domain', that is, the property of the public. This means that the work belongs to all of us, and we are all entitled to make any use of it, including commercial use, without the need to ask permission of anyone.
         by_permission: Although the work is still copyrighted, the Ben־Yehuda Project has received *explicit permission to publish* The work in the Ben־Yehuda Project database, for the general public to read and research. Other uses (such as play, composition, or commercial performance) still *require express approval* from the rights holders.
         copyrighted: TBD description for 'copyrighted'
         orphan: TBD description for 'orphan'
+        permission_for_all: TBD description for 'permission_for_all'
+        permission_for_selected: TBD description for 'permission_for_selected'
         unknown: TBD description for 'unknown'
   welcome:
     submit_contact:
@@ -49,4 +53,6 @@ en:
     by_permission: by permission
     copyrighted: copyrighted
     orphan: orphan
+    permission_for_all: permission for all
+    permission_for_selected: permission for selected
     unknown: unknown

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,6 +1,14 @@
 en:
   name_starts_with_x: "Name starts with: '%{x}'"
   title_starts_with_x: "Title starts with: '%{x}'"
+  admin:
+    index:
+      takes_long_time: Takes long time
+    incongruous_copyright:
+      title: Probably incongruous copyright report
+      columns:
+        db_intellectual_property: Intellectual property in DB
+        has_non_public_domain_authority: Has non public domain authority
   shared:
     filters:
       pagination:

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -1353,12 +1353,16 @@ he:
         by_permission: מה פירוש ברשות פרסום?
         copyrighted: מה פירוש הזכויות בתוקף?
         orphan: מה פירוש יצירות יתומות?
+        permission_for_all: what does it means 'permission for all'?
+        permission_for_selected: what does it means 'permission for selected'?
         unknown: מה פירוש מצב הזכויות אינו ידוע?
       popover:
         public_domain: חוק זכויות יוצרים מגן מפני שימוש בלתי-מורשה ביצירות למשך תקופת תוקפו (בישראל, שבעים שנה מסוף שנת מות היוצר).  עם פקוע הזכויות, הופכת היצירה 'נחלת הכלל', כלומר רכוש הציבור.  פירוש הדבר שהיצירה שייכת לכולנו, וכולנו רשאים לעשות בה כל שימוש, לרבות שימוש מסחרי, מבלי צורך לבקש רשות מאיש.
         by_permission: על אף שהיצירה עדיין מוגנת בזכויות יוצרים, פרויקט בן־יהודה קיבל *רשות מפורשת לפרסם* את היצירה במאגר היצירה של פרויקט בן־יהודה, לשימוש הקהל הרחב לקריאה ומחקר.  שימושים אחרים (כגון המחזה, הלחנה, או ביצוע מסחרי) עדיין *טעונים אישור מפורש* מאת בעלי הזכויות.
         copyrighted: זכויות היוצרים עודן בתוקף, ואין רשות להנגיש את החומר או לעשות בו כל שימוש שלא הותר במפורש, למעט שימוש הוגן כהגדרתו בחוק זכויות יוצרים.
         orphan: זכויות היוצרים עודן בתוקף, אלא שזהות המחזיקים בזכויות אינה ידועה, או שאין דרך ליצור עמם קשר, ולכן מותר להנגיש את היצירות בתנאים המוגדרים בסעיף יצירות יתומות בחוק זכויות יוצרים.
+        permission_for_all: TBD description for 'permission_for_all'
+        permission_for_selected: TBD description for 'permission_for_selected'
         unknown: "על אף כל המאמצים, לא ניתן לקבוע מה מצב זכויות היוצרים, בדרך כלל בשל מידע חסר לגבי זהות או מועד פטירת המחבר[ים] או המתרגם[ים]."
   welcome:
     submit_contact:
@@ -1381,12 +1385,10 @@ he:
     by_permission: מוגש ברשות פרסום
     copyrighted: מוגן בזכויות
     orphan: יצירות יתומות
+    permission_for_all: permission for all
+    permission_for_selected: permission for selected
     unknown: לא ידוע
 
-# This block of strings below should be removed when we finish work. Grouped them together to make it easier to find them again
-  copyright_status: מצב זכויות יוצרים
+  # This block of strings below should be removed when we finish work. Grouped them together to make it easier to find them again
   public_domain: נחלת הכלל
-  by_permission: מוגש ברשות פרסום
-  pd_explain: פגו זכויות היוצרים על יצירות אלו
-  permission_explain: התקבלה רשות מפורשת מבעלי הזכויות לפרסום היצירות
 

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -1335,8 +1335,8 @@ he:
     incongruous_copyright:
       title: דו\"ח יצירות במצב זכויות יוצרים שגוי (כנראה)
       columns:
-        db_intellectual_property: קנין הציבור במערכת?
-        has_non_public_domain_authority: Has non public domain authority
+        db_intellectual_property: מצב זכויות יוצרים במערכת
+        has_non_public_domain_authority: זכויות הישות טרם פקעו
   shared:
     filters:
       pagination:
@@ -1357,16 +1357,16 @@ he:
         by_permission: מה פירוש ברשות פרסום?
         copyrighted: מה פירוש הזכויות בתוקף?
         orphan: מה פירוש יצירות יתומות?
-        permission_for_all: what does it means 'permission for all'?
-        permission_for_selected: what does it means 'permission for selected'?
+        permission_for_all: רשות גורפת לכלל היצירות
+        permission_for_selected: רשות לכותרים מסוימים בלבד
         unknown: מה פירוש מצב הזכויות אינו ידוע?
       popover:
         public_domain: חוק זכויות יוצרים מגן מפני שימוש בלתי-מורשה ביצירות למשך תקופת תוקפו (בישראל, שבעים שנה מסוף שנת מות היוצר).  עם פקוע הזכויות, הופכת היצירה 'נחלת הכלל', כלומר רכוש הציבור.  פירוש הדבר שהיצירה שייכת לכולנו, וכולנו רשאים לעשות בה כל שימוש, לרבות שימוש מסחרי, מבלי צורך לבקש רשות מאיש.
         by_permission: על אף שהיצירה עדיין מוגנת בזכויות יוצרים, פרויקט בן־יהודה קיבל *רשות מפורשת לפרסם* את היצירה במאגר היצירה של פרויקט בן־יהודה, לשימוש הקהל הרחב לקריאה ומחקר.  שימושים אחרים (כגון המחזה, הלחנה, או ביצוע מסחרי) עדיין *טעונים אישור מפורש* מאת בעלי הזכויות.
         copyrighted: זכויות היוצרים עודן בתוקף, ואין רשות להנגיש את החומר או לעשות בו כל שימוש שלא הותר במפורש, למעט שימוש הוגן כהגדרתו בחוק זכויות יוצרים.
         orphan: זכויות היוצרים עודן בתוקף, אלא שזהות המחזיקים בזכויות אינה ידועה, או שאין דרך ליצור עמם קשר, ולכן מותר להנגיש את היצירות בתנאים המוגדרים בסעיף יצירות יתומות בחוק זכויות יוצרים.
-        permission_for_all: TBD description for 'permission_for_all'
-        permission_for_selected: TBD description for 'permission_for_selected'
+        permission_for_all: ניתנה רשות גורפת להנגיש את כל החיבורים והתרגומים
+        permission_for_selected: ניתנה רשות פרטנית לכותרים מסוימים בלבד. את שאר הכתבים אסור להנגיש לפני פקיעת הזכויות.
         unknown: "על אף כל המאמצים, לא ניתן לקבוע מה מצב זכויות היוצרים, בדרך כלל בשל מידע חסר לגבי זהות או מועד פטירת המחבר[ים] או המתרגם[ים]."
   welcome:
     submit_contact:
@@ -1389,8 +1389,8 @@ he:
     by_permission: מוגש ברשות פרסום
     copyrighted: מוגן בזכויות
     orphan: יצירות יתומות
-    permission_for_all: permission for all
-    permission_for_selected: permission for selected
+    permission_for_all: מוגש ברשות גורפת
+    permission_for_selected: מוגש ברשות לכותר פרטני
     unknown: לא ידוע
 
 

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -1243,10 +1243,6 @@ he:
   missing_xlat: תרגומים שאינם מוזכרים
   missing_language_report: "דו\"ח יצירות מתורגמות ללא ציון שפת מקור"
   missing_genre_report: "דו\"ח יצירות ללא סוגה"
-  incongruous_copyright_report: "דו\"ח יצירות במצב זכויות יוצרים שגוי (כנראה)"
-  takes_long_time: דורש זמן רב!
-  calculated_copyright: לכאורה קנין הציבור?
-  db_copyright: קנין הציבור במערכת?
   volunteer_profiles: פרופילי מתנדבים
   feature_on: להציג בתאריכים
   featured_content_heading: ניהול תכני מערכת
@@ -1333,6 +1329,14 @@ he:
       - "day"
       - "month"
       - "year"
+  admin:
+    index:
+      takes_long_time: דורש זמן רב!
+    incongruous_copyright:
+      title: דו\"ח יצירות במצב זכויות יוצרים שגוי (כנראה)
+      columns:
+        db_intellectual_property: קנין הציבור במערכת?
+        has_non_public_domain_authority: Has non public domain authority
   shared:
     filters:
       pagination:
@@ -1388,6 +1392,7 @@ he:
     permission_for_all: permission for all
     permission_for_selected: permission for selected
     unknown: לא ידוע
+
 
   # This block of strings below should be removed when we finish work. Grouped them together to make it easier to find them again
   public_domain: נחלת הכלל

--- a/db/migrate/20240426134401_change_people_copyright.rb
+++ b/db/migrate/20240426134401_change_people_copyright.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class ChangePeopleCopyright < ActiveRecord::Migration[6.1]
+  def change
+    add_column :people, :intellectual_property, :integer
+
+    # setting all non-public-domain authors to 'permission_for_selected'
+    execute <<~sql
+      update people set intellectual_property = case public_domain when 0 then 5 when 1 then 0 else 100 end 
+    sql
+
+    change_column_null :people, :intellectual_property, false
+    remove_column :people, :public_domain
+
+    add_index :people, :intellectual_property
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_04_24_145657) do
+ActiveRecord::Schema.define(version: 2024_04_26_134401) do
 
   create_table "aboutnesses", id: :integer, charset: "utf8mb4", collation: "utf8mb4_bin", force: :cascade do |t|
     t.integer "work_id"
@@ -263,7 +263,7 @@ ActiveRecord::Schema.define(version: 2024_04_24_145657) do
 
   create_table "corporate_bodies", charset: "utf8mb4", collation: "utf8mb4_bin", force: :cascade do |t|
     t.string "name"
-    t.string "alternate_names", limit: 5000
+    t.string "alternate_names"
     t.string "location"
     t.string "inception"
     t.integer "inception_year"
@@ -274,17 +274,7 @@ ActiveRecord::Schema.define(version: 2024_04_24_145657) do
     t.text "comments"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.string "sort_name"
-    t.string "country"
-    t.string "nli_id"
-    t.string "wikipedia_url", limit: 800
-    t.text "wikipedia_snippet"
-    t.boolean "public_domain"
-    t.boolean "bib_done"
-    t.integer "status"
-    t.datetime "published_at"
     t.index ["name"], name: "index_corporate_bodies_on_name"
-    t.index ["sort_name"], name: "index_corporate_bodies_on_sort_name"
   end
 
   create_table "creations", id: :integer, charset: "utf8mb4", collation: "utf8mb4_bin", force: :cascade do |t|
@@ -767,7 +757,6 @@ ActiveRecord::Schema.define(version: 2024_04_24_145657) do
     t.string "viaf_id"
     t.string "nli_id"
     t.integer "toc_id"
-    t.boolean "public_domain"
     t.text "wikipedia_snippet", size: :medium
     t.string "wikipedia_url", limit: 1024
     t.string "image_url", limit: 1024
@@ -792,8 +781,10 @@ ActiveRecord::Schema.define(version: 2024_04_24_145657) do
     t.integer "status"
     t.datetime "published_at"
     t.integer "root_collection_id"
+    t.integer "intellectual_property", null: false
     t.index ["gender"], name: "gender_index"
     t.index ["impressions_count"], name: "index_people_on_impressions_count"
+    t.index ["intellectual_property"], name: "index_people_on_intellectual_property"
     t.index ["name"], name: "index_people_on_name"
     t.index ["period"], name: "index_people_on_period"
     t.index ["root_collection_id"], name: "index_people_on_root_collection_id"

--- a/spec/api/v1/people_api_spec.rb
+++ b/spec/api/v1/people_api_spec.rb
@@ -93,7 +93,7 @@ describe V1::PeopleAPI do
     expect(metadata['birth_year']).to eq(person.birth_year)
     expect(metadata['death_year']).to eq(person.death_year)
     expect(metadata['gender']).to eq(person.gender)
-    expect(metadata['copyright_status']).to eq(!person.public_domain?)
+    expect(metadata['intellectual_property']).to eq(person.intellectual_property)
     expect(metadata['period']).to eq(person.period)
 
     if %w(texts enriched).include?(detail)

--- a/spec/controllers/admin_controller_spec.rb
+++ b/spec/controllers/admin_controller_spec.rb
@@ -56,7 +56,7 @@ describe AdminController do
   describe '#incongruous_copyright' do
     include_context 'Admin user logged in'
     subject(:request) { get :incongruous_copyright }
-    let(:copyrighted_person) { create(:person, public_domain: false) }
+    let(:copyrighted_person) { create(:person, intellectual_property: :permission_for_selected) }
 
     let!(:public_domain_manifestation) do
       create(:manifestation, intellectual_property: :public_domain)

--- a/spec/controllers/admin_controller_spec.rb
+++ b/spec/controllers/admin_controller_spec.rb
@@ -56,41 +56,89 @@ describe AdminController do
   describe '#incongruous_copyright' do
     include_context 'Admin user logged in'
     subject(:request) { get :incongruous_copyright }
-    let(:copyrighted_person) { create(:person, intellectual_property: :permission_for_selected) }
+    let(:copyrighted_person) { create(:person, intellectual_property: :copyrighted) }
+    let(:by_permission_person) { create(:person, intellectual_property: :permission_for_selected) }
+    let(:public_domain_person) { create(:person, intellectual_property: :public_domain) }
 
-    let!(:public_domain_manifestation) do
-      create(:manifestation, intellectual_property: :public_domain)
+    let!(:public_domain) do
+      create(
+        :manifestation,
+        orig_lang: 'he',
+        intellectual_property: :public_domain,
+        author: public_domain_person
+      )
     end
-    let!(:by_permission_manifestation) do
-      create(:manifestation, author: copyrighted_person, intellectual_property: :by_permission)
+
+    let!(:public_domain_translated) do
+      create(
+        :manifestation,
+        orig_lang: 'ru',
+        intellectual_property: :public_domain,
+        translator: public_domain_person,
+        author: public_domain_person
+      )
     end
-    let!(:wrong_public_domain_manifestation_1) do
-      create(:manifestation, author: copyrighted_person, intellectual_property: :public_domain)
+
+    let!(:by_permission_translated) do
+      create(
+        :manifestation,
+        orig_lang: 'ru',
+        intellectual_property: :by_permission,
+        translator: by_permission_person,
+        author: public_domain_person
+      )
     end
-    let!(:wrong_public_domain_manifestation_2) do
-      create(:manifestation, orig_lang: 'ru', translator: copyrighted_person, intellectual_property: :public_domain)
+
+    let!(:wrong_public_domain) do
+      create(
+        :manifestation,
+        orig_lang: 'he',
+        intellectual_property: :public_domain,
+        author: copyrighted_person
+      )
     end
-    let!(:wrong_by_permission_manifestation) do
-      create(:manifestation, intellectual_property: :by_permission)
+
+    let!(:wrong_public_domain_translated) do
+      create(
+        :manifestation,
+        orig_lang: 'de',
+        intellectual_property: :public_domain,
+        author: public_domain_person,
+        translator: by_permission_person
+      )
     end
-    let!(:wrong_copyrighted_manifestation) do
-      create(:manifestation, orig_lang: 'ru', intellectual_property: :copyrighted)
+
+    let!(:wrong_by_permission) do
+      create(
+        :manifestation,
+        orig_lang: 'he',
+        intellectual_property: :by_permission,
+        author: public_domain_person
+      )
+    end
+
+    let!(:wrong_copyrighted_translated) do
+      create(
+        :manifestation,
+        orig_lang: 'de',
+        intellectual_property: :copyrighted,
+        author: public_domain_person,
+        translator: public_domain_person
+      )
     end
 
     let(:wrong_manifestation_ids) do
       [
-        wrong_public_domain_manifestation_1.id,
-        wrong_public_domain_manifestation_2.id,
-        wrong_by_permission_manifestation.id,
-        wrong_copyrighted_manifestation.id
+        wrong_public_domain.id,
+        wrong_public_domain_translated.id,
+        wrong_by_permission.id,
+        wrong_copyrighted_translated.id
       ]
     end
 
     it 'renders successfully' do
-      # TODO: re-enable
-      skip 'Not sure how to fix'
       expect(request).to be_successful
-      expect(assigns(:incong).map(&:first).map(&:id)).to match_array wrong_manifestation_ids
+      expect(assigns(:incong).map(&:id)).to match_array wrong_manifestation_ids
     end
   end
 

--- a/spec/factories/persons.rb
+++ b/spec/factories/persons.rb
@@ -7,6 +7,6 @@ FactoryBot.define do
     other_designation { Faker::Name.name_with_middle }
     wikipedia_snippet { Faker::Quotes::Shakespeare.hamlet_quote }
     impressions_count { Random.rand(200) }
-    public_domain { true }
+    intellectual_property { :public_domain }
   end
 end

--- a/spec/factories/taggings.rb
+++ b/spec/factories/taggings.rb
@@ -1,8 +1,10 @@
+# frozen_string_literal: true
+
 FactoryBot.define do
   factory :tagging do
     status { :pending }
-    suggester { create(:user)}
-    tag { create(:tag)}
-    taggable { create(:manifestation)}
+    suggester { create(:user) }
+    tag { create(:tag) }
+    taggable { create(:manifestation) }
   end
 end

--- a/spec/factories/tags.rb
+++ b/spec/factories/tags.rb
@@ -1,9 +1,12 @@
+# frozen_string_literal: true
+
 FactoryBot.define do
   factory :tag do
     status { :approved }
     name { Faker::Lorem.unique.word }
-    creator { create(:user)}
+    creator { create(:user) }
   end
+
   trait :pending do
     status { :pending }
   end

--- a/spec/models/manifestation_spec.rb
+++ b/spec/models/manifestation_spec.rb
@@ -81,6 +81,7 @@ describe Manifestation do
       let(:manifestation) { create(:manifestation, author: author_1) }
       before do
         create(:creation, work: manifestation.expression.work, role: :author, person: author_2)
+        manifestation.reload
       end
       it { is_expected.to eq 'Alpha, Beta' }
     end
@@ -104,6 +105,7 @@ describe Manifestation do
       let(:manifestation) { create(:manifestation, orig_lang: 'de', translator: translator_1) }
       before do
         create(:realizer, expression: manifestation.expression, role: :translator, person: translator_2)
+        manifestation.reload
       end
       it { is_expected.to eq 'Alpha, Beta' }
     end
@@ -113,6 +115,7 @@ describe Manifestation do
 
       before do
         manifestation.expression.realizers.delete_all
+        manifestation.reload
       end
 
       it { is_expected.to eq I18n.t(:nil) }
@@ -127,6 +130,7 @@ describe Manifestation do
 
     before do
       create(:creation, work: manifestation.expression.work, role: :author, person: author_2)
+      manifestation.reload
     end
 
     context 'when work is not a translation' do
@@ -139,6 +143,7 @@ describe Manifestation do
       context 'when no authors present' do
         before do
           manifestation.expression.work.creations.delete_all
+          manifestation.reload
         end
 
         it { is_expected.to eq I18n.t(:nil) }
@@ -153,6 +158,7 @@ describe Manifestation do
 
       before do
         create(:realizer, expression: manifestation.expression, role: :translator, person: translator_2)
+        manifestation.reload
       end
 
       context 'when both authors and transaltors are present' do
@@ -162,6 +168,7 @@ describe Manifestation do
       context 'when no authors present' do
         before do
           manifestation.expression.work.creations.delete_all
+          manifestation.reload
         end
 
         it { is_expected.to eq I18n.t(:nil) }
@@ -170,6 +177,7 @@ describe Manifestation do
       context 'when no translators present' do
         before do
           manifestation.expression.realizers.delete_all
+          manifestation.reload
         end
 
         it { is_expected.to eq 'Alpha, Beta / ' + I18n.t(:unknown) }

--- a/spec/models/manifestation_spec.rb
+++ b/spec/models/manifestation_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 describe Manifestation do
@@ -203,5 +205,19 @@ describe Manifestation do
         expect(string.include?(I18n.t(:translated_from))).to be_truthy
       end
     end
+  end
+
+  describe '.approved_tags' do
+    subject { manifestation.approved_tags }
+
+    let(:manifestation) { create(:manifestation) }
+    let(:approved_tag) { create(:tag, status: :approved) }
+    let(:pending_tag) { create(:tag, status: :pending) }
+
+    let!(:approved_approved_tagging) { create(:tagging, tag: approved_tag, taggable: manifestation, status: :approved) }
+    let!(:approved_pending_tagging) { create(:tagging, tag: pending_tag, taggable: manifestation, status: :approved) }
+    let!(:pending_approved_tagging) { create(:tagging, tag: approved_tag, taggable: manifestation, status: :pending) }
+
+    it { is_expected.to contain_exactly(approved_tag) }
   end
 end

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -3,12 +3,12 @@ require 'rails_helper'
 describe Person do
   describe 'validations' do
     it 'considers empty Person invalid' do
-      p = Person.new
+      p = described_class.new
       expect(p).to_not be_valid
     end
 
-    it 'considers Person with only name as valid' do
-      p = Person.new(name: Faker::Artist.name)
+    it 'considers Person with all mandatory fields filled as valid' do
+      p = described_class.new(name: Faker::Artist.name, intellectual_property: :public_domain)
       expect(p).to be_valid
     end
   end

--- a/spec/models/tagging_spec.rb
+++ b/spec/models/tagging_spec.rb
@@ -1,4 +1,7 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
+
 describe Tagging do
   it "considers invalid an empty tagging" do
     t = Tagging.new
@@ -86,33 +89,17 @@ describe Tagging do
     expect(m2.tags.count).to eq 5
     expect(m2.taggings.count).to eq 5
   end
-  it 'gets only approved tags for manifestation via taggings' do
-    m = create(:manifestation)
-    5.times do
-      Tagging.create!(tag: build(:tag), suggester: create(:user), status: 'approved', taggable: m)
+
+  describe '.destroy' do
+    subject(:destroy) { tagging.destroy }
+
+    let!(:tagging) { create(:tagging) }
+
+    it 'deletes tagging but not tag or manifestation' do
+      expect { destroy }.to change(described_class, :count).by(-1)
+                                                           .and not_change(Tag, :count)
+                                                           .and not_change(Manifestation, :count)
     end
-    3.times do
-      Tagging.create!(tag: build(:tag), suggester: create(:user), status: 'pending', taggable: m)
-    end
-    expect(m.tags.count).to eq 8
-    expect(m.approved_tags.count).to eq 5
-    3.times do
-      Tagging.create!(tag: build(:tag), suggester: create(:user), status: 'approved', taggable: build(:manifestation))
-    end
-    m2 = Manifestation.find(m.id)
-    expect(m2.tags.count).to eq 8
-    expect(m2.approved_tags.count).to eq 5
-    expect(m2.taggings.count).to eq 8
-    expect(m2.approved_taggings.count).to eq 5
   end
 
-  it 'deletes tagging but not tag or manifestation' do
-    tag = Tag.create!(name: Faker::Science.science, creator: create(:user), status: 'approved')
-    m = create(:manifestation)
-    tagging = Tagging.create!(tag: tag, taggable: m, suggester: create(:user), status: 'pending')
-    tagging.destroy
-    expect(Tagging.count).to eq 0
-    expect(Tag.count).to eq 1
-    expect(Manifestation.count).to eq 1
-  end
 end

--- a/spec/support/negated_matchers.rb
+++ b/spec/support/negated_matchers.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+RSpec::Matchers.define_negated_matcher :not_change, :change


### PR DESCRIPTION
Updated person model and people table: replaced public_domain column with intellectual_property enum.

Fixed incongruous copyright report.

Also this PR contains changes to speedup ManifestationIdex rebuilding: I've added preloading of all involved persons and tags, and modified methods used to fetch authors/translators etc to be able to use preloaded data.

It allowed to reduce chewy:reset time for ManifestationIndex on my machine from 23 minutes to 11 minutes.

I propose to use 'Rebase and merge' policy for this PR to keep those changes separated in commit history.