### PR TITLE
Collection toc

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -52,6 +52,9 @@ Style/HashSyntax:
 Style/IfUnlessModifier:
   Enabled: false
 
+Style/MultilineBlockChain:
+  Enabled: false
+
 Style/NumericPredicate:
   Enabled: false
 

--- a/app/controllers/admin/authorities_controller.rb
+++ b/app/controllers/admin/authorities_controller.rb
@@ -9,7 +9,7 @@ module Admin
 
     def refresh_uncollected_works_collection
       RefreshUncollectedWorksCollection.call(@authority)
-      redirect_to authority_path(@authority), notice: t(:updated_successfully)
+      redirect_to authority_new_toc_path(@authority), notice: t(:updated_successfully)
     end
 
     private

--- a/app/controllers/manifestation_controller.rb
+++ b/app/controllers/manifestation_controller.rb
@@ -4,10 +4,7 @@ class ManifestationController < ApplicationController
   include FilteringAndPaginationConcern
 
   before_action only: [:list, :show, :remove_link, :edit_metadata, :add_aboutnesses] do |c| c.require_editor('edit_catalog') end
-
-  # before_action only: [:edit, :update] do |c|
-  #   c.require_editor(['edit_catalog', 'conversion_verification', 'handle_proofs'])
-  # end
+  before_action only: [:edit, :update] do |c| c.require_editor(['edit_catalog', 'conversion_verification', 'handle_proofs']) end
   before_action only: [:all, :genre, :period, :by_tag] do |c| c.refuse_unreasonable_page end
   autocomplete :manifestation, :title, limit: 20, display_value: :title_and_authors, full: true
   autocomplete :authority, :name, limit: 2, full: true

--- a/app/controllers/manifestation_controller.rb
+++ b/app/controllers/manifestation_controller.rb
@@ -4,7 +4,10 @@ class ManifestationController < ApplicationController
   include FilteringAndPaginationConcern
 
   before_action only: [:list, :show, :remove_link, :edit_metadata, :add_aboutnesses] do |c| c.require_editor('edit_catalog') end
-  # before_action only: [:edit, :update] do |c| c.require_editor(['edit_catalog', 'conversion_verification', 'handle_proofs']) end
+
+  # before_action only: [:edit, :update] do |c|
+  #   c.require_editor(['edit_catalog', 'conversion_verification', 'handle_proofs'])
+  # end
   before_action only: [:all, :genre, :period, :by_tag] do |c| c.refuse_unreasonable_page end
   autocomplete :manifestation, :title, limit: 20, display_value: :title_and_authors, full: true
   autocomplete :authority, :name, limit: 2, full: true

--- a/app/controllers/manifestation_controller.rb
+++ b/app/controllers/manifestation_controller.rb
@@ -4,7 +4,7 @@ class ManifestationController < ApplicationController
   include FilteringAndPaginationConcern
 
   before_action only: [:list, :show, :remove_link, :edit_metadata, :add_aboutnesses] do |c| c.require_editor('edit_catalog') end
-  before_action only: [:edit, :update] do |c| c.require_editor(['edit_catalog', 'conversion_verification', 'handle_proofs']) end
+  # before_action only: [:edit, :update] do |c| c.require_editor(['edit_catalog', 'conversion_verification', 'handle_proofs']) end
   before_action only: [:all, :genre, :period, :by_tag] do |c| c.refuse_unreasonable_page end
   autocomplete :manifestation, :title, limit: 20, display_value: :title_and_authors, full: true
   autocomplete :authority, :name, limit: 2, full: true

--- a/app/models/authority.rb
+++ b/app/models/authority.rb
@@ -108,6 +108,20 @@ class Authority < ApplicationRecord
     taggings.where(status: Tagging.statuses[:approved])
   end
 
+  def collections
+    Collection.where(
+      <<~SQL.squish
+        exists (
+          select 1 from
+            involved_authorities ia
+          where
+            ia.collection_id = collections.id
+            and ia.authority_id = #{id}
+        )
+      SQL
+    )
+  end
+
   # @param roles [String / Symbol] optional, if provided will only return Manifestations where authority has
   #   one of the given roles.
   # @return relation representing [Manifestation] objects current authority is involved into.

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -177,7 +177,12 @@ class Collection < ApplicationRecord
   end
 
   def parent_collections
-    CollectionItem.where(item: self).map(&:collection)
+    parent_collection_items.preload(:collection).map(&:collection)
+  end
+
+  # returns collection_items where given collection is specified as an item
+  def parent_collection_items
+    CollectionItem.where(item: self)
   end
 
   protected

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -2,6 +2,8 @@
 
 # Heterogeneous collection
 class Collection < ApplicationRecord
+  include RecordWithInvolvedAuthorities
+
   before_save :update_sort_title!
 
   validates :collection_type, presence: true

--- a/app/services/generate_toc_tree.rb
+++ b/app/services/generate_toc_tree.rb
@@ -1,0 +1,107 @@
+# frozen_string_literal: true
+
+# Service to generate collections-based TOC tree for a single authority
+class GenerateTocTree < ApplicationService
+  # Node represents a single collection
+  class Node
+    attr_accessor :item, :children, :new
+
+    # Item is an collection
+    # Children is an array of manifestations or other nodes
+    def initialize(item, children)
+      @item = item
+      @children = children
+      @new = true
+    end
+
+    # Returns array of child elements (Manifestations or Nodes) where given author is invovled with given role
+    def children_by_role(role, authority_id)
+      @children_by_role ||= {}
+      @children_by_role[role] ||= sorted_children.select do |child|
+        if child.is_a?(Manifestation)
+          # child is a Manifestation
+          child.involved_authorities_by_role(role).any? { |a| a.id == authority_id }
+        else
+          # child is a node representing other collection
+          collection = child.item
+
+          if collection.involved_authorities.any? { |ia| ia.role == role && ia.authority_id == authority_id }
+            # authority is specified on collection level with given role
+            true
+          else
+            # or collection contains other items where given authority has given role (will be recursive check)
+            child.children_by_role(role, authority_id).present?
+          end
+        end
+      end
+    end
+
+    def sorted_children
+      @sorted_children ||= children.sort_by do |child|
+        [
+          child.is_a?(Node) ? (child.item.uncollected? ? 1 : 0) : 2,
+          child.is_a?(Node) ? child.item.created_at : child.created_at
+        ]
+      end
+    end
+  end
+
+  def call(authority)
+    manifestations = authority.manifestations(:author, :translator, :editor)
+                              .preload(collection_items: :collection).with_involved_authorities
+    @nodes = {}
+    @top_level = []
+
+    manifestations.each do |manifestation|
+      collections = manifestation.collection_items.map(&:collection)
+      collections.each do |c|
+        node(c, manifestation)
+      end
+    end
+
+    authority.collections.each do |collection|
+      node(collection, nil)
+    end
+
+    current_level = @nodes.values
+
+    current_level = get_parents(current_level) until current_level.empty?
+
+    @top_level
+  end
+
+  private
+
+  # This method either creates a new node with given child, or finds existing node and adds child to it
+  def node(collection, child)
+    node = @nodes[collection.id]
+    if node.nil?
+      node = @nodes[collection.id] = Node.new(collection, [child].compact)
+    else
+      # This collection was already visited
+      node.new = false # marking node as not new
+      if child.present? && node.children.exclude?(child)
+        node.children << child
+      end
+    end
+
+    node
+  end
+
+  def get_parents(nodes)
+    # NOTE: consider using batch loading
+    parents = []
+    nodes.each do |node|
+      parent_collections = node.item.parent_collections
+      if parent_collections.empty?
+        @top_level << node
+      else
+        parent_collections.each do |parent_collection|
+          parent_node = node(parent_collection, node)
+          parents << parent_node if parent_node.new
+        end
+      end
+    end
+    parents
+  end
+end

--- a/app/services/generate_toc_tree.rb
+++ b/app/services/generate_toc_tree.rb
@@ -20,7 +20,7 @@ class GenerateTocTree < ApplicationService
 
     # Checks if given Node should be displayed in TOC tree for given authority and role combination
     def visible?(role, authority_id)
-      if item.involved_authorities.any? { |ia| ia.role == role && ia.authority_id == authority_id }
+      if item.involved_authorities.any? { |ia| ia.role == role.to_s && ia.authority_id == authority_id }
         # authority is specified on collection level with given role
         true
       else

--- a/app/services/generate_toc_tree.rb
+++ b/app/services/generate_toc_tree.rb
@@ -51,6 +51,7 @@ class GenerateTocTree < ApplicationService
   end
 
   def call(authority)
+    @authority = authority
     manifestations = authority.manifestations(:author, :translator, :editor)
                               .preload(collection_items: :collection).with_involved_authorities
     @nodes = {}
@@ -58,7 +59,11 @@ class GenerateTocTree < ApplicationService
 
     manifestations.each do |manifestation|
       manifestation.collection_items.each do |collection_item|
-        node(collection_item.collection, manifestation, collection_item.seqno)
+        col = collection_item.collection
+        # We should not include in results 'uncollected' collections belonging to other authorities
+        next if col.uncollected? && col.id != @authority.uncollected_works_collection_id
+
+        node(col, manifestation, collection_item.seqno)
       end
     end
 

--- a/app/services/refresh_uncollected_works_collection.rb
+++ b/app/services/refresh_uncollected_works_collection.rb
@@ -19,7 +19,7 @@ class RefreshUncollectedWorksCollection < ApplicationService
     nextseqno = (collection.collection_items.maximum(:seqno) || 0) + 1
 
     # Checking all manifestations given authority is involved into as author or translator
-    authority.manifestations(:author, :translator)
+    authority.manifestations(:author, :translator, :editor)
              .preload(collection_items: :collection)
              .find_each do |m|
       # skipping if manifestation is included in some other collection or already included in uncollected works

--- a/app/views/authors/_toc_by_role.html.haml
+++ b/app/views/authors/_toc_by_role.html.haml
@@ -1,4 +1,6 @@
-- top_level_by_role = top_nodes.select { |node| node.children_by_role(role, authority_id).present? }
+:ruby
+  top_level_by_role = top_nodes.select { |node| node.children_by_role(role, authority_id).present? }
+                               .sort_by { |node| [ node.item.uncollected? ? 1 : 0, node.item.created_at ] }
 %h3= title
 %ol
   = render partial: 'toc_node', collection: top_level_by_role, locals: { role: role, authority_id: authority_id }

--- a/app/views/authors/_toc_by_role.html.haml
+++ b/app/views/authors/_toc_by_role.html.haml
@@ -1,5 +1,5 @@
 :ruby
-  top_level_by_role = top_nodes.select { |node| node.children_by_role(role, authority_id).present? }
+  top_level_by_role = top_nodes.select { |node| node.visible?(role, authority_id) }
                                .sort_by { |node| [node.item.uncollected? ? 1 : 0, node.item.created_at] }
 %h3= title
 %ol

--- a/app/views/authors/_toc_by_role.html.haml
+++ b/app/views/authors/_toc_by_role.html.haml
@@ -1,6 +1,6 @@
 :ruby
   top_level_by_role = top_nodes.select { |node| node.children_by_role(role, authority_id).present? }
-                               .sort_by { |node| [ node.item.uncollected? ? 1 : 0, node.item.created_at ] }
+                               .sort_by { |node| [node.item.uncollected? ? 1 : 0, node.item.created_at] }
 %h3= title
 %ol
   = render partial: 'toc_node', collection: top_level_by_role, locals: { role: role, authority_id: authority_id }

--- a/app/views/authors/_toc_by_role.html.haml
+++ b/app/views/authors/_toc_by_role.html.haml
@@ -1,0 +1,4 @@
+- top_level_by_role = top_nodes.select { |node| node.children_by_role(role, authority_id).present? }
+%h3= title
+%ol
+  = render partial: 'toc_node', collection: top_level_by_role, locals: { role: role, authority_id: authority_id }

--- a/app/views/authors/_toc_node.html.haml
+++ b/app/views/authors/_toc_node.html.haml
@@ -1,0 +1,15 @@
+%li
+  - if toc_node.is_a?(Manifestation)
+    - if toc_node.published?
+      = link_to toc_node.title, manifestation_path(toc_node)
+    - else
+      = toc_node.title
+  - else
+    -# Collection node
+    - collection = toc_node.item
+    = link_to collection.title, collection_path(collection)
+    - children = toc_node.children_by_role(role, authority_id)
+    - unless children.empty?
+      %ol
+        = render partial: 'toc_node', collection: children,
+                 locals: { role: role, authority_id: authority_id }

--- a/app/views/authors/new_toc.html.haml
+++ b/app/views/authors/new_toc.html.haml
@@ -1,0 +1,24 @@
+.author-page-content
+  .row
+    .col-lg-2.col-sm-4
+      %ul
+        %li= link_to 'TOC', authority_path(@author)
+        %li= link_to 'Refresh uncollected works',
+                      refresh_uncollected_works_collection_admin_authority_path(@author),
+                      method: :post
+
+    .col-lg-10.col-sm-8
+      %h2= @author.name
+      .toc#maintext
+        .mainlist#browse_mainlist
+          = cache @author, expires_in: 12.hour do
+            - top_nodes = GenerateTocTree.call(@author)
+            = render partial: 'toc_by_role',
+                     locals: { top_nodes: top_nodes, title: t(:original_works), role: :author,
+                     authority_id: @author.id }
+            = render partial: 'toc_by_role',
+                     locals: { top_nodes: top_nodes, title: t(:translations), role: :translator,
+                     authority_id: @author.id }
+            = render partial: 'toc_by_role',
+                     locals: { top_nodes: top_nodes, title: t(:edited_works), role: :editor,
+                     authority_id: @author.id }

--- a/app/views/authors/new_toc.html.haml
+++ b/app/views/authors/new_toc.html.haml
@@ -3,22 +3,29 @@
     .col-lg-2.col-sm-4
       %ul
         %li= link_to 'TOC', authority_path(@author)
+        -# rubocop:disable Layout/ArgumentAlignment:
         %li= link_to 'Refresh uncollected works',
                       refresh_uncollected_works_collection_admin_authority_path(@author),
                       method: :post
-
+        -# rubocop:enable Layout/ArgumentAlignment:
     .col-lg-10.col-sm-8
       %h2= @author.name
       .toc#maintext
         .mainlist#browse_mainlist
-          = cache @author, expires_in: 12.hour do
+          = cache @author, expires_in: 12.hours do
             - top_nodes = GenerateTocTree.call(@author)
             = render partial: 'toc_by_role',
-                     locals: { top_nodes: top_nodes, title: t(:original_works), role: :author,
-                     authority_id: @author.id }
+                     locals: { top_nodes: top_nodes,
+                               title: t(:original_works),
+                               role: :author,
+                               authority_id: @author.id }
             = render partial: 'toc_by_role',
-                     locals: { top_nodes: top_nodes, title: t(:translations), role: :translator,
-                     authority_id: @author.id }
+                     locals: { top_nodes: top_nodes,
+                               title: t(:translations),
+                               role: :translator,
+                               authority_id: @author.id }
             = render partial: 'toc_by_role',
-                     locals: { top_nodes: top_nodes, title: t(:edited_works), role: :editor,
-                     authority_id: @author.id }
+                     locals: { top_nodes: top_nodes,
+                               title: t(:edited_works),
+                               role: :editor,
+                               authority_id: @author.id }

--- a/app/views/authors/new_toc.html.haml
+++ b/app/views/authors/new_toc.html.haml
@@ -26,6 +26,6 @@
                                authority_id: @author.id }
             = render partial: 'toc_by_role',
                      locals: { top_nodes: top_nodes,
-                               title: t(:edited_works),
+                               title: t(:edited_works, gender_letter: @author.gender_letter),
                                role: :editor,
                                authority_id: @author.id }

--- a/app/views/authors/toc.html.haml
+++ b/app/views/authors/toc.html.haml
@@ -48,7 +48,7 @@
                     = t(:about_author_in_blog, author:@author.name)
               - if current_user && current_user.editor?
                 %p{style:'text-align:left'}
-                  != "&nbsp;&nbsp;&nbsp;"
+                  != '&nbsp;&nbsp;&nbsp;'
                   - unless @author.toc.nil?
                     %span.static-btn
                       %b= link_to t(:edit_toc), authors_edit_toc_path(@author)
@@ -57,10 +57,10 @@
                     != "&nbsp;&nbsp;&nbsp;"
                     %b= link_to t(:convert_to_manual_toc), authors_to_manual_toc_path(@author)
 
-                  != "&nbsp;&nbsp;&nbsp;"
+                  != '&nbsp;&nbsp;&nbsp;'
                   %span.static-btn
                     %b= link_to t(:edit_metadata), authors_edit_path(id: @author.id)
-                  != "&nbsp;&nbsp;&nbsp;"
+                  != '&nbsp;&nbsp;&nbsp;'
                   %span.static-btn
                     %b= link_to 'New TOC', authority_new_toc_path(@author)
 

--- a/app/views/authors/toc.html.haml
+++ b/app/views/authors/toc.html.haml
@@ -60,12 +60,9 @@
                   != "&nbsp;&nbsp;&nbsp;"
                   %span.static-btn
                     %b= link_to t(:edit_metadata), authors_edit_path(id: @author.id)
-
-                  != '&nbsp;&nbsp;&nbsp;'
+                  != "&nbsp;&nbsp;&nbsp;"
                   %span.static-btn
-                    %b= link_to 'Refresh uncollected works',
-                                refresh_uncollected_works_collection_admin_authority_path(@author),
-                                method: :post
+                    %b= link_to 'New TOC', authority_new_toc_path(@author)
 
             .select-all-with-buttons{style:'display:none;margin-right:100px;'}
               .number-of-selected-texts{style: 'display:none'}

--- a/app/views/collections/_form.html.haml
+++ b/app/views/collections/_form.html.haml
@@ -20,7 +20,7 @@
     = f.text_field :issn
   .field
     = f.label :collection_type
-    = f.number_field :collection_type
+    = f.select :collection_type, options_for_select(Collection.collection_types.keys - %w(uncollected))
   .field
     = f.label :inception
     = f.text_field :inception

--- a/config/locales/active_record.en.yml
+++ b/config/locales/active_record.en.yml
@@ -13,6 +13,8 @@ en:
   activerecord:
     models:
       authority: Authority
+      collection: Collection
+      collection_item: Collection Item
       corporate_body: Corporate Body
       featured_content: Featured Content
       person: Person
@@ -29,6 +31,10 @@ en:
               no_linked_authority: either Person or CorporateBody object must be specified
               multiple_linked_authorities: Person and CorporateBody objects cannot be specified together
           wrong_collection_type: must be of '%{expected_type}' type
+        collection_item:
+          attributes:
+            collection:
+              cycle_found: Cycle found
     attributes:
       authority:
         other_designation: Other designation

--- a/config/locales/active_record.he.yml
+++ b/config/locales/active_record.he.yml
@@ -13,6 +13,8 @@ he:
   activerecord:
     models:
       authority: מחבר
+      collection: Collection
+      collection_item: Collection Item
       corporate_body: גוף/מוסד
       featured_content: תוכן מערכת
       person: אדם
@@ -29,6 +31,10 @@ he:
               no_linked_authority: יש לקשר או רשומת אישים או רשומת ארגונים
               multiple_linked_authorities: אי אפשר לקשר גם רשומת אישים וגם רשומת ארגונים
           wrong_collection_type: חייב להיות מסוג '%{expected_type}'
+        collection_item:
+          attributes:
+            collection:
+              cycle_found: Cycle found
     attributes:
       authority:
         other_designation: כינויים אחרים

--- a/config/locales/active_record.he.yml
+++ b/config/locales/active_record.he.yml
@@ -13,8 +13,8 @@ he:
   activerecord:
     models:
       authority: מחבר
-      collection: Collection
-      collection_item: Collection Item
+      collection: אוסף
+      collection_item: פריט באוסף
       corporate_body: גוף/מוסד
       featured_content: תוכן מערכת
       person: אדם
@@ -34,7 +34,7 @@ he:
         collection_item:
           attributes:
             collection:
-              cycle_found: Cycle found
+              cycle_found: נמצאה מעגליות באוסף!
     attributes:
       authority:
         other_designation: כינויים אחרים

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -16,6 +16,9 @@ en:
   created_successfully: Created Successfully
   updated_successfully: Updated Successfully
   deleted_successfully: Deleted Successfully
+  original_works: Original Works
+  translations: Translations
+  edited_works: Edited Works
   alefbet: Alphabetical
   alefbet_asc: 'Alphabetical: A-Z'
   alefbet_desc: 'Alphabetical: Z-A'

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -397,7 +397,7 @@ he:
   already_done: כבר טופל
   original_works: יצירות מקור
   translation: תרגום
-  edited_works: Edited Works
+  edited_works: יצירות בעריכת%{gender_letter}
   toc_order_reminder: 'תזכורת לגבי סדר הסוגות: '
   translations: יצירות מתורגמות
   translator_name: "שם המתרגם/ת"

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -397,6 +397,7 @@ he:
   already_done: כבר טופל
   original_works: יצירות מקור
   translation: תרגום
+  edited_works: Edited Works
   toc_order_reminder: 'תזכורת לגבי סדר הסוגות: '
   translations: יצירות מתורגמות
   translator_name: "שם המתרגם/ת"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -172,6 +172,7 @@ Bybeconv::Application.routes.draw do
   match 'author/:id/edit_toc' => 'authors#edit_toc', as: 'authors_edit_toc', via: [:get, :post]
   match 'author/:id/to_manual_toc' => 'authors#to_manual_toc', as: 'authors_to_manual_toc', via: [:get, :post]
   match 'author/:id' => 'authors#toc', as: 'authority', via: %i(get post)
+  get 'author/:id/new_toc' => 'authors#new_toc', as: 'authority_new_toc'
 
   match 'author/publish/:id' => 'authors#publish', as: 'author_publish', via: [:get, :post]
   get 'author/:id/delete_photo' => 'authors#delete_photo', as: 'delete_author_photo'

--- a/spec/controllers/authors_controller_spec.rb
+++ b/spec/controllers/authors_controller_spec.rb
@@ -84,6 +84,14 @@ describe AuthorsController do
       end
     end
 
+    describe '#new_toc' do
+      subject { get :new_toc, params: { id: authority.id } }
+
+      include_context 'when authority has several collections'
+
+      it { is_expected.to be_successful }
+    end
+
     describe '#whatsnew_popup' do
       let!(:manifestation) { create(:manifestation, created_at: created_at, author: author) }
 

--- a/spec/factories/collections.rb
+++ b/spec/factories/collections.rb
@@ -7,5 +7,31 @@ FactoryBot.define do
     subtitle { Faker::Book.title }
     issn { 'MyString' }
     collection_type { %w(volume periodical periodical_issue series other).sample }
+
+    transient do
+      authors { [] }
+      translators { [] }
+      editors { [] }
+      included_collections { [] }
+      manifestations { [] }
+    end
+
+    involved_authorities do
+      result = []
+      if authors.present?
+        result += authors.map { |authority| build(:involved_authority, authority: authority, role: :author) }
+      end
+      if translators.present?
+        result += translators.map { |authority| build(:involved_authority, authority: authority, role: :translator) }
+      end
+      if editors.present?
+        result += editors.map { |authority| build(:involved_authority, authority: authority, role: :editor) }
+      end
+      result
+    end
+
+    collection_items do
+      (included_collections + manifestations).map { |item| build(:collection_item, item: item) }
+    end
   end
 end

--- a/spec/models/collection_item_spec.rb
+++ b/spec/models/collection_item_spec.rb
@@ -3,5 +3,55 @@
 require 'rails_helper'
 
 describe CollectionItem do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe 'Validations' do
+    subject(:result) { collection_item.valid? }
+
+    let(:collection_item) { build(:collection_item, collection: collection, item: item) }
+    let(:collection) { create(:collection) }
+
+    describe '#ensure_no_cycles' do
+      context 'when item is an Manifestation' do
+        let(:item) { create(:manifestation) }
+
+        it { is_expected.to be_truthy }
+      end
+
+      shared_examples 'fails if cycle is found' do
+        it 'fails due to cycle' do
+          expect(result).to be false
+          expect(collection_item.errors[:collection]).to eq [
+            I18n.t('activerecord.errors.models.collection_item.attributes.collection.cycle_found')
+          ]
+        end
+      end
+
+      context 'when item is a collection' do
+        context 'when item is the same collection' do
+          let(:item) { collection }
+
+          it_behaves_like 'fails if cycle is found'
+        end
+
+        context 'when item is another collection' do
+          let(:item) { create(:collection) }
+
+          before do
+            create(:collection_item, collection: item, item: create(:collection))
+          end
+
+          context 'when there is no cycle' do
+            it { is_expected.to be_truthy }
+          end
+
+          context 'when there is a cycle' do
+            before do
+              create(:collection_item, collection: item, item: collection)
+            end
+
+            it_behaves_like 'fails if cycle is found'
+          end
+        end
+      end
+    end
+  end
 end

--- a/spec/models/collection_spec.rb
+++ b/spec/models/collection_spec.rb
@@ -13,6 +13,7 @@ describe Collection do
     i1 = create(:collection_item, collection: c, seqno: 1)
     i2 = create(:collection_item, collection: c, seqno: 3)
     i3 = create(:collection_item, collection: c, seqno: 2)
+    c.reload
     expect(c.collection_items).to eq [i1, i3, i2]
   end
 
@@ -93,6 +94,7 @@ describe Collection do
     i1 = create(:collection_item, collection: c, seqno: 1)
     i2 = create(:collection_item, collection: c, seqno: 3)
     i3 = create(:collection_item, collection: c, seqno: 2)
+    c.reload
     expect(c.collection_items).to eq [i1, i3, i2]
     c.move_item_up(i2.id)
     expect(c.collection_items.reload).to eq [i1, i2, i3]
@@ -103,6 +105,7 @@ describe Collection do
     i1 = create(:collection_item, collection: c, seqno: 1)
     i2 = create(:collection_item, collection: c, seqno: 3)
     i3 = create(:collection_item, collection: c, seqno: 2)
+    c.reload
     expect(c.collection_items).to eq [i1, i3, i2]
     c.move_item_down(i1.id)
     expect(c.collection_items.reload).to eq [i3, i1, i2]
@@ -113,6 +116,7 @@ describe Collection do
     i1 = create(:collection_item, collection: c, seqno: 1)
     i2 = create(:collection_item, collection: c, seqno: 3)
     i3 = create(:collection_item, collection: c, seqno: 2)
+    c.reload
     expect(c.collection_items).to eq [i1, i3, i2]
     m = create(:manifestation)
     c.append_item(m)
@@ -124,6 +128,7 @@ describe Collection do
     c = create(:collection)
     create_list(:collection_item, 5, collection: c)
     expect(c.collection_items.count).to eq 5
+    c.reload
     c.collection_items.destroy_all
     expect(c.collection_items.count).to eq 0
   end
@@ -135,6 +140,7 @@ describe Collection do
     i3 = create(:collection_item, collection: c, seqno: 2)
     expect(c.collection_items.count).to eq 3
     c.remove_item(i3.id)
+    c.reload
     expect(c.collection_items.count).to eq 2
     expect(c.collection_items.first).to eq i1
     expect(c.collection_items.last).to eq i2
@@ -151,6 +157,7 @@ describe Collection do
     let!(:third_item) { create(:collection_item, collection: collection, seqno: 2) }
 
     before do
+      collection.reload
       call
       collection.reload
     end

--- a/spec/services/generate_toc_tree_spec.rb
+++ b/spec/services/generate_toc_tree_spec.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe GenerateTocTree do
+  subject(:result) { described_class.call(authority) }
+
+  let!(:authority) { create(:authority, uncollected_works_collection: uncollected_collection) }
+
+  context 'when there are no works or collections' do
+    let(:uncollected_collection) { nil }
+
+    it { is_expected.to be_empty }
+  end
+
+  context 'when there are works' do
+    let!(:other_authority) { create(:authority) }
+
+    let!(:top_level_collection) { create(:collection) }
+    let!(:top_level_collection_with_nested_collections) do
+      create(
+        :collection,
+        authors: [other_authority],
+        included_collections: [nested_edited_collection, nested_translated_collection]
+      )
+    end
+    let!(:uncollected_collection) { create(:collection, collection_type: :uncollected) }
+    let!(:nested_edited_collection) { create(:collection, editors: [authority]) }
+    let!(:nested_translated_collection) { create(:collection, translators: [authority]) }
+    let!(:edited_manifestations) do
+      create_list(
+        :manifestation,
+        3,
+        collections: [nested_edited_collection],
+        editor: authority,
+        author: other_authority
+      )
+    end
+    # For translated manifestations we don's specify authority on manifestaton level
+    let!(:translated_manifestations) do
+      create_list(
+        :manifestation,
+        2,
+        collections: [nested_translated_collection],
+        author: other_authority
+      )
+    end
+
+    let!(:uncollected_manifestations) do
+      create_list(:manifestation, 2, author: authority, collections: [uncollected_collection])
+    end
+
+    let!(:top_level_manifestations) do
+      create_list(:manifestation, 3, author: authority, collections: [top_level_collection])
+    end
+
+    let(:top_level_node) { result.find { |n| n.item == top_level_collection } }
+    let(:top_level_with_nested_node) { result.find { |n| n.item == top_level_collection_with_nested_collections } }
+    let(:uncollected_node) { result.find { |n| n.item == uncollected_collection } }
+    let(:nested_edited_node) { top_level_with_nested_node.children.find { |n| n.item == nested_edited_collection } }
+    let(:nested_translated_node) do
+      top_level_with_nested_node.children.find { |n| n.item == nested_translated_collection }
+    end
+
+    it 'runs successfully' do
+      expect(result).to contain_exactly top_level_node, top_level_with_nested_node, uncollected_node
+
+      expect(top_level_node.children).to match_array top_level_manifestations
+      expect(top_level_with_nested_node.children.map(&:item)).to contain_exactly nested_translated_collection,
+                                                                                 nested_edited_collection
+
+      expect(nested_edited_node.children).to match_array edited_manifestations
+      expect(nested_translated_node.children).to be_empty
+    end
+  end
+end

--- a/spec/services/generate_toc_tree_spec.rb
+++ b/spec/services/generate_toc_tree_spec.rb
@@ -27,7 +27,7 @@ describe GenerateTocTree do
 
       expect(top_level_node.children.map(&:first)).to match_array top_level_manifestations
       expect(
-        top_level_with_nested_node.children.map { |c| c.first.item}
+        top_level_with_nested_node.children.map { |c| c.first.item }
       ).to contain_exactly nested_translated_collection,
                            nested_edited_collection
 

--- a/spec/services/generate_toc_tree_spec.rb
+++ b/spec/services/generate_toc_tree_spec.rb
@@ -14,63 +14,35 @@ describe GenerateTocTree do
   end
 
   context 'when there are works' do
-    let!(:other_authority) { create(:authority) }
+    include_context 'when authority has several collections'
 
-    let!(:top_level_collection) { create(:collection) }
-    let!(:top_level_collection_with_nested_collections) do
-      create(
-        :collection,
-        authors: [other_authority],
-        included_collections: [nested_edited_collection, nested_translated_collection]
-      )
-    end
-    let!(:uncollected_collection) { create(:collection, collection_type: :uncollected) }
-    let!(:nested_edited_collection) { create(:collection, editors: [authority]) }
-    let!(:nested_translated_collection) { create(:collection, translators: [authority]) }
-    let!(:edited_manifestations) do
-      create_list(
-        :manifestation,
-        3,
-        collections: [nested_edited_collection],
-        editor: authority,
-        author: other_authority
-      )
-    end
-    # For translated manifestations we don's specify authority on manifestaton level
-    let!(:translated_manifestations) do
-      create_list(
-        :manifestation,
-        2,
-        collections: [nested_translated_collection],
-        author: other_authority
-      )
-    end
-
-    let!(:uncollected_manifestations) do
-      create_list(:manifestation, 2, author: authority, collections: [uncollected_collection])
-    end
-
-    let!(:top_level_manifestations) do
-      create_list(:manifestation, 3, author: authority, collections: [top_level_collection])
-    end
-
-    let(:top_level_node) { result.find { |n| n.item == top_level_collection } }
-    let(:top_level_with_nested_node) { result.find { |n| n.item == top_level_collection_with_nested_collections } }
-    let(:uncollected_node) { result.find { |n| n.item == uncollected_collection } }
-    let(:nested_edited_node) { top_level_with_nested_node.children.find { |n| n.item == nested_edited_collection } }
-    let(:nested_translated_node) do
-      top_level_with_nested_node.children.find { |n| n.item == nested_translated_collection }
-    end
+    let(:top_level_node) { find_node(result, top_level_collection) }
+    let(:top_level_with_nested_node) { find_node(result, top_level_collection_with_nested_collections) }
+    let(:uncollected_node) { find_node(result, uncollected_collection) }
+    let(:nested_edited_node) { find_child_node(top_level_with_nested_node, nested_edited_collection) }
+    let(:nested_translated_node) { find_child_node(top_level_with_nested_node, nested_translated_collection) }
 
     it 'runs successfully' do
       expect(result).to contain_exactly top_level_node, top_level_with_nested_node, uncollected_node
 
-      expect(top_level_node.children).to match_array top_level_manifestations
-      expect(top_level_with_nested_node.children.map(&:item)).to contain_exactly nested_translated_collection,
-                                                                                 nested_edited_collection
+      expect(top_level_node.children.map(&:first)).to match_array top_level_manifestations
+      expect(
+        top_level_with_nested_node.children.map { |c| c.first.item}
+      ).to contain_exactly nested_translated_collection,
+                           nested_edited_collection
 
-      expect(nested_edited_node.children).to match_array edited_manifestations
+      expect(nested_edited_node.children.map(&:first)).to match_array edited_manifestations
       expect(nested_translated_node.children).to be_empty
     end
+  end
+
+  private
+
+  def find_node(nodes, item)
+    nodes.find { |n| n.item == item }
+  end
+
+  def find_child_node(parent_node, item)
+    find_node(parent_node.children.map(&:first), item)
   end
 end

--- a/spec/support/shared_examples/collection_toc.rb
+++ b/spec/support/shared_examples/collection_toc.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+RSpec.shared_context 'when authority has several collections' do
+  let!(:authority) { create(:authority, uncollected_works_collection: uncollected_collection) }
+  let!(:other_authority) { create(:authority) }
+
+  let!(:top_level_collection) { create(:collection) }
+  let!(:top_level_collection_with_nested_collections) do
+    create(
+      :collection,
+      authors: [other_authority],
+      included_collections: [nested_edited_collection, nested_translated_collection]
+    )
+  end
+  let!(:uncollected_collection) { create(:collection, collection_type: :uncollected) }
+  let!(:nested_edited_collection) { create(:collection, editors: [authority]) }
+  let!(:nested_translated_collection) { create(:collection, translators: [authority]) }
+  let!(:edited_manifestations) do
+    create_list(
+      :manifestation,
+      3,
+      collections: [nested_edited_collection],
+      editor: authority,
+      author: other_authority
+    )
+  end
+  # For translated manifestations we don's specify authority on manifestaton level
+  let!(:translated_manifestations) do
+    create_list(
+      :manifestation,
+      2,
+      collections: [nested_translated_collection],
+      author: other_authority
+    )
+  end
+
+  let!(:uncollected_manifestations) do
+    create_list(:manifestation, 2, author: authority, collections: [uncollected_collection])
+  end
+
+  let!(:top_level_manifestations) do
+    create_list(:manifestation, 3, author: authority, collections: [top_level_collection])
+  end
+end


### PR DESCRIPTION
Initial implementation of Collection-based TOC.

Now there is a new link 'New TOC' on authority page:

![изображение](https://github.com/user-attachments/assets/81d9b9c7-7b70-48e7-b100-5f91a496f450)

It will lead to a new page. It displays authority's TOC as a set of three nested ordered lists: for Original, Translated and Edited works. Every subcollection will add a new level of nesting to the ordered list:

![изображение](https://github.com/user-attachments/assets/893f7278-f2ed-4ad8-ae5c-aa0cb4dd33fd)

I've also moved link to refresh uncollected works collection to new_toc page.

I've added caching of generated TOC page for 12 hours.

Also this PR includes validation check to prevent cyclic collection dependencies.

P.S. I've did not added I18n resource for New_toc as I expect this to be renamed soon (as well as controller action itself)
