### PR TITLE
fixed wrongly-generated links to authors page from edit_metadata page

### DIFF
--- a/app/views/manifestation/_involved_authorities.html.haml
+++ b/app/views/manifestation/_involved_authorities.html.haml
@@ -2,7 +2,7 @@
 %ul
   - involved_authorities.each do |ia|
     %li{ id: "ia#{ia.id}" }
-      = link_to ia.authority.name, authors_show_path(ia.authority)
+      = link_to ia.authority.name, authors_show_path(id: ia.authority)
       (#{textify_authority_role(ia.role)})
       - if edit
         = link_to t(:destroy), involved_authority_path(ia),


### PR DESCRIPTION
In involved-authorities lists on edit_metadata page link to involved authority page was generated wrongly.

NOTE: backported from https://github.com/abartov/bybeconv/pull/410 to master branch.