### PR TITLE
Refactor Person methods

### DIFF
--- a/app/controllers/authors_controller.rb
+++ b/app/controllers/authors_controller.rb
@@ -353,6 +353,23 @@ class AuthorsController < ApplicationController
     end
   end
 
+  def show
+    @author = Person.find(params[:id])
+    @published_works = @author.original_works.count
+    @published_xlats = @author.translations.count
+    @total_orig_works = @author.manifestations(:author).count
+    @total_xlats = @author.manifestations(:translator).count
+    @aboutnesses = @author.aboutnesses
+
+    if @author.nil?
+      flash[:error] = t(:no_such_item)
+      redirect_to '/'
+    else
+      # TODO: add other types of content
+      @page_title = "#{t(:author_details)}: #{@author.name}"
+    end
+  end
+
   def new
     @person = Person.new(intellectual_property: :unknown)
     @page_title = t(:new_author)
@@ -381,7 +398,7 @@ class AuthorsController < ApplicationController
 
   def destroy
     @author = Person.find(params[:id])
-    Chewy.strategy(:atomic) {
+    Chewy.strategy(:atomic) do
       if @author.nil?
         flash[:error] = t(:no_such_item)
         redirect_to '/'
@@ -389,23 +406,6 @@ class AuthorsController < ApplicationController
         @author.destroy!
         redirect_to action: :list
       end
-    }
-  end
-
-  def show
-    @author = Person.find(params[:id])
-    @published_works = @author.original_works.count
-    @published_xlats = @author.translations.count
-    @total_orig_works = @author.original_work_count_including_unpublished
-    @total_xlats = @author.translations_count_including_unpublished
-    @aboutnesses = @author.aboutnesses
-
-    if @author.nil?
-      flash[:error] = t(:no_such_item)
-      redirect_to '/'
-    else
-      # TODO: add other types of content
-      @page_title = t(:author_details)+': '+@author.name
     end
   end
 

--- a/app/models/concerns/record_with_involved_authorities.rb
+++ b/app/models/concerns/record_with_involved_authorities.rb
@@ -4,6 +4,10 @@
 module RecordWithInvolvedAuthorities
   extend ActiveSupport::Concern
 
+  # Returns list of authorities involved into given object with the given role.
+  # Note: some roles can be specified both on Work and Expression level and this method will fetch only part of them.
+  # If you need a full list use {#Manifestation.involved_authorities_by_role}
+  # @param role [String/Symbol] role code
   def involved_authorities_by_role(role)
     role = role.to_s
     raise "Unknown role #{role}" unless InvolvedAuthority.roles.keys.include?(role)


### PR DESCRIPTION
As a followup to comments in https://github.com/abartov/bybeconv/pull/345#discussion_r1601018191

Updated method Person.published_manifestations, to accept several roles to filter.
Added method Person.manifestations with optional roles array as an argument to return all manifestations (including unpublished).

Updated several methods in Person to consider work as 'original' work only when person is listed as an author (previously it worked for any work-level involvements, e.g. illustrators) using `published_manifestations` and `manifestations` methods.

