### PR TITLE
Authors bugfixes

### DIFF
--- a/app/controllers/authors_controller.rb
+++ b/app/controllers/authors_controller.rb
@@ -92,9 +92,9 @@ class AuthorsController < ApplicationController
     when 'uploaded'
       return 'pby_publication_date'
     when 'birth'
-      return 'birth_year'
+      return 'person.birth_year'
     when 'death'
-      return 'death_year'
+      return 'person.death_year'
     end
   end
 
@@ -104,14 +104,14 @@ class AuthorsController < ApplicationController
     # periods
     @periods = params['ckb_periods'] if params['ckb_periods'].present?
     if @periods.present?
-      ret << {terms: {period: @periods}}
-      @filters += @periods.map{|x| [I18n.t(x), "period_#{x}", :checkbox]}
+      ret << { terms: { 'person.period' => @periods } }
+      @filters += @periods.map { |x| [I18n.t(x), "period_#{x}", :checkbox] }
     end
     # genders
     @genders = params['ckb_genders'] if params['ckb_genders'].present?
     if @genders.present?
-      ret << {terms: {gender: @genders}}
-      @filters += @genders.map{|x| [I18n.t(:author)+': '+I18n.t(x), "gender_#{x}", :checkbox]}
+      ret << { terms: { 'person.gender' => @genders } }
+      @filters += @genders.map { |x| ["#{I18n.t(:author)}: #{I18n.t(x)}", "gender_#{x}", :checkbox] }
     end
     # genres
     @genres = params['ckb_genres'] if params['ckb_genres'].present?

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -1109,6 +1109,7 @@ he:
   no_such_item: אין פריט כזה.
   item: פריט
   created_toc: נוצר דף יוצר עם תבנית ריקה
+  already_has_toc: Author already has TOC
   miscellaneous: שונות
   etext: ספר אלקטרוני
   url: כתובת URL

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -1109,7 +1109,7 @@ he:
   no_such_item: אין פריט כזה.
   item: פריט
   created_toc: נוצר דף יוצר עם תבנית ריקה
-  already_has_toc: Author already has TOC
+  already_has_toc: כבר קיים דף יוצר ליוצר/ת
   miscellaneous: שונות
   etext: ספר אלקטרוני
   url: כתובת URL


### PR DESCRIPTION
Fixed several bugs introduced during Authorities refactoring:
- fixed filtering by person's traits (gender, perdiod, birth and death years)
- updated authors#to_manual_toc, #create_toc and #destroy actions to work with Authorities instead of People. There are many changes in #to_manual_toc, but they should not affect logic, I did them to satisfy linters

P.S. also please see https://github.com/abartov/bybeconv/issues/373