### PR TITLE
Updated Search to show Authorities first

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -13,6 +13,8 @@ class SearchController < ApplicationController
         @search = ManifestationsSearch.new(query: @searchterm)
       end
       @results = @search.search.page(params[:page])
+      page = (params[:page] || 1).to_i
+      @offset = (page - 1) * Kaminari.config.default_per_page
       @total = @results.count
     rescue # Faraday::Error::ConnectionFailed => e
       @total = -1

--- a/app/lib/manifestations_search.rb
+++ b/app/lib/manifestations_search.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'multi_index_search_request'
 class ManifestationsSearch
   include ActiveData::Model
@@ -6,16 +8,16 @@ class ManifestationsSearch
   attribute :genre, type: String
   attribute :min_orig_pub_year, type: Integer
   attribute :max_orig_pub_year, type: Integer
-  attribute :tags, mode: :arrayed, type: String #, normalize: ->(value) { value.reject(&:blank?) }, default: ""
+  attribute :tags, mode: :arrayed, type: String # , normalize: ->(value) { value.reject(&:blank?) }, default: ""
 
   # This accessor is for the form. It will have a single text field
   # for comma-separated tag inputs.
-  def tag_list= value
+  def tag_list=(value)
     self.tags = value.split(',').map(&:strip)
   end
 
   def tag_list
-    self.tags.join(', ')
+    tags.join(', ')
   end
 
   def index
@@ -29,34 +31,78 @@ class ManifestationsSearch
 
   # Using query_string advanced query for the main query input
   def query_string
-    index.query(query_string: {fields: ['title^10', 'alternate_titles^5', 'defhead^7', 'aliases^4', :name, :other_designation, :author_string, :fulltext, :deftext], query: query, default_operator: 'and'}) if query?
+    return unless query?
+
+    index.query(
+      query_string: {
+        fields: [
+          'title^10',
+          'alternate_titles^5',
+          'defhead^7',
+          'aliases^4',
+          :name,
+          :other_designation,
+          :author_string,
+          :fulltext,
+          :deftext
+        ],
+        query: query,
+        default_operator: 'and'
+      }
+    ).order(
+      [
+        {
+          '_script' => {
+            type: :number,
+            # we want search results to be shown in following order: Authorities, Manifestations, Dicts
+            script: {
+              lang: :painless,
+              source: <<~SORT_SCRIPT.squish
+                def index_name = doc._index[0];
+                if (index_name.indexOf('authorities') == 0) {
+                  return 1;
+                } else if (index_name.indexOf('manifestations') == 0) {
+                  return 2;
+                } else if (index_name.indexOf('dict') == 0) {
+                  return 3;
+                } else {
+                  return 100;
+                }
+              SORT_SCRIPT
+            },
+            order: :asc
+          }
+        }
+      ]
+    )
   end
 
   # Simple term filter for genre. ignored if empty.
   def genre_filter
-    index.filter(term: {genre: genre}) if genre?
+    index.filter(term: { genre: genre }) if genre?
   end
 
   # For filtering on years, we will use range filter.
   # Returns nil if both min_year and max_year are not passed to the model.
   def orig_pub_year_filter
-    body = {}.tap do |body|
-      body.merge!(gte: min_orig_pub_year) if min_orig_pub_year?
-      body.merge!(lte: max_orig_pub_year) if max_orig_pub_year?
+    body = {}.tap do |new_body|
+      new_body.merge!(gte: min_orig_pub_year) if min_orig_pub_year?
+      new_body.merge!(lte: max_orig_pub_year) if max_orig_pub_year?
     end
-    index.filter(range: {orig_publication_date: body}) if body.present?
+    index.filter(range: { orig_publication_date: body }) if body.present?
   end
 
   # here, for aggregate, `terms` filter used.
   # Returns nil if no tags passed in.
   def tags_filter
-    index.filter(terms: {tags: tags}) if tags?
+    index.filter(terms: { tags: tags }) if tags?
   end
 
   def highlight
-    index.highlight(max_analyzed_offset: 999000, fields: {fulltext: {}, deftext: {}})
+    index.highlight(max_analyzed_offset: 999_000, fields: { fulltext: {}, deftext: {} })
   end
+
   def index_order
-    index.order(['_index' => {order: :desc}, '_score' => {order: :desc}]) # people before works, then by score
+    index.order(['_index' => { order: :desc }, '_score' => { order: :desc }]) # people before works, then by score
   end
 end

--- a/app/views/search/results.html.haml
+++ b/app/views/search/results.html.haml
@@ -7,7 +7,7 @@
     %h1= "#{t(:search_results)}: #{@search.query}"
     %h4= "#{t(:search_total)}: #{@total} #{t(:items)}"
     %p
-    %ol
+    %ol{ start: @offset + 1 }
       - @results.each do |result|
         %li
           - attrs = result.attributes

--- a/lib/multi_index_search_request.rb
+++ b/lib/multi_index_search_request.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # This class allows us to get around the single index search constraint in Chewy
 class MultiIndexSearchRequest < Chewy::Search::Request
   # By including this we get Kaminari pagination behavior


### PR DESCRIPTION
Updated multiindex search to explicitely sort items to sort items in following order Authorities, Manifestations, Dicts using script sorting.

By default Kaminary sorts by index name in **desc** order, so after Person to Authority refactoring we got [Manifestations, Dicts, Authorities]. Previously (before index renaming) it was [People, Manifestations, Dicts].

Also I fixed another minor issue: it always displayed items with index starting from 1 even if non-first page of results was requested. Now second page will start from 26, third from 51, etc.