### PR TITLE
Clean old base users

### DIFF
--- a/app/services/clean_up_base_users.rb
+++ b/app/services/clean_up_base_users.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+# This service deletes all base_user records for anonymous users where session record does not exists
+# We clean sessions table periodically by running standard rake task 'db:sessions:trim' this service should be
+# run after each sessions cleanup
+class CleanUpBaseUsers < ApplicationService
+  def call
+    stale_users = BaseUser.where(user: nil)
+                          .where('not exists (select 1 from sessions s where s.session_id = base_users.session_id)')
+
+    Bookmark.where(base_user: stale_users).delete_all
+
+    run_sql("delete from base_user_preferences where base_user_id in (#{stale_users.select(:id).to_sql})")
+    stale_users.delete_all
+
+    run_sql('optimize table base_users')
+  end
+
+  private
+
+  def run_sql(sql)
+    st = ActiveRecord::Base.connection.raw_connection.prepare(sql)
+    st.execute
+  ensure
+    st.close if st.present?
+  end
+end

--- a/lib/tasks/cleanup_base_users.rake
+++ b/lib/tasks/cleanup_base_users.rake
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+# We periodically run db:cleanup:trim rake task to clean stale session records but it lefts us with hanging
+# BaseUser records.
+# So we need to delete BaseUsers linked to deleted sessions too. This enhance will run base_user cleanup right after
+# each db:sessions:trim call
+Rake::Task['db:sessions:trim'].enhance do
+  CleanUpBaseUsers.call
+end

--- a/spec/factories/base_users.rb
+++ b/spec/factories/base_users.rb
@@ -1,4 +1,33 @@
+# frozen_string_literal: true
+
 FactoryBot.define do
   factory :base_user do
+    session_id { Random.hex(32) if user.nil? }
+
+    trait :registered do
+      user
+    end
+
+    trait :unregistered do
+      # Use this trait if you need a record in sessions table for unregistered user
+      session_id { create(:session).session_id }
+    end
+
+    trait :with_bookmarks do
+      transient do
+        bookmarks_count { 1 }
+      end
+
+      after(:create) do |bu, evaluator|
+        create_list(:bookmark, evaluator.bookmarks_count, base_user: bu)
+      end
+    end
+
+    trait :with_preferences do
+      after(:create) do |bu|
+        bu.set_preference(:fontsize, Random.rand(10..15))
+        bu.set_preference(:accepted_tag_policy, Random.rand(1))
+      end
+    end
   end
 end

--- a/spec/factories/bookmarks.rb
+++ b/spec/factories/bookmarks.rb
@@ -1,5 +1,6 @@
 FactoryBot.define do
   factory :bookmark do
+    manifestation
     base_user { create(:base_user) }
     bookmark_p { 'PATH' }
   end

--- a/spec/factories/sessions.rb
+++ b/spec/factories/sessions.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :session, class: 'ActiveRecord::SessionStore::Session' do
+    session_id { SecureRandom.hex(32) }
+    data { '' }
+  end
+end

--- a/spec/models/base_user_spec.rb
+++ b/spec/models/base_user_spec.rb
@@ -1,25 +1,31 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe BaseUser do
   describe 'validation' do
     context 'when session_id and no user_id are provided' do
-      let(:subject) { build(:base_user, session_id: '123') }
+      subject { build(:base_user, session_id: '123') }
+
       it { is_expected.to be_valid }
     end
 
     context 'when user_id and no session_id are provided' do
-      let(:subject) { build(:base_user, user: create(:user)) }
+      subject { build(:base_user, user: create(:user)) }
+
       it { is_expected.to be_valid }
     end
 
     context 'when both session_id and user_id are provided' do
-      let(:subject) { build(:base_user, user: create(:user), session_id: '123') }
-      it { is_expected.to_not be_valid }
+      subject { build(:base_user, user: create(:user), session_id: '123') }
+
+      it { is_expected.not_to be_valid }
     end
 
     context 'when nor session_id nor user_id are provided' do
-      let(:subject) { build(:base_user) }
-      it { is_expected.to_not be_valid }
+      subject { build(:base_user, user: nil, session_id: nil) }
+
+      it { is_expected.not_to be_valid }
     end
   end
 end

--- a/spec/services/clean_up_base_users_spec.rb
+++ b/spec/services/clean_up_base_users_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe CleanUpBaseUsers do
+  subject(:call) { described_class.call }
+
+  let!(:registered_user) { create(:base_user, :registered, :with_bookmarks, :with_preferences, bookmarks_count: 3) }
+  let!(:stale_users) { create_list(:base_user, 5, :with_bookmarks, :with_preferences, bookmarks_count: 5) }
+
+  let(:new_unregistered_user) do
+    create(:base_user, :unregistered, :with_bookmarks, :with_preferences, bookmarks_count: 3)
+  end
+
+  it 'cleans up unregistered users not having record in sessions table and their bookmarks' do
+    expect { call }.to change(BaseUser, :count).by(-5).and change(Bookmark, :count).by(-25)
+    expect { new_unregistered_user.reload }.not_to raise_error(ActiveRecord::RecordNotFound)
+    expect { registered_user.reload }.not_to raise_error(ActiveRecord::RecordNotFound)
+  end
+end

--- a/spec/support/clean_db.rb
+++ b/spec/support/clean_db.rb
@@ -13,6 +13,7 @@ def clean_tables
   Aboutness.destroy_all
 
   ListItem.destroy_all
+  BaseUser.destroy_all
   User.destroy_all
 
   Manifestation.destroy_all


### PR DESCRIPTION
- Created service to clean up stale base_users.
- Enchanced db:sessions:trim rake task to call this serice after each run

I've 'enchanced' `db:sessions:trim` rake task, to call BaseUsersCleanup after every call, so no need to schedule any new job.

BUT, there is is a problem with a first run. As we need to delete ~8 millions of records from BaseUsers table it takes a while. On my machine with MySQL running in docker it took ~30 minutes.  The problem is that Rails kills transaction due to lock timeout.
And it would be good to not have app running during first run.


To avoid this I propose following workaround:
1. Stop the app
2. Temporarily add
```
timeout: 1000
```
to production connection in `database.yml` (if it still fail with LockTimeout we'll need to increase it, but 1000 worked for me).
3. Run rake `db:sessions:cleanup` once
4. Remove timeout settings from `database.yml`
5. Start app again.

All following invocations of rake task should be quick, as there will not be so much records for deletion.

@abartov , FYI

