### PR TITLE
Toc with collections and placeholders

### DIFF
--- a/app/models/toc_tree/collection_node.rb
+++ b/app/models/toc_tree/collection_node.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+module TocTree
+  # Collection node
+  class CollectionNode
+    attr_accessor :collection, :children, :new, :has_parents
+
+    # Item is a collection
+    # Children is an array of [x, seqno] where x is a Node (Collection/Manifestation/Placeholder),
+    # seqno used for ordering
+    def initialize(collection)
+      @collection = collection
+      @children = []
+      @new = true
+      @parents = []
+      @has_parents = false
+    end
+
+    def id
+      @id ||= "collection:#{@collection.id}"
+    end
+
+    def add_child(child, seqno)
+      return if child.nil?
+
+      @children << [child, seqno] unless @children.any? { |ch, _seqno| ch.id == child.id }
+      child.has_parents = true if child.is_a?(TocTree::CollectionNode)
+    end
+
+    # Checks if given Node should be displayed in TOC tree for given authority and role combination
+    def visible?(role, authority_id)
+      if @collection.involved_authorities.any? { |ia| ia.role == role.to_s && ia.authority_id == authority_id }
+        # authority is specified on collection level with given role
+        true
+      else
+        # or collection contains other items where given authority has given role (recursive check)
+        children_by_role(role, authority_id).present?
+      end
+    end
+
+    # Returns array of child elements (Manifestations or Nodes) where given author is involved with given role
+    def children_by_role(role, authority_id)
+      @children_by_role ||= {}
+      @children_by_role[role] ||= sorted_children.select { |child| child.visible?(role, authority_id) }
+    end
+
+    def sorted_children
+      @sorted_children ||= children.sort_by { |child, seqno| [seqno, child.id] }.map(&:first)
+    end
+  end
+end

--- a/app/models/toc_tree/manifestation_node.rb
+++ b/app/models/toc_tree/manifestation_node.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module TocTree
+  # Manifestation node
+  class ManifestationNode
+    attr_reader :manifestation
+
+    def initialize(manifestation)
+      @manifestation = manifestation
+    end
+
+    def id
+      @id ||= "manifestation:#{@manifestation.id}"
+    end
+
+    def visible?(role, authority_id)
+      @manifestation.involved_authorities_by_role(role).any? { |a| a.id == authority_id }
+    end
+  end
+end

--- a/app/models/toc_tree/placeholder_node.rb
+++ b/app/models/toc_tree/placeholder_node.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module TocTree
+  # Placeholder node
+  class PlaceholderNode
+    attr_reader :collection_item
+
+    def initialize(collection_item)
+      @collection_item = collection_item
+    end
+
+    def id
+      @id ||= "placeholder:#{@collection_item.id}"
+    end
+
+    def visible?(role, authority_id)
+      # Placeholder should be visible if authority is involved in parent collection with given role
+      @collection_item.collection.involved_authorities.any? do |ia|
+        ia.role == role.to_s && ia.authority_id == authority_id
+      end
+    end
+
+    def alt_title
+      @collection_item.alt_title
+    end
+
+    def markdown
+      @collection_item.markdown
+    end
+  end
+end

--- a/app/services/generate_toc_tree.rb
+++ b/app/services/generate_toc_tree.rb
@@ -6,8 +6,8 @@ class GenerateTocTree < ApplicationService
   class Node
     attr_accessor :item, :children, :new
 
-    # Item is an collection
-    # Children is an array of [x, seqno] where x is a manifestations or other node (representing subcollection)
+    # Item is a collection
+    # Children is an array of [x, seqno] where x is a manifestations or other node (representing sub-collection)
     def initialize(item)
       @item = item
       @children = []
@@ -29,7 +29,7 @@ class GenerateTocTree < ApplicationService
       end
     end
 
-    # Returns array of child elements (Manifestations or Nodes) where given author is invovled with given role
+    # Returns array of child elements (Manifestations or Nodes) where given author is involved with given role
     def children_by_role(role, authority_id)
       @children_by_role ||= {}
       @children_by_role[role] ||= sorted_children.select do |child|

--- a/app/services/generate_toc_tree.rb
+++ b/app/services/generate_toc_tree.rb
@@ -4,18 +4,21 @@
 class GenerateTocTree < ApplicationService
   # Node represents a single collection
   class Node
-    attr_accessor :item, :children, :new
+    attr_accessor :item, :children, :new, :has_parents
 
     # Item is a collection
-    # Children is an array of [x, seqno] where x is a manifestations or other node (representing sub-collection)
+    # Children is an array of [x, seqno] where x is a manifestations, string (placeholder) or other
+    # node (representing sub-collection)
     def initialize(item)
       @item = item
       @children = []
       @new = true
+      @has_parents = false
     end
 
     def add_child(child, seqno)
       @children << [child, seqno] unless child.nil? || @children.any? { |ch, _seqno| ch == child }
+      child.has_parents = true if child.is_a?(Node)
     end
 
     # Checks if given Node should be displayed in TOC tree for given authority and role combination
@@ -36,29 +39,72 @@ class GenerateTocTree < ApplicationService
         if child.is_a?(Manifestation)
           # child is a Manifestation
           child.involved_authorities_by_role(role).any? { |a| a.id == authority_id }
-        else
+        elsif child.is_a?(Collection)
           # child is a node representing other collection
           child.visible?(role, authority_id)
+        else
+          # All placeholders should be shown
+          true
         end
       end
     end
 
     def sorted_children
       @sorted_children ||= children.sort_by do |child, seqno|
+        date = if child.is_a?(Node)
+                 child.item.created_at
+               elsif child.is_a?(Manifestation)
+                 child.created_at
+               else
+                 # Placeholders
+                 Time.zone.today
+               end
         [
           seqno,
-          child.is_a?(Node) ? child.item.created_at : child.created_at
+          date
         ]
-      end.map { |child, _seqno| child }
+      end.map(&:first)
     end
   end
 
   def call(authority)
     @authority = authority
-    manifestations = authority.manifestations(:author, :translator, :editor)
-                              .preload(collection_items: :collection).with_involved_authorities
     @nodes = {}
-    @top_level = []
+
+    build_collection_tree
+    fetch_manifestations
+
+    current_level = top_level_nodes
+
+    current_level = get_parents(current_level) until current_level.empty?
+
+    top_level_nodes
+  end
+
+  private
+
+  def top_level_nodes
+    @nodes.values.reject(&:has_parents)
+  end
+
+  # This is a first step of building TOC tree
+  # We check all collections where authority is involved on collection level and fetch all their children
+  # down to the bottom
+  def build_collection_tree
+    # Fetching all collections authority is directly involved into on collection level
+    nodes = @authority.collections.map do |collection|
+      node(collection, nil, nil)
+    end
+
+    nodes = fetch_children(nodes) until nodes.empty?
+  end
+
+  # This is a second step of building TOC tree
+  # We check all manifestations whene authority is directly involved, and fetching all their parent collections
+  # NOTE: we assume every manifestation must be included at least in one collection (either 'normal' or 'uncollected')
+  def fetch_manifestations
+    manifestations = @authority.manifestations(:author, :translator, :editor)
+                               .preload(collection_items: :collection).with_involved_authorities
 
     manifestations.each do |manifestation|
       manifestation.collection_items.each do |collection_item|
@@ -69,19 +115,37 @@ class GenerateTocTree < ApplicationService
         node(col, manifestation, collection_item.seqno)
       end
     end
-
-    authority.collections.each do |collection|
-      node(collection, nil, nil)
-    end
-
-    current_level = @nodes.values
-
-    current_level = get_parents(current_level) until current_level.empty?
-
-    @top_level
   end
 
-  private
+  # Fetches children of given collection node and adds them as children to it
+  # Returns list of child nodes representing other sub-collections (only not yet traversed)
+  def fetch_children(parent_nodes)
+    next_level = []
+    parent_nodes.each do |parent_node|
+      parent_node.item.collection_items.preload(:item).map do |ci|
+        child_item = if ci.paratext?
+                       # placeholder with markdown
+                       MultiMarkdown.new(ci.markdown).to_html
+                     elsif ci.item.nil?
+                       # placeholder with title only
+                       ci.alt_title
+                     elsif ci.item.is_a?(Collection)
+                       # nested collection
+                       item = node(ci.item, nil, nil)
+                       item.has_parents = true
+                       if item.new
+                         next_level << item
+                       end
+                       item
+                     else
+                       # manifestation
+                       ci.item
+                     end
+        parent_node.add_child(child_item, ci.seqno)
+      end
+    end
+    next_level
+  end
 
   # This method either creates a new node with given child, or finds existing node and adds child to it
   def node(collection, child, seqno)
@@ -102,13 +166,11 @@ class GenerateTocTree < ApplicationService
     parents = []
     nodes.each do |node|
       parent_collection_items = node.item.parent_collection_items.preload(:collection)
-      if parent_collection_items.empty?
-        @top_level << node
-      else
-        parent_collection_items.each do |collection_item|
-          parent_node = node(collection_item.collection, node, collection_item.seqno)
-          parents << parent_node if parent_node.new
-        end
+      next if parent_collection_items.empty?
+
+      parent_collection_items.each do |collection_item|
+        parent_node = node(collection_item.collection, node, collection_item.seqno)
+        parents << parent_node if parent_node.new
       end
     end
     parents

--- a/app/views/authors/_toc_by_role.html.haml
+++ b/app/views/authors/_toc_by_role.html.haml
@@ -1,6 +1,6 @@
 :ruby
   top_level_by_role = top_nodes.select { |node| node.visible?(role, authority_id) }
-                               .sort_by { |node| [node.item.uncollected? ? 1 : 0, node.item.created_at] }
+                               .sort_by { |node| [node.collection.uncollected? ? 1 : 0, node.collection.created_at] }
 - if top_level_by_role.present?
   .by-card-v02{id: 'works-'+role.to_s, role: 'tabpanel'}
     .by-card-header-v02

--- a/app/views/authors/_toc_node.html.haml
+++ b/app/views/authors/_toc_node.html.haml
@@ -1,31 +1,33 @@
-%li{ style: toc_node.is_a?(Manifestation) ? '' : 'margin-top: 15px; margin-bottom: 10px;'}
-  - if toc_node.is_a?(Manifestation)
-    - genre = toc_node.expression.work.genre
+-# rubocop:disable Style/CaseLikeIf
+%li{ style: toc_node.is_a?(TocTree::ManifestationNode) ? '' : 'margin-top: 15px; margin-bottom: 10px;' }
+  - if toc_node.is_a?(TocTree::ManifestationNode)
+    - m = toc_node.manifestation
+    - genre = m.expression.work.genre
     %span.by-icon-v02{ title: t(genre) }>= glyph_for_genre(genre)
     &nbsp;
     :ruby
-      label = toc_node.title
+      label = m.title
       case role
       when :editor
-        label += " / #{toc_node.author_string}"
+        label += " / #{m.author_string}"
       when :translator
-        label += " / #{authorities_string(toc_node, :author)}"
-        if toc_node.translators.size > 1
-          label += " / #{authorities_string(toc_node, :translator, exclude_authority_id: authority_id)}"
+        label += " / #{authorities_string(m, :author)}"
+        if m.translators.size > 1
+          label += " / #{authorities_string(m, :translator, exclude_authority_id: authority_id)}"
         end
       when :author
-        if toc_node.authors.size > 1
-          label += " / #{authorities_string(toc_node, :author, exclude_authority_id: authority_id)}"
+        if m.authors.size > 1
+          label += " / #{authorities_string(m, :author, exclude_authority_id: authority_id)}"
         end
       end
 
-    - if toc_node.published?
-      = link_to label, manifestation_path(toc_node)
+    - if m.published?
+      = link_to label, manifestation_path(m)
     - else
       = label
-  - elsif toc_node.is_a?(GenerateTocTree::Node)
+  - elsif toc_node.is_a?(TocTree::CollectionNode)
     -# Collection node
-    - collection = toc_node.item
+    - collection = toc_node.collection
     - type_prefix = collection.collection_type == 'uncollected' ? '' : textify_collection_type(collection.collection_type)
     %span{style:'font-size:120%;'}
       = link_to collection.title, collection_path(collection)
@@ -38,7 +40,12 @@
       - unless children.empty?
         %ul.toclist
           = render partial: 'authors/toc_node', collection: children,
-                  locals: { role: role, authority_id: authority_id, editable: editable }
-  - else
+                   locals: { role: role, authority_id: authority_id, editable: editable }
+  - elsif toc_node.is_a?(TocTree::PlaceholderNode)
     -# Placeholder, toc_node should be a String with HTML layout
-    != toc_node
+    - ci = toc_node.collection_item
+    - if toc_node.markdown.present?
+      != MultiMarkdown.new(ci.markdown).to_html
+    - else
+      = ci.alt_title
+-# rubocop:enable Style/CaseLikeIf

--- a/app/views/authors/_toc_node.html.haml
+++ b/app/views/authors/_toc_node.html.haml
@@ -23,7 +23,7 @@
       = link_to label, manifestation_path(toc_node)
     - else
       = label
-  - else
+  - elsif toc_node.is_a?(GenerateTocTree::Node)
     -# Collection node
     - collection = toc_node.item
     - type_prefix = collection.collection_type == 'uncollected' ? '' : textify_collection_type(collection.collection_type)
@@ -39,3 +39,6 @@
         %ul.toclist
           = render partial: 'authors/toc_node', collection: children,
                   locals: { role: role, authority_id: authority_id, editable: editable }
+  - else
+    -# Placeholder, toc_node should be a String with HTML layout
+    != toc_node

--- a/spec/factories/collection_items.rb
+++ b/spec/factories/collection_items.rb
@@ -3,7 +3,8 @@
 FactoryBot.define do
   factory :collection_item do
     collection { create(:collection) }
-    alt_title { 'MyString' }
+    alt_title { nil }
+    markdown { nil }
 
     seqno { 1 }
     item { nil }

--- a/spec/factories/collections.rb
+++ b/spec/factories/collections.rb
@@ -14,6 +14,8 @@ FactoryBot.define do
       editors { [] }
       included_collections { [] }
       manifestations { [] }
+      title_placeholders { [] }
+      markdown_placeholders { [] }
     end
 
     involved_authorities do
@@ -31,7 +33,10 @@ FactoryBot.define do
     end
 
     collection_items do
-      (included_collections + manifestations).map { |item| build(:collection_item, item: item) }
+      i = 0
+      (included_collections + manifestations).map { |item| build(:collection_item, item: item, seqno: ++i) } +
+        title_placeholders.map { |title| build(:collection_item, alt_title: title, seqno: ++i) } +
+        markdown_placeholders.map { |markdown| build(:collection_item, markdown: markdown, seqno: ++i) }
     end
   end
 end

--- a/spec/factories/manifestations.rb
+++ b/spec/factories/manifestations.rb
@@ -50,7 +50,11 @@ FactoryBot.define do
 
     collection_items do
       collections.map do |c|
-        build(:collection_item, collection: c)
+        build(
+          :collection_item,
+          collection: c,
+          seqno: (c.collection_items.maximum(:seqno) || 0) + 1
+        )
       end
     end
 

--- a/spec/services/generate_toc_tree_spec.rb
+++ b/spec/services/generate_toc_tree_spec.rb
@@ -21,6 +21,7 @@ describe GenerateTocTree do
     let(:uncollected_node) { find_node(result, uncollected_collection) }
     let(:nested_edited_node) { find_child_node(top_level_with_nested_node, nested_edited_collection) }
     let(:nested_translated_node) { find_child_node(top_level_with_nested_node, nested_translated_collection) }
+    let(:nested_translated_subnode) { find_child_node(nested_translated_node, nested_translated_subcollection) }
 
     it 'runs successfully' do
       expect(result).to contain_exactly top_level_node, top_level_with_nested_node, uncollected_node
@@ -32,7 +33,12 @@ describe GenerateTocTree do
                            nested_edited_collection
 
       expect(nested_edited_node.children.map(&:first)).to match_array edited_manifestations
-      expect(nested_translated_node.children).to be_empty
+      expect(nested_translated_node.children.map(&:first)).to match_array(
+        translated_manifestations + [nested_translated_subnode]
+      )
+      expect(nested_translated_subnode.children.map(&:first)).to match_array(
+        ['Title placeholder', "<p>Markdown placeholder</p>\n"]
+      )
     end
   end
 

--- a/spec/services/generate_toc_tree_spec.rb
+++ b/spec/services/generate_toc_tree_spec.rb
@@ -16,9 +16,9 @@ describe GenerateTocTree do
   context 'when there are works' do
     include_context 'when authority has several collections'
 
-    let(:top_level_node) { find_node(result, top_level_collection) }
-    let(:top_level_with_nested_node) { find_node(result, top_level_collection_with_nested_collections) }
-    let(:uncollected_node) { find_node(result, uncollected_collection) }
+    let(:top_level_node) { find_collection_node(result, top_level_collection) }
+    let(:top_level_with_nested_node) { find_collection_node(result, top_level_collection_with_nested_collections) }
+    let(:uncollected_node) { find_collection_node(result, uncollected_collection) }
     let(:nested_edited_node) { find_child_node(top_level_with_nested_node, nested_edited_collection) }
     let(:nested_translated_node) { find_child_node(top_level_with_nested_node, nested_translated_collection) }
     let(:nested_translated_subnode) { find_child_node(nested_translated_node, nested_translated_subcollection) }
@@ -26,29 +26,33 @@ describe GenerateTocTree do
     it 'runs successfully' do
       expect(result).to contain_exactly top_level_node, top_level_with_nested_node, uncollected_node
 
-      expect(top_level_node.children.map(&:first)).to match_array top_level_manifestations
+      expect(top_level_node.children.map(&:first).map(&:manifestation)).to match_array top_level_manifestations
       expect(
-        top_level_with_nested_node.children.map { |c| c.first.item }
+        top_level_with_nested_node.children.map { |c| c.first.collection }
       ).to contain_exactly nested_translated_collection,
                            nested_edited_collection
 
-      expect(nested_edited_node.children.map(&:first)).to match_array edited_manifestations
-      expect(nested_translated_node.children.map(&:first)).to match_array(
-        translated_manifestations + [nested_translated_subnode]
+      expect(nested_edited_node.children.map(&:first).map(&:manifestation)).to match_array edited_manifestations
+      expect(nested_translated_node.children.map(&:first).map(&:id)).to match_array(
+        translated_manifestations.map { |m| "manifestation:#{m.id}" } +
+          ["collection:#{nested_translated_subcollection.id}"]
       )
-      expect(nested_translated_subnode.children.map(&:first)).to match_array(
-        ['Title placeholder', "<p>Markdown placeholder</p>\n"]
+      expect(nested_translated_subnode.children.map(&:first).map(&:alt_title)).to contain_exactly(
+        'Title placeholder', nil
+      )
+      expect(nested_translated_subnode.children.map(&:first).map(&:markdown)).to contain_exactly(
+        nil, 'Markdown placeholder'
       )
     end
   end
 
   private
 
-  def find_node(nodes, item)
-    nodes.find { |n| n.item == item }
+  def find_collection_node(nodes, collection)
+    nodes.find { |n| n.collection == collection }
   end
 
   def find_child_node(parent_node, item)
-    find_node(parent_node.children.map(&:first), item)
+    find_collection_node(parent_node.children.map(&:first), item)
   end
 end

--- a/spec/support/shared_examples/collection_toc.rb
+++ b/spec/support/shared_examples/collection_toc.rb
@@ -20,6 +20,7 @@ RSpec.shared_context 'when authority has several collections' do
   let!(:nested_translated_subcollection) do
     create(
       :collection,
+      translators: [authority],
       title_placeholders: ['Title placeholder'],
       markdown_placeholders: ['Markdown placeholder']
     )

--- a/spec/support/shared_examples/collection_toc.rb
+++ b/spec/support/shared_examples/collection_toc.rb
@@ -14,7 +14,17 @@ RSpec.shared_context 'when authority has several collections' do
   end
   let!(:uncollected_collection) { create(:collection, collection_type: :uncollected) }
   let!(:nested_edited_collection) { create(:collection, editors: [authority]) }
-  let!(:nested_translated_collection) { create(:collection, translators: [authority]) }
+  let!(:nested_translated_collection) do
+    create(:collection, translators: [authority], included_collections: [nested_translated_subcollection])
+  end
+  let!(:nested_translated_subcollection) do
+    create(
+      :collection,
+      title_placeholders: ['Title placeholder'],
+      markdown_placeholders: ['Markdown placeholder']
+    )
+  end
+
   let!(:edited_manifestations) do
     create_list(
       :manifestation,


### PR DESCRIPTION
see https://github.com/abartov/bybeconv/issues/441

Updated "new toc" functionality to include in tree:
- placeholders (only when user is specified as actor in containing collection)
- subcollections and all manifistatuibs where authoritiy is not involved directly in them, but included in some of parent (possibly several levels higher) collections.