### PR TITLE
Publish fix

### DIFF
--- a/app/controllers/authors_controller.rb
+++ b/app/controllers/authors_controller.rb
@@ -16,27 +16,22 @@ class AuthorsController < ApplicationController
   autocomplete :tag, :name, :limit => 2
 
   def publish
-    if @author
-      if params[:commit].present?
-        # POST request
-        if @author.unpublished? and (@author.all_works_including_unpublished.count > 0)
-          @author.publish!
-          Rails.cache.delete('newest_authors') # force cache refresh
-          Rails.cache.delete('homepage_authors')
-          Rails.cache.delete("au_#{@author.id}_work_count")
-          flash[:success] = t(:published)
-        else
-          @author.awaiting_first!
-          flash[:success] = t(:awaiting_first)
-        end
-        redirect_to action: :list
+    if params[:commit].present?
+      # POST request
+      if @author.unpublished? && @author.all_works_including_unpublished.count > 0
+        @author.publish!
+        Rails.cache.delete('newest_authors') # force cache refresh
+        Rails.cache.delete('homepage_authors')
+        Rails.cache.delete("au_#{@author.id}_work_count")
+        flash[:success] = t(:published)
       else
-        # GET request
-        @manifestations = @author.all_works_including_unpublished
+        @author.awaiting_first!
+        flash[:success] = t(:awaiting_first)
       end
+      redirect_to action: :list
     else
-      flash[:error] = t(:not_found)
-      redirect_to admin_index_path
+      # GET request
+      @manifestations = @author.all_works_including_unpublished
     end
   end
 

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -7,24 +7,6 @@ class Person < ApplicationRecord
   scope :with_name, -> { joins(:authority).select('people.*, authorities.name') }
 
   has_paper_trail
-
-  def publish!
-    # set all person's works to status published
-    all_works_including_unpublished.each do |m| # be cautious about publishing joint works, because the *other* author(s) or translators may yet be unpublished!
-      next if m.published?
-      can_publish = true
-      m.authors.each {|au| can_publish = false unless au.published? || au == self}
-      m.translators.each {|au| can_publish = false unless au.published? || au == self}
-      if can_publish
-        m.created_at = Time.now # pretend the works were created just now, so that they appear in whatsnew (NOTE: real creation date can be discovered through papertrail)
-        m.status = :published
-        m.save!
-      end
-    end
-    self.published_at = Time.now
-    self.status = :published
-    self.save! # finally, set this person to published
-  end
   def died_years_ago
     begin
       dy = death_year.to_i

--- a/spec/support/clean_db.rb
+++ b/spec/support/clean_db.rb
@@ -6,6 +6,7 @@ def clean_tables
 
   InvolvedAuthority.destroy_all
 
+  CorporateBody.destroy_all
   Person.destroy_all
   Authority.destroy_all
 


### PR DESCRIPTION
Fixed publish action to work with Authorities table.

I relied to existing spec for it, but it turned out it was too shallow.
In fact authors#publish can either render list of unpublished works, or do actual publishing.
I believe it would be better to split it into a two action (one for GET and one for POST request)