### PR TITLE
Hide 'copyrighted' value in filters

### DIFF
--- a/app/api/v1/api.rb
+++ b/app/api/v1/api.rb
@@ -10,5 +10,5 @@ class V1::Api < V1::ApplicationApi
   mount V1::TextsAPI => '/'
   mount V1::PeopleAPI => '/'
 
-  add_swagger_documentation info: { title: 'Project Ben-Yehuda public API' }, doc_version: '1.1.0'
+  add_swagger_documentation info: { title: 'Project Ben-Yehuda public API' }, doc_version: '1.2.0'
 end

--- a/app/api/v1/texts_api.rb
+++ b/app/api/v1/texts_api.rb
@@ -106,7 +106,7 @@ class V1::TextsAPI < V1::ApplicationApi
                desc: 'specifies what section of the rough timeline of Hebrew literature an object belongs to.'
       optional :intellectual_property_types,
                type: [String],
-               values: Expression.intellectual_properties.keys,
+               values: Expression::PUBLIC_INTELLECTUAL_PROPERTY_TYPES,
                desc: 'limit search to works with selected intellectual property types'
       optional :author_genders, type: [String], values: Person.genders.keys
       optional :translator_genders, type: [String], values: Person.genders.keys

--- a/app/models/expression.rb
+++ b/app/models/expression.rb
@@ -20,6 +20,9 @@ class Expression < ApplicationRecord
     unknown: 100
   }, _prefix: true
 
+  # In browse works filters and API we should not show copyrighted works
+  PUBLIC_INTELLECTUAL_PROPERTY_TYPES = intellectual_properties.keys - ['copyrighted']
+
   validates :intellectual_property, presence: true
 
   def editors

--- a/app/views/manifestation/_browse_filters.html.haml
+++ b/app/views/manifestation/_browse_filters.html.haml
@@ -53,7 +53,7 @@
              locals: { group_name: :intellectual_property,
                        title: Expression.human_attribute_name(:intellectual_property),
                        field_name: :ckb_intellectual_property,
-                       all_values: Expression.intellectual_properties.keys,
+                       all_values: Expression::PUBLIC_INTELLECTUAL_PROPERTY_TYPES,
                        labels: labels,
                        selected_values: @intellectual_property_types,
                        facet: @intellectual_property_facet,


### PR DESCRIPTION
All 'copyrighted' works should not be available to public anyway (not published) so it has no sense in showing such values in public available filters.

Removed it from works browse page filter and from texts::search API endpoint.

Also bumped API version to 1.2.0 (this version indicates intellectual_property refactoring-related changes)