### PR TITLE
Render google-analytics script only in production environment

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -2,15 +2,17 @@
 <html>
 <head>
   <title><%= @page_title ? @page_title : t(:default_page_title)%></title>
-  <!-- Global site tag (gtag.js) - Google Analytics -->
-  <script async src="https://www.googletagmanager.com/gtag/js?id=UA-4865013-2"></script>
-  <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    gtag('js', new Date());
+  <% if Rails.env.production? %>
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-4865013-2"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
 
-    gtag('config', 'UA-4865013-2');
-  </script>
+      gtag('config', 'UA-4865013-2');
+    </script>
+  <% end %>
   <!-- bootstrap 4.x -->
   <link
   rel="stylesheet"


### PR DESCRIPTION
This PR disables rendering of google analytics script in development environment