### PR TITLE
Made it possible to switch UI to english in development

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,0 +1,4 @@
+# Common environment variables for development environment.
+# Usually you don't need to change this file directly, if you need to override some vars with values specific to
+# your machine, create an `.env.development.local` file and set values there.
+BY_LANGUAGE=he

--- a/.gitignore
+++ b/.gitignore
@@ -59,6 +59,9 @@ bin/delayed_job
 *VBox*.log
 ubuntu-*-console.log
 
+# Ignore local dotenv configs (as they should be different for every developer)
+.env.*.local
+
 # Docker-compose config
 docker/bybe_dev/docker-compose.override.yml
 

--- a/Gemfile
+++ b/Gemfile
@@ -147,6 +147,7 @@ group :development do
 end
 
 group :test, :development do
+  gem 'dotenv', '~> 3.1.2'
   gem 'factory_bot_rails', '~> 6.2.0'
   gem 'rspec-rails', '~> 5.0.2'
   gem 'spring'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -207,6 +207,7 @@ GEM
       nokogiri (~> 1.13, >= 1.13.0)
       rubyzip (~> 2.0)
     domain_name (0.6.20240107)
+    dotenv (3.1.2)
     dry-core (1.0.0)
       concurrent-ruby (~> 1.0)
       zeitwerk (~> 2.6)
@@ -765,6 +766,7 @@ DEPENDENCIES
   derailed_benchmarks
   diffy
   docx
+  dotenv (~> 3.1.2)
   ed25519
   execjs
   factory_bot_rails (~> 6.2.0)

--- a/config/application.rb
+++ b/config/application.rb
@@ -52,10 +52,11 @@ module Bybeconv
     #config.active_job.queue_adapter = :delayed_job # scheduler
     config.active_job.queue_adapter = :sidekiq
     config.active_job.queue_name_prefix = Rails.env
-    # The default locale is :en and all translations from config/locales/*.rb,yml are auto loaded.
-    # config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}').to_s]
+
     config.i18n.default_locale = :he
+    config.i18n.available_locales = %i(he en)
     config.i18n.enforce_available_locales = true
+    config.i18n.fallbacks = %i(he)
 
     config.middleware.insert_before 0, Rack::Cors do
       allow do

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -27,7 +27,8 @@ Rails.application.configure do
     config.cache_store = :null_store
   end
 
-  config.i18n.enforce_available_locales = false
+  # In development we allow using of different locales (en for now) for non-hebrew speaking developers
+  config.i18n.default_locale = ENV['BY_LANGUAGE']&.to_sym || :he
 
   # Don't care if the mailer can't send
   config.action_mailer.raise_delivery_errors = true
@@ -54,7 +55,6 @@ Rails.application.configure do
   #config.assets.debug = true
   config.eager_load = false
   # config.public_file_server.enabled = true # Rails 5.x?
-  config.i18n.available_locales = :he
 
   # Store Active Storage files locally.
   config.active_storage.service = :local
@@ -83,9 +83,6 @@ Rails.application.configure do
 
   # Suppress logger output for asset requests.
   config.assets.quiet = true
-
-  # Raises error for missing translations.
-  # config.i18n.raise_on_missing_translations = true
 
   # Annotate rendered view with file names.
   # config.action_view.annotate_rendered_view_with_filenames = true

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -68,16 +68,12 @@ Rails.application.configure do
   # Enable threaded mode
   # config.threadsafe!
 
-  # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
-  # the I18n.default_locale when a translation can not be found)
-  config.i18n.fallbacks = true
-
   # Send deprecation notices to registered listeners
   config.active_support.deprecation = :notify
 
   config.action_mailer.delivery_method = :sendmail # let's start sending mail :)
   config.eager_load = true
-  config.i18n.available_locales = :he
+  config.i18n.available_locales = :he # to not load other locales in memory
 
   # Store Active Storage files on the S3 service
   config.active_storage.service = :amazon
@@ -101,10 +97,6 @@ Rails.application.configure do
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.
   # config.action_mailer.raise_delivery_errors = false
-
-  # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
-  # the I18n.default_locale when a translation cannot be found).
-  config.i18n.fallbacks = true
 
   # Send deprecation notices to registered listeners.
   config.active_support.deprecation = :notify

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,4 +1,5 @@
 en:
+  edit_metadata: Edit metadata
   name_starts_with_x: "Name starts with: '%{x}'"
   title_starts_with_x: "Title starts with: '%{x}'"
   new_person: New Person


### PR DESCRIPTION
If BY_LANGUAGE env variable is provided it will try to use given locale as default.
For now only en or he locale is accepted (and only in dev environment)

I've added dotenv gem to simply manage env variables in development and test. I plan to use it also in https://github.com/abartov/bybeconv/issues/166

You can create `.env.development.local` file and override BY_LANGUAGE value there instead of overwriting `.env.development`

