### PR TITLE
Ingestible paging

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -73,6 +73,9 @@ Style/UnlessElse:
 Rails/ActionOrder: # TODO: temporary disabled. it would be good to enable in future
   Enabled: false
 
+Rails/OutputSafety: # we actively use such output
+  Enabled: false
+
 RSpec/ExampleLength:
   Max: 20
 

--- a/app/controllers/ingestible_texts_controller.rb
+++ b/app/controllers/ingestible_texts_controller.rb
@@ -4,6 +4,7 @@
 class IngestibleTextsController < ApplicationController
   include LockIngestibleConcern
 
+  before_action { |c| c.require_editor('edit_catalog') }
   before_action :set_ingestible
   before_action :try_to_lock_ingestible
 

--- a/app/controllers/ingestible_texts_controller.rb
+++ b/app/controllers/ingestible_texts_controller.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+# Controller to work with individual texts within an Ingestible object
+class IngestibleTextsController < ApplicationController
+  include LockIngestibleConcern
+
+  before_action :set_ingestible
+  before_action :try_to_lock_ingestible
+
+  def edit; end
+
+  def update
+    @ingestible.texts[@text_index] = IngestibleText.new(params.require(:ingestible_text).permit(:content, :title))
+    @ingestible.save!
+    redirect_to edit_ingestible_path(@ingestible, text_index: @text_index), notice: t(:updated_successfully)
+  end
+
+  private
+
+  def set_ingestible
+    @ingestible = Ingestible.find(params[:ingestible_id])
+    # Id is a zero-based index of text inside of ingestible texts collection
+    @text_index = params[:id].to_i
+  end
+end

--- a/app/models/ingestible.rb
+++ b/app/models/ingestible.rb
@@ -183,7 +183,11 @@ class Ingestible < ApplicationRecord
   def obtain_lock(user)
     return false if locked? && locked_by_user_id != user.id
 
-    update!(locked_at: Time.zone.now, locked_by_user: user)
+    # To avoid excessive updates we only refresh lock if more than 10 seconds passed since previous lock refresh
+    if locked_at.nil? || locked_at < 10.seconds.ago
+      update!(locked_at: Time.zone.now, locked_by_user: user)
+    end
+
     return true
   end
 

--- a/app/models/ingestible_text.rb
+++ b/app/models/ingestible_text.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+# This class represents single text inside an Ingestible.
+# Each ingestible contains array of buffers serialized to json field works_buffer
+class IngestibleText
+  include ActiveModel::Model
+
+  attr_accessor :content, :title
+
+  def initialize(json)
+    @title = json['title']
+    @content = json['content']
+  end
+
+  def to_hash
+    {
+      title: @title,
+      content: @content
+    }
+  end
+end

--- a/app/services/markdown_to_html.rb
+++ b/app/services/markdown_to_html.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+# Converts markdown to HTML
+class MarkdownToHtml < ApplicationService
+  def call(markdown)
+    return '' if markdown.blank?
+
+    MultiMarkdown.new(markdown).to_html.force_encoding('UTF-8')
+                 .gsub(%r{<figcaption>.*?</figcaption>}, '') # remove MMD's automatic figcaptions
+  end
+end

--- a/app/views/ingestible_texts/_edit.html.haml
+++ b/app/views/ingestible_texts/_edit.html.haml
@@ -1,0 +1,31 @@
+- text = ingestible.texts[index]
+.container-fluid
+  = form_for [ingestible, text], url: ingestible_text_path(ingestible, index), method: :patch do |f|
+    .row
+      .col-sm-2
+        - if index > 0
+          = link_to 'Previous',
+                    edit_ingestible_text_path(ingestible, index - 1),
+                    class: 'btn btn-primary form-control',
+                    remote: true
+      .col-sm-8
+        .row
+          .col-sm-2
+            %label.control-label= IngestibleText.human_attribute_name(:title)
+          .col-sm-10
+            .form-control= f.text_field :title
+      .col-sm-2
+        - if index < ingestible.texts.length - 1
+          = link_to 'Next',
+                    edit_ingestible_text_path(ingestible, index + 1),
+                    class: 'btn btn-primary form-control',
+                    remote: true
+    .markdown_container.row
+      .col-sm-3
+        = f.text_area :content, class: 'textarea100 markdown'
+      .col-sm-9
+        %h2= t(:display_text)
+        #buffer_preview{ style: 'padding-left:10px;padding-right:15px;background:#d2cfcf; overflow-y:auto' }
+          != raw(MarkdownToHtml.call(text.content))
+    .actions
+      = f.submit t(:save), class: 'btn btn-primary btn-sm', remote: true

--- a/app/views/ingestible_texts/edit.js.erb
+++ b/app/views/ingestible_texts/edit.js.erb
@@ -1,0 +1,1 @@
+$('#texts').html("<%= j(render partial: 'edit', locals: { ingestible: @ingestible, index: @text_index } ) %>");

--- a/app/views/ingestibles/_form.html.haml
+++ b/app/views/ingestibles/_form.html.haml
@@ -1,22 +1,23 @@
-= form_for @ingestible do |f|
-  - if @ingestible.errors.any?
-    #error_explanation
-      %h2= t('ingestible.invalid')
-      %ul
-        - @ingestible.errors.full_messages.each do |message|
-          %li= message
+- if @ingestible.errors.any?
+  #error_explanation
+    %h2= t('ingestible.invalid')
+    %ul
+      - @ingestible.errors.full_messages.each do |message|
+        %li= message
 
-  %ul.nav.nav-tabs{style: 'width: 100%;'}
-    %li.nav-item
-      %a.nav-link.active{href: '#general', 'data-toggle': 'tab', style: 'width: unset;'}= t('.general')
+%ul.nav.nav-tabs{ style: 'width: 100%;' }
+  %li.nav-item
+    %a.nav-link.active{ href: '#general', 'data-toggle': 'tab', style: 'width: unset;' }= t('.general')
+  - unless @ingestible.new_record?
     %li.nav-item
       %a.nav-link{href: '#full_markdown', 'data-toggle': 'tab', style: 'width: unset;'}= t('.full_markdown')
     %li.nav-item
       %a.nav-link{href: '#toc', 'data-toggle': 'tab', style: 'width: unset;'}= t('.toc')
     %li.nav-item
-      %a.nav-link{href: '#texts', 'data-toggle': 'tab', style: 'width: unset;'}= t('.texts')
-  .tab-content
-    .tab-pane.active#general
+      %a.nav-link#texts_header{ href: '#texts', 'data-toggle': 'tab', style: 'width: unset;' }= t('.texts')
+.tab-content
+  .tab-pane.active#general
+    = form_for @ingestible do |f|
       .field
         = f.label t('ingestible.title')
         = f.text_field :title, style: 'width:80%'
@@ -79,42 +80,55 @@
         %b= t(:upload_file)
         = t(:file_can_be_skipped)
       = f.file_field :docx
+      .actions
+        = f.submit t(:save), class: 'btn btn-primary'
+  - unless @ingestible.new_record?
     .tab-pane#full_markdown
       %h2= t('.full_markdown')
       .container-fluid
         .row
           .col-md-12
-            .markdown_container.row
-              .col-sm-3
-                #legacy_markdown_link
-                %h2= t(:markdown)
-                %button.btn-small-outline-v02#add_stanza_break{style:'display:unset'}
-                  %b.btn-text-v02= t(:add_stanza_break)
-                %button.btn-small-outline-v02#add_angled_brackets{style:'display:unset'}
-                  %b.btn-text-v02= t(:add_angled_brackets)
-                %button.btn-small-outline-v02#remove_angled_brackets{style:'display:unset'}
-                  %b.btn-text-v02= t(:remove_angled_brackets)
-                %button.btn-small-outline-v02#minuses_to_makafim{style:'display:unset'}
-                  %b.btn-text-v02= t(:minuses_to_makafim)
-                = f.text_area :markdown, class: 'textarea100 markdown'
-              .col-sm-9
-                %h2= t(:display_text)
-                #preview{ style:"padding-left:10px;padding-right:15px;background:#d2cfcf; overflow-y:auto"}
-                  != raw(@html)
-                  %br
+            = form_for @ingestible, url: update_markdown_ingestible_path(@ingestible) do |f|
+              .markdown_container.row
+                .col-sm-3
+                  #legacy_markdown_link
+                  %h2= t(:markdown)
+                  %button.btn-small-outline-v02#add_stanza_break{ style: 'display:unset' }
+                    %b.btn-text-v02= t(:add_stanza_break)
+                  %button.btn-small-outline-v02#add_angled_brackets{ style: 'display:unset' }
+                    %b.btn-text-v02= t(:add_angled_brackets)
+                  %button.btn-small-outline-v02#remove_angled_brackets{ style: 'display:unset' }
+                    %b.btn-text-v02= t(:remove_angled_brackets)
+                  %button.btn-small-outline-v02#minuses_to_makafim{ style: 'display:unset' }
+                    %b.btn-text-v02= t(:minuses_to_makafim)
+                  = f.text_area :markdown, class: 'textarea100 markdown'
+                .col-sm-9
+                  %h2= t(:display_text)
+                  #preview{ style: 'padding-left:10px;padding-right:15px;background:#d2cfcf; overflow-y:auto' }
+                    != raw(@html)
+                    %br
+                .actions
+                  = f.submit t(:save), class: 'btn btn-primary'
     .tab-pane#toc
       %h2= t('.toc')
-      = f.text_area :toc_buffer, class: 'textarea100'
+      = form_for @ingestible do |f|
+        = f.text_area :toc_buffer, class: 'textarea100'
+        .actions
+          = f.submit t(:save), class: 'btn btn-primary'
     .tab-pane#texts
-      = 'Implement texts here'
-  .actions
-    = f.submit t(:save), class: 'btn btn-primary'
+      - unless @ingestible.texts.empty?
+        = render partial: 'ingestible_texts/edit',
+                 locals: { ingestible: @ingestible, index: (params[:text_index] || 0).to_i }
   - if @ingestible.persisted?
     .review
-      = link_to t(:review), review_ingestible_path(@ingestible), class: 'btn btn-primary'
+      = link_to t('.review'), review_ingestible_path(@ingestible), class: 'btn btn-primary'
 :javascript
-  $(document).ready(function() {
-    $('#explain_no_volume').popover({content: 
+  $(function() {
+    if (#{params[:text_index].present?}) {
+      $('#texts_header').click();
+    }
+
+    $('#explain_no_volume').popover({content:
     "#{t('ingestible.no_volume_explanation')}", 
     trigger: 'hover', placement: 'right'});
     $('#explain_attach_photos').popover({content: 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -65,10 +65,19 @@ en:
       failure: Failed to create Ingestible
     edit:
       title: Edit Ingestible
+    form:
+      general: General
+      texts: Texts
+      full_markdown: Full Markdown
+      toc: TOC
+      review: Review
     update:
       success: Ingestible was successfully updated
     destroy:
       success: Ingestible was successfully destroyed
+  ingestible_texts:
+    edit:
+      text_x_of_total: Text %{index} of %{total}
   shared:
     filters:
       pagination:

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -1375,10 +1375,14 @@ he:
       texts: טקסטים
       full_markdown: מארקדאון מלא
       toc: תוכן עניינים
+      review: Review
     update:
       success: ההעלאה עודכנה
     destroy:
       success: ההעלאה נמחקה
+  ingestible_texts:
+    edit:
+      text_x_of_total: Text %{index} of %{total}
   shared:
     filters:
       pagination:

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -1382,7 +1382,7 @@ he:
       success: ההעלאה נמחקה
   ingestible_texts:
     edit:
-      text_x_of_total: Text %{index} of %{total}
+      text_x_of_total: טקסט %{index} מתוך %{total}
   shared:
     filters:
       pagination:

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -1375,7 +1375,7 @@ he:
       texts: טקסטים
       full_markdown: מארקדאון מלא
       toc: תוכן עניינים
-      review: Review
+      review: סקירה
     update:
       success: ההעלאה עודכנה
     destroy:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,8 +9,10 @@ Bybeconv::Application.routes.draw do
 
   resources :ingestibles do
     resources :authorities, controller: :ingestible_authorities, only: %i(create destroy)
+    resources :texts, controller: :ingestible_texts, only: %i(edit update)
     member do
       get :review
+      patch :update_markdown
     end
   end
 

--- a/spec/controllers/ingestible_texts_controller_spec.rb
+++ b/spec/controllers/ingestible_texts_controller_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe IngestibleTextsController do
+  include_context 'when editor logged in', :edit_catalog
+
+  let!(:ingestible) { create(:ingestible, :with_buffers) }
+
+  describe '#edit' do
+    subject(:call) { get :edit, params: { ingestible_id: ingestible.id, id: 2 }, format: :js, xhr: true }
+
+    it 'completes successfully' do
+      expect(call).to have_http_status(:success)
+    end
+  end
+
+  describe '#update' do
+    subject(:call) do
+      patch :update, params: { ingestible_id: ingestible.id, id: 2, ingestible_text: text_params, format: :js }
+    end
+
+    let(:text_params) do
+      {
+        title: 'new_title',
+        content: 'new_content'
+      }
+    end
+
+    it 'updates ingestible and redirects to ingestible edit page' do
+      expect(call).to redirect_to edit_ingestible_path(ingestible, text_index: 2)
+      ingestible.reload
+      expect(flash.notice).to eq I18n.t(:updated_successfully)
+      expect(ingestible.texts[2]).to have_attributes(text_params)
+    end
+  end
+end

--- a/spec/controllers/ingestibles_controller_spec.rb
+++ b/spec/controllers/ingestibles_controller_spec.rb
@@ -83,16 +83,15 @@ describe IngestiblesController do
     describe '#update' do
       subject(:call) { patch :update, params: { id: ingestible.id, ingestible: ingestible_params } }
 
-      let(:ingestible_params) { attributes_for(:ingestible) }
+      let(:ingestible_params) { attributes_for(:ingestible).except(:markdown, :toc_buffer) }
 
       it_behaves_like 'redirects to show page if record cannot be locked'
 
       context 'when valid params' do
         it 'updates record and re-renders edit page' do
-          expect(call).to be_successful
+          expect(call).to redirect_to edit_ingestible_path(ingestible)
           ingestible.reload
           expect(ingestible).to have_attributes(ingestible_params)
-          expect(call).to render_template :edit
           expect(flash.notice).to eq I18n.t('ingestibles.update.success')
         end
       end
@@ -104,6 +103,21 @@ describe IngestiblesController do
           expect(call).to have_http_status(:unprocessable_entity)
           expect(call).to render_template(:edit)
         end
+      end
+    end
+
+    describe '#update_markdown' do
+      subject(:call) { patch :update_markdown, params: { id: ingestible.id, ingestible: { markdown: new_markdown } } }
+
+      let(:new_markdown) { Faker::Lorem.paragraph }
+
+      it_behaves_like 'redirects to show page if record cannot be locked'
+
+      it 'updates record and re-renders edit page' do
+        expect(call).to redirect_to edit_ingestible_path(ingestible)
+        ingestible.reload
+        expect(ingestible.markdown).to eq new_markdown
+        expect(flash.notice).to eq I18n.t(:updated_successfully)
       end
     end
 

--- a/spec/factories/ingestibles.rb
+++ b/spec/factories/ingestibles.rb
@@ -5,5 +5,15 @@ FactoryBot.define do
     title { Faker::Book.title }
     status { 'draft' }
     markdown { Faker::Lorem.paragraph }
+    trait :with_buffers do
+      works_buffer do
+        5.times.map do
+          {
+            title: Faker::Book.title,
+            content: Faker::Lorem.paragraph
+          }
+        end.to_json
+      end
+    end
   end
 end

--- a/spec/models/ingestible_spec.rb
+++ b/spec/models/ingestible_spec.rb
@@ -59,6 +59,18 @@ describe Ingestible do
       it_behaves_like 'lock obtained'
     end
 
+    context 'when record is locked by same user less than 10 seconds ago' do
+      let(:locked_at) { 5.seconds.ago }
+      let(:other_user) { user }
+
+      it 'returns true but does not updates lock timestamp' do
+        expect(result).to be_truthy
+        ingestible.reload
+        expect(ingestible.locked_by_user).to eq user
+        expect(ingestible.locked_at).to be_within(1.second).of(locked_at)
+      end
+    end
+
     context 'when record is locked by different user, but lock is expired' do
       let(:locked_at) { 20.minutes.ago }
       let(:other_user) { create(:user) }


### PR DESCRIPTION
Added UI to page between individual texts inside an ingestible.
For now only markdown and title can be edited (I expect we'll have an authorities too?)

One of limitations of current implementation is that when saving changes to ingestible text we will loose any changes to other ingestible metadata (if any was changed) will be lost.

we can either add a warning message about this, or consider splitting metadata and markdown update into a separate actions (as we currently have in manifestations)