### PR TITLE
fixed DropImpressions migration to handle duplicated entries in YearTotals

### DIFF
--- a/db/migrate/20250624185016_drop_impressions.rb
+++ b/db/migrate/20250624185016_drop_impressions.rb
@@ -4,9 +4,17 @@ class DropImpressions < ActiveRecord::Migration[6.1]
   def change
     execute <<~SQL
         insert into year_totals (item_type, item_id, year, total, event, created_at, updated_at)
-        select impressionable_type, impressionable_id, year(updated_at) as year, count(*), 'view', current_timestamp(), current_timestamp() 
-        from impressions 
-        group by impressionable_id, impressionable_type, year(updated_at)
+        select impressionable_type, impressionable_id, year, total_cnt, event, current_timestamp(), current_timestamp() from     
+            (
+                select
+                    impressionable_type, impressionable_id, year(updated_at) as year, count(*) as total_cnt, 'view' as event 
+                from
+                    impressions 
+                group by
+                    impressionable_id, impressionable_type, year(updated_at)
+            ) t
+        on duplicate key update
+            total = total + t.total_cnt, updated_at = current_timestamp()
     SQL
 
     drop_table :impressions


### PR DESCRIPTION
This PR updates migration used to remove Impressions table.
It seems production DB has some records in impressions table for 2024, so when migration tried to compact them in YearTotals we got an unique key violation.

Updated migration will update duplicated entries instead.
