### PR TITLE
Toc co-authors names

### DIFF
--- a/app/helpers/authors_helper.rb
+++ b/app/helpers/authors_helper.rb
@@ -37,4 +37,16 @@ module AuthorsHelper
   def browse_null_decorator(item)
     return ''
   end
+
+  # Returns string, containing comma-separated list of names of authorities linked to given text with given role
+  # @param manifestation
+  # @param role
+  # @param exclude_authority_id - if provided given authority will be excluded from the list
+  def authorities_string(manifestation, role, exclude_authority_id: nil)
+    manifestation.involved_authorities_by_role(role)
+                 .reject { |au| au.id == exclude_authority_id }
+                 .map(&:name)
+                 .sort
+                 .join(', ')
+  end
 end

--- a/app/views/authors/_toc_node.html.haml
+++ b/app/views/authors/_toc_node.html.haml
@@ -1,9 +1,28 @@
 %li
   - if toc_node.is_a?(Manifestation)
+    - genre = toc_node.expression.work.genre
+    %span.by-icon-v02{ title: t(genre) }>= glyph_for_genre(genre)
+    &nbsp;
+    :ruby
+      label = toc_node.title
+      case role
+      when :editor
+        label += "/ #{toc_node.author_string}"
+      when :translator
+        label += "/ #{authorities_string(toc_node, :author)}"
+        if toc_node.translators.size > 1
+          label += "/ #{authorities_string(toc_node, :translator, exclude_authority_id: authority_id)}"
+        end
+      when :author
+        if toc_node.authors.size > 1
+          label += "/ #{authorities_string(toc_node, :author, exclude_authority_id: authority_id)}"
+        end
+      end
+
     - if toc_node.published?
-      = link_to toc_node.title, manifestation_path(toc_node)
+      = link_to label, manifestation_path(toc_node)
     - else
-      = toc_node.title
+      = label
   - else
     -# Collection node
     - collection = toc_node.item

--- a/app/views/authors/_toc_node.html.haml
+++ b/app/views/authors/_toc_node.html.haml
@@ -7,15 +7,15 @@
       label = toc_node.title
       case role
       when :editor
-        label += "/ #{toc_node.author_string}"
+        label += " / #{toc_node.author_string}"
       when :translator
-        label += "/ #{authorities_string(toc_node, :author)}"
+        label += " / #{authorities_string(toc_node, :author)}"
         if toc_node.translators.size > 1
-          label += "/ #{authorities_string(toc_node, :translator, exclude_authority_id: authority_id)}"
+          label += " / #{authorities_string(toc_node, :translator, exclude_authority_id: authority_id)}"
         end
       when :author
         if toc_node.authors.size > 1
-          label += "/ #{authorities_string(toc_node, :author, exclude_authority_id: authority_id)}"
+          label += " / #{authorities_string(toc_node, :author, exclude_authority_id: authority_id)}"
         end
       end
 

--- a/app/views/manifestation/_involved_authorities.html.haml
+++ b/app/views/manifestation/_involved_authorities.html.haml
@@ -2,7 +2,7 @@
 %ul
   - involved_authorities.each do |ia|
     %li{ id: "ia#{ia.id}" }
-      = link_to ia.authority.name, authors_show_path(ia.authority)
+      = link_to ia.authority.name, authors_show_path(id: ia.authority.id)
       (#{textify_authority_role(ia.role)})
       - if edit
         = link_to t(:destroy), involved_authority_path(ia),


### PR DESCRIPTION
Now if manifestation has several authors or translators, Collection TOC will show all co-authors or co-translators.
For edited works it will show full authors string.

Also fixed bug: on edit_metadata page links to involved authorities was generated wrongly.