### PR TITLE
Sub-collection addition failed on collection/manage page

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -327,6 +327,7 @@ module ApplicationHelper
               .map { |k, _v| [textify_collection_type(k), k] } +
       [
         [t(:work), 'Manifestation'],
+        [Collection.model_name, 'Collection'],
         [t(:paratext), 'paratext'],
         [t(:placeholder_item), 'placeholder_item']
       ]


### PR DESCRIPTION
It was impossible to add a new existing sub-collection (using autocomplete) on collection/manage page as we missed 'Collection' item_type value in drop-down.