### PR TITLE
Added memory usage constaint for elasticsearch docker container

### DIFF
--- a/docker/bybe_dev/docker-compose.yml
+++ b/docker/bybe_dev/docker-compose.yml
@@ -23,6 +23,7 @@ services:
       - xpack.security.enabled=false
       - ingest.geoip.downloader.enabled=false
       - action.destructive_requires_name=false
+      - "ES_JAVA_OPTS=-Xms4096m -Xmx4096m"
     volumes:
       - elasticsearch_data:/usr/share/elasticsearch/data:delegated
     ports:


### PR DESCRIPTION
This PR adds some settings to docker config I use for development.
It limits memory usage for elasticsearch to 4Gb. 
Without this elastic can take too much memory in system which causes continuous swapping and slowliness (I faced this problem on laptop with 16Gb RAM,on my home machine with 32Gb it was ok).
