### PR TITLE
Rspec fix

### DIFF
--- a/app/api/v1/texts_api.rb
+++ b/app/api/v1/texts_api.rb
@@ -47,7 +47,7 @@ class V1::TextsAPI < V1::ApplicationApi
       post do
         ids = params[:ids]
         records = ManifestationsIndex.find(ids)
-        # If ids contains one one value, Chewy returns single object instead of array, so explicitely convert
+        # If ids contains only single value, Chewy returns single object instead of array, so explicitely convert
         # it to single-element array
         if ids.size == 1
           records = [records]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,8 @@
-FROM ruby:3.2.1-buster
+FROM ruby:3.3.5-bullseye
 
 RUN apt-get update -qq && apt-get install -y \
     curl \
+    cmake \
     wkhtmltopdf \
     pandoc \
     yaz \

--- a/docker/bybe_dev/docker-compose.yml
+++ b/docker/bybe_dev/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3'
-
 volumes:
   mysql_data:
   bundler_data:

--- a/spec/api/v1/text_api_spec.rb
+++ b/spec/api/v1/text_api_spec.rb
@@ -265,7 +265,7 @@ describe V1::TextsAPI do
           m.expression.intellectual_property_public_domain? || m.expression.intellectual_property_unknown?
         end
 
-        expect(data_ids).to eq matched.sort_by(&:impressions_count).map(&:id)[0..24]
+        expect(data_ids).to eq matched.sort_by { |rec| [rec.impressions_count, rec.id] }.map(&:id)[0..24]
       end
     end
 


### PR DESCRIPTION
Fixed error in specs.
Problem occured when there where two manifestations with same impressions_count.

In this case TextAPI uses additional sorting by id, but spec code ignored it. Added missing sorting by id