### PR TITLE
Used font-url helper to have properly fingerprinted paths to fonts in CSS

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -512,11 +512,11 @@ small p{
 
 @font-face {
   font-family: "ben-yehuda";
-  src:url("/assets/ben-yehuda2.eot");
-  src:url("/assets/ben-yehuda2.eot?#iefix") format("embedded-opentype"),
-    url("/assets/ben-yehuda2.woff") format("woff"),
-    url("/assets/ben-yehuda2.ttf") format("truetype"),
-    url("/assets/ben-yehuda2.svg#ben-yehuda") format("svg");
+  src:font-url("ben-yehuda2.eot");
+  src:font-url("ben-yehuda2.eot?#iefix") format("embedded-opentype"),
+    font-url("ben-yehuda2.woff") format("woff"),
+    font-url("ben-yehuda2.ttf") format("truetype"),
+    font-url("ben-yehuda2.svg#ben-yehuda") format("svg");
   font-weight: normal;
   font-style: normal;
 

--- a/app/assets/stylesheets/fonts.scss
+++ b/app/assets/stylesheets/fonts.scss
@@ -4,11 +4,11 @@
 
 @font-face {
   font-family: "ben-yehuda-2";
-  src:url("/assets/ben-yehuda-2.eot");
-  src:url("/assets/ben-yehuda-2.eot?#iefix") format("embedded-opentype"),
-    url("/assets/ben-yehuda-2.woff") format("woff"),
-    url("/assets/ben-yehuda-2.ttf") format("truetype"),
-    url("/assets/ben-yehuda-2.svg#ben-yehuda-2") format("svg");
+  src:font-url("ben-yehuda-2.eot");
+  src:font-url("ben-yehuda-2.eot?#iefix") format("embedded-opentype"),
+    font-url("ben-yehuda-2.woff") format("woff"),
+    font-url("ben-yehuda-2.ttf") format("truetype"),
+    font-url("ben-yehuda-2.svg#ben-yehuda-2") format("svg");
   font-weight: normal;
   font-style: normal;
 }


### PR DESCRIPTION
During  migration to Rails 7 I've disabled fallback to assets pipeline in production.
It caused fonts loading failures in prod, as we used not-fingerprinted paths to fonts in css.
To resolve issues I've used `font-url` helper and renamed affected files to scss