### PR TITLE
Fixed tag_spec

### DIFF
--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -96,11 +96,11 @@ describe Tag do
 
   describe 'taggings scopes' do
     let(:first) do
-      described_class.create!(name: Faker::Science.science, creator: create(:user), status: 'approved')
+      described_class.create!(name: Faker::Science.unique.science, creator: create(:user), status: 'approved')
     end
 
     let(:second) do
-      described_class.create!(name: Faker::Science.science, creator: create(:user), status: 'approved')
+      described_class.create!(name: Faker::Science.unique.science, creator: create(:user), status: 'approved')
     end
 
     before do


### PR DESCRIPTION
In some cases this spec failed due to non-unique tag name. Used Faker's unique feature to prevent this.