### PR TITLE
added validation check to prevent creation of cyclic collections

### DIFF
--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -177,7 +177,12 @@ class Collection < ApplicationRecord
   end
 
   def parent_collections
-    CollectionItem.where(item: self).map(&:collection)
+    parent_collection_items.preload(:collection).map(&:collection)
+  end
+
+  # returns collection_items where given collection is specified as an item
+  def parent_collection_items
+    CollectionItem.where(item: self)
   end
 
   protected

--- a/config/locales/active_record.en.yml
+++ b/config/locales/active_record.en.yml
@@ -13,6 +13,8 @@ en:
   activerecord:
     models:
       authority: Authority
+      collection: Collection
+      collection_item: Collection Item
       corporate_body: Corporate Body
       featured_content: Featured Content
       person: Person
@@ -29,6 +31,10 @@ en:
               no_linked_authority: either Person or CorporateBody object must be specified
               multiple_linked_authorities: Person and CorporateBody objects cannot be specified together
           wrong_collection_type: must be of '%{expected_type}' type
+        collection_item:
+          attributes:
+            collection:
+              cycle_found: Cycle found
     attributes:
       authority:
         other_designation: Other designation

--- a/config/locales/active_record.he.yml
+++ b/config/locales/active_record.he.yml
@@ -13,6 +13,8 @@ he:
   activerecord:
     models:
       authority: מחבר
+      collection: Collection
+      collection_item: Collection Item
       corporate_body: גוף/מוסד
       featured_content: תוכן מערכת
       person: אדם
@@ -29,6 +31,10 @@ he:
               no_linked_authority: יש לקשר או רשומת אישים או רשומת ארגונים
               multiple_linked_authorities: אי אפשר לקשר גם רשומת אישים וגם רשומת ארגונים
           wrong_collection_type: חייב להיות מסוג '%{expected_type}'
+        collection_item:
+          attributes:
+            collection:
+              cycle_found: Cycle found
     attributes:
       authority:
         other_designation: כינויים אחרים

--- a/spec/models/collection_item_spec.rb
+++ b/spec/models/collection_item_spec.rb
@@ -3,5 +3,55 @@
 require 'rails_helper'
 
 describe CollectionItem do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe 'Validations' do
+    subject(:result) { collection_item.valid? }
+
+    let(:collection_item) { build(:collection_item, collection: collection, item: item) }
+    let(:collection) { create(:collection) }
+
+    describe '#ensure_no_cycles' do
+      context 'when item is an Manifestation' do
+        let(:item) { create(:manifestation) }
+
+        it { is_expected.to be_truthy }
+      end
+
+      shared_examples 'fails if cycle is found' do
+        it 'fails due to cycle' do
+          expect(result).to be false
+          expect(collection_item.errors[:collection]).to eq [
+            I18n.t('activerecord.errors.models.collection_item.attributes.collection.cycle_found')
+          ]
+        end
+      end
+
+      context 'when item is a collection' do
+        context 'when item is the same collection' do
+          let(:item) { collection }
+
+          it_behaves_like 'fails if cycle is found'
+        end
+
+        context 'when item is another collection' do
+          let(:item) { create(:collection) }
+
+          before do
+            create(:collection_item, collection: item, item: create(:collection))
+          end
+
+          context 'when there is no cycle' do
+            it { is_expected.to be_truthy }
+          end
+
+          context 'when there is a cycle' do
+            before do
+              create(:collection_item, collection: item, item: collection)
+            end
+
+            it_behaves_like 'fails if cycle is found'
+          end
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
While building TOC it is important to not have cyclic dependencies between collections.
This PR adds validation check to CollectionItem which will not allow to create a CollectionItem if it produces cyclic collections dependency.