### PR TITLE
Added session cleanup if we have user with non-existant ID

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -347,6 +347,9 @@ class ApplicationController < ActionController::Base
 
   def current_user
     @current_user ||= User.find(session[:user_id]) if session[:user_id]
+  rescue ActiveRecord::RecordNotFound
+    # Should only happen in development environment
+    session.delete(:user_id)
   end
 
   def html_entities_coder


### PR DESCRIPTION
I believe we never delete users records in production, but this situation happened to me in dev environment. So I've added handling to it, to avoid crashes.