### PR TITLE
Catch all collection

### DIFF
--- a/app/controllers/admin/authorities_controller.rb
+++ b/app/controllers/admin/authorities_controller.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Admin
+  # Controller to work with Authorities records
+  class AuthoritiesController < ApplicationController
+    before_action :require_editor
+
+    before_action :set_authority, only: %i(refresh_uncollected_works_collection)
+
+    def refresh_uncollected_works_collection
+      RefreshUncollectedWorksCollection.call(@authority)
+      redirect_to authority_path(@authority), notice: t(:updated_successfully)
+    end
+
+    private
+
+    def set_authority
+      @authority = Authority.find(params[:id])
+    end
+  end
+end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -416,7 +416,7 @@ class ApplicationController < ActionController::Base
   end
 
   def prep_toc_as_collection
-    @root_collection = @author.root_collection
+    @root_collection = @author.obtain_root_collection
     @toc = @author.toc # may be nil
     # credits = @author.toc.credit_section || ''
     # credits.sub!(

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -34,7 +34,16 @@ class Collection < ApplicationRecord
   #   a multi-volume work, are their appropriate type -- a manifestation if a single text, a collection of type volume
   #   if a book, etc.;
   # other is a catch-all for anything else
-  enum collection_type: { volume: 0, periodical: 1, periodical_issue: 2, series: 3, root: 4, other: 5 }
+  # uncollected is used to group authority's works not belonging to any other collections. Each authority can have one.
+  enum collection_type: {
+    volume: 0,
+    periodical: 1,
+    periodical_issue: 2,
+    series: 3,
+    root: 4,
+    other: 5,
+    uncollected: 100
+  }
   enum toc_strategy: { default: 0, custom_markdown: 1 } # placeholder for future custom ToC-generation strategies
 
   # scope :published, -> { where(status: Collection.statuses[:published]) }

--- a/app/services/refresh_uncollected_works_collection.rb
+++ b/app/services/refresh_uncollected_works_collection.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+# We want to group all works author was involved into but not belonging to any colleciton into a special
+# 'Uncollected works' collection
+class RefreshUncollectedWorksCollection < ApplicationService
+  # rubocop:disable Style/GuardClause
+  def call(authority)
+    collection = authority.uncollected_works_collection
+
+    remove_collected_works(authority) if collection.present?
+
+    if collection.nil?
+      collection = Collection.new(
+        collection_type: :uncollected,
+        title: I18n.t(:uncollected_works_collection_title)
+      )
+    end
+
+    nextseqno = (collection.collection_items.maximum(:seqno) || 0) + 1
+
+    # Checking all manifestations given authority is involved into as author or translator
+    authority.manifestations(:author, :translator)
+             .preload(collection_items: :collection)
+             .find_each do |m|
+      # skipping if manifestation is included in some other collection or already included in uncollected works
+      # collection for this authority
+      next if m.collection_items.any? do |ci|
+        !ci.collection.uncollected? || (collection.present? && ci.collection == collection)
+      end
+
+      collection.collection_items.build(item: m, seqno: nextseqno)
+      nextseqno += 1
+    end
+
+    collection.save! # should save all added items
+
+    if authority.uncollected_works_collection.nil?
+      authority.uncollected_works_collection = collection
+      authority.save!
+    end
+  end
+  # rubocop:enable Style/GuardClause
+
+  # removes from uncollected_works collection works which was included in some other collection
+  def remove_collected_works(authority)
+    authority.uncollected_works_collection
+             .collection_items
+             .preload(item: { collection_items: :collection })
+             .find_each do |collection_item|
+      # The only possible item type in uncollected works collection is Manifestation
+      manifestation = collection_item.item
+      # NOTE: same work can be in several different uncollected works collection related to different authorities
+      if manifestation.collection_items.any? { |ci| !ci.collection.uncollected? }
+        collection_item.destroy!
+      end
+    end
+  end
+end

--- a/app/views/authors/toc.html.haml
+++ b/app/views/authors/toc.html.haml
@@ -60,7 +60,13 @@
                   != "&nbsp;&nbsp;&nbsp;"
                   %span.static-btn
                     %b= link_to t(:edit_metadata), authors_edit_path(id: @author.id)
-        
+
+                  != '&nbsp;&nbsp;&nbsp;'
+                  %span.static-btn
+                    %b= link_to 'Refresh uncollected works',
+                                refresh_uncollected_works_collection_admin_authority_path(@author),
+                                method: :post
+
             .select-all-with-buttons{style:'display:none;margin-right:100px;'}
               .number-of-selected-texts{style: 'display:none'}
                 = t(:number_of_selected_texts)

--- a/app/views/shared/_collection.html.haml
+++ b/app/views/shared/_collection.html.haml
@@ -37,5 +37,5 @@
               - else
                 .headline-3-v02
                   = t(:text)
-                  :
+                  \:
                   = link_to collection_item_string(ci), default_link_by_class(ci.item.class, ci.item.id)

--- a/config/locales/active_record.en.yml
+++ b/config/locales/active_record.en.yml
@@ -28,6 +28,7 @@ en:
             base:
               no_linked_authority: either Person or CorporateBody object must be specified
               multiple_linked_authorities: Person and CorporateBody objects cannot be specified together
+          wrong_collection_type: must be of '%{expected_type}' type
     attributes:
       authority:
         other_designation: Other designation

--- a/config/locales/active_record.he.yml
+++ b/config/locales/active_record.he.yml
@@ -28,7 +28,7 @@ he:
             base:
               no_linked_authority: יש לקשר או רשומת אישים או רשומת ארגונים
               multiple_linked_authorities: אי אפשר לקשר גם רשומת אישים וגם רשומת ארגונים
-          wrong_collection_type: must be of '%{expected_type}' type
+          wrong_collection_type: חייב להיות מסוג '%{expected_type}'
     attributes:
       authority:
         other_designation: כינויים אחרים

--- a/config/locales/active_record.he.yml
+++ b/config/locales/active_record.he.yml
@@ -28,6 +28,7 @@ he:
             base:
               no_linked_authority: יש לקשר או רשומת אישים או רשומת ארגונים
               multiple_linked_authorities: אי אפשר לקשר גם רשומת אישים וגם רשומת ארגונים
+          wrong_collection_type: must be of '%{expected_type}' type
     attributes:
       authority:
         other_designation: כינויים אחרים

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -37,6 +37,8 @@ en:
   feature_on: Featuring Periods
   unknown: Unknown
   sort_by: Sort by
+  uncollected_works_collection_title: Uncollected works
+
   admin:
     featured_contents:
       index:

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -1294,7 +1294,7 @@ he:
   ctype_series_up_link: לתצוגת המחזור/שער כולו
   parent_collections: "שייך לאוספים:"
   collection_circular_reference: אוסף מקושר לעצמו!
-  uncollected_works_collection_title: Uncollected works
+  uncollected_works_collection_title: יצירות שלא כונסו
 
   notifications:
     proof_fixed:

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -1294,6 +1294,7 @@ he:
   ctype_series_up_link: לתצוגת המחזור/שער כולו
   parent_collections: "שייך לאוספים:"
   collection_circular_reference: אוסף מקושר לעצמו!
+  uncollected_works_collection_title: Uncollected works
 
   notifications:
     proof_fixed:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,12 @@ Bybeconv::Application.routes.draw do
       resources :features, controller: 'featured_content_features', only: %i(create)
     end
     resources :featured_content_features, only: %i(destroy)
+
+    resources :authorities, only: [] do
+      member do
+        post :refresh_uncollected_works_collection
+      end
+    end
   end
 
   resources :ingestibles do

--- a/db/migrate/20240719103532_add_uncollected_works_collection_id_to_authorities.rb
+++ b/db/migrate/20240719103532_add_uncollected_works_collection_id_to_authorities.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AddUncollectedWorksCollectionIdToAuthorities < ActiveRecord::Migration[6.1]
+  def change
+    add_belongs_to :authorities, :uncollected_works_collection,
+                   foreign_key: { to_table: :collections}, index: { unique: true }, type: :integer
+
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_07_07_201410) do
+ActiveRecord::Schema.define(version: 2024_07_19_103532) do
 
   create_table "aboutnesses", id: :integer, charset: "utf8mb4", collation: "utf8mb4_bin", force: :cascade do |t|
     t.integer "work_id"
@@ -158,6 +158,7 @@ ActiveRecord::Schema.define(version: 2024_07_07_201410) do
     t.integer "person_id"
     t.integer "corporate_body_id"
     t.integer "root_collection_id"
+    t.integer "uncollected_works_collection_id"
     t.index ["corporate_body_id"], name: "index_authorities_on_corporate_body_id", unique: true
     t.index ["impressions_count"], name: "index_authorities_on_impressions_count"
     t.index ["intellectual_property"], name: "index_authorities_on_intellectual_property"
@@ -167,6 +168,7 @@ ActiveRecord::Schema.define(version: 2024_07_07_201410) do
     t.index ["sort_name"], name: "index_authorities_on_sort_name"
     t.index ["status", "published_at"], name: "index_authorities_on_status_and_published_at"
     t.index ["toc_id"], name: "people_toc_id_fk"
+    t.index ["uncollected_works_collection_id"], name: "index_authorities_on_uncollected_works_collection_id", unique: true
   end
 
   create_table "base_user_preferences", id: :integer, charset: "utf8mb4", collation: "utf8mb4_bin", force: :cascade do |t|
@@ -1075,6 +1077,7 @@ ActiveRecord::Schema.define(version: 2024_07_07_201410) do
   add_foreign_key "anthology_texts", "anthologies"
   add_foreign_key "anthology_texts", "manifestations"
   add_foreign_key "authorities", "collections", column: "root_collection_id"
+  add_foreign_key "authorities", "collections", column: "uncollected_works_collection_id"
   add_foreign_key "authorities", "corporate_bodies"
   add_foreign_key "authorities", "people"
   add_foreign_key "authorities", "tocs", name: "people_toc_id_fk"

--- a/spec/factories/collections.rb
+++ b/spec/factories/collections.rb
@@ -2,15 +2,10 @@
 
 FactoryBot.define do
   factory :collection do
-    title { 'MyString' }
-    sort_title { 'MyString' }
-    subtitle { 'MyString' }
+    title { Faker::Book.title }
+    sort_title { title }
+    subtitle { Faker::Book.title }
     issn { 'MyString' }
-    collection_type { 1 }
-    inception { 'MyString' }
-    inception_year { 1 }
-    publication { nil }
-    toc { nil }
-    toc_strategy { 1 }
+    collection_type { %w(volume periodical periodical_issue series other).sample }
   end
 end

--- a/spec/factories/manifestations.rb
+++ b/spec/factories/manifestations.rb
@@ -16,6 +16,7 @@ FactoryBot.define do
       primary { true }
       expression_date { '2 ביוני 1960' }
       work_date { '3 ביוני 1960' }
+      collections { [] }
     end
 
     title { "Title for #{manifestation_name}" }
@@ -45,6 +46,12 @@ FactoryBot.define do
         date: expression_date,
         work_date: work_date
       )
+    end
+
+    collection_items do
+      collections.map do |c|
+        build(:collection_item, collection: c)
+      end
     end
 
     trait :with_external_links do

--- a/spec/models/authority_spec.rb
+++ b/spec/models/authority_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 describe Authority do
   describe 'validations' do
-    it 'considers empty Person invalid' do
+    it 'considers empty Authority invalid' do
       a = described_class.new
       expect(a).not_to be_valid
     end
@@ -16,6 +16,60 @@ describe Authority do
         person: create(:person)
       )
       expect(a).to be_valid
+    end
+
+    describe 'root collection type validation' do
+      let(:authority) { build(:authority, root_collection: root_collection) }
+
+      context 'when root collection is not set' do
+        let(:root_collection) { nil }
+
+        it { expect(authority).to be_valid }
+      end
+
+      context 'when root collection is set and has root type' do
+        let(:root_collection) { create(:collection, collection_type: :root) }
+
+        it { expect(authority).to be_valid }
+      end
+
+      context 'when root collection is set but has wrong type' do
+        let(:root_collection) { create(:collection) }
+
+        it 'fails validation' do
+          expect(authority).not_to be_valid
+          expect(authority.errors[:root_collection]).to eq [
+            I18n.t('activerecord.errors.models.authority.wrong_collection_type', expected_type: :root)
+          ]
+        end
+      end
+    end
+
+    describe 'uncollected works collection type validation' do
+      let(:authority) { build(:authority, uncollected_works_collection: uncollected_works_collection) }
+
+      context 'when root collection is not set' do
+        let(:uncollected_works_collection) { nil }
+
+        it { expect(authority).to be_valid }
+      end
+
+      context 'when root collection is set and has uncollected type' do
+        let(:uncollected_works_collection) { create(:collection, collection_type: :uncollected) }
+
+        it { expect(authority).to be_valid }
+      end
+
+      context 'when root collection is set but has wrong type' do
+        let(:uncollected_works_collection) { create(:collection) }
+
+        it 'fails validation' do
+          expect(authority).not_to be_valid
+          expect(authority.errors[:uncollected_works_collection]).to eq [
+            I18n.t('activerecord.errors.models.authority.wrong_collection_type', expected_type: :uncollected)
+          ]
+        end
+      end
     end
 
     describe '.validate_linked_authority' do

--- a/spec/services/refresh_uncollected_works_collection_spec.rb
+++ b/spec/services/refresh_uncollected_works_collection_spec.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe RefreshUncollectedWorksCollection do
+  let!(:authority) { create(:authority, uncollected_works_collection: uncollected_works) }
+  let!(:other_uncollected_works) { create(:collection, collection_type: :uncollected) }
+  let!(:other_authority) { create(:authority, uncollected_works_collection: other_uncollected_works) }
+
+  # Those items are not included to any collection so should get into uncollected works collection
+  let!(:uncollected_original_works) do
+    create_list(
+      :manifestation,
+      3,
+      author: authority,
+      orig_lang: :de,
+      translator: other_authority
+    )
+  end
+
+  # Those items belongs to uncollected works collection but for different authority, so it should be included too
+  let!(:uncollected_translated_works) do
+    create_list(
+      :manifestation,
+      2,
+      author: other_authority,
+      orig_lang: :en,
+      translator: authority,
+      collections: [other_uncollected_works]
+    )
+  end
+
+  let(:uncollected_manifestation_ids) do
+    uncollected_original_works.map(&:id) + uncollected_translated_works.map(&:id)
+  end
+
+  let!(:volume) { create(:collection, collection_type: :volume) }
+
+  # This work is included in volume collection, so should not be included in uncollected works collection
+  let!(:collected_work) { create(:manifestation, collections: [volume], author: authority) }
+
+  describe '.call' do
+    subject(:call) { described_class.call(authority) }
+
+    context 'when there is no uncollected works collection' do
+      let(:uncollected_works) { nil }
+
+      it 'creates collection and adds there uncollected works' do
+        expect { call }.to change(Collection, :count).by(1)
+        authority.reload
+        collection = authority.uncollected_works_collection
+        expect(collection).not_to be_nil
+        expect(collection.collection_type).to eq 'uncollected'
+        expect(collection.collection_items.map(&:item_id)).to match_array(uncollected_manifestation_ids)
+      end
+    end
+
+    context 'when there is an uncollected works collection and it has items to be removed' do
+      let(:uncollected_works) { create(:collection, collection_type: :uncollected) }
+
+      # this item should be removed from collection
+      let!(:already_collected_manifestation) do
+        create(
+          :manifestation,
+          author: authority,
+          collections: [uncollected_works, volume]
+        )
+      end
+
+      it 'adds missing items to collection and removes items included in other collections' do
+        expect { call }.to not_change(Collection, :count)
+        collection = authority.uncollected_works_collection
+        expect(collection.collection_items.map(&:item_id)).to match_array(uncollected_manifestation_ids)
+      end
+    end
+  end
+end


### PR DESCRIPTION
One of prerequisites of creating root collection functionality is to implement 'catch all' colleciton for all uncollected works per authority.

This PR adds new collection type 'uncollected', and adds authorities.uncollected_works_collection_id column to link those collections with authorities. So each authority can have own collection.

There is a new service RefreshUncollectedWorksCollection, used to create or update uncollected collection per authority.

For test purpose I've added a new link 'Refresh uncollected works collection' to Author's TOC page, which calls this service. Later we can remove it and made service to be run automatically on certain events. This service does two things:
- it removes from uncollected works collection all items included in any collection of other type
- it adds works which are either not included in any collections, or only added to other 'uncollected' collections to other authorities.

NOTE: I've created new AuthoritiesController in admin namespace for this purpose. I propose to move all non-public actions related to authorities theres instead of AuthorsController (in future we can make AuthorsController to be responsible for public functionality, and admin/authorities controller to be responsible for editor functions).