### PR TITLE
Added Collections#fix_ordering action

### DIFF
--- a/app/controllers/collections_controller.rb
+++ b/app/controllers/collections_controller.rb
@@ -6,7 +6,7 @@ class CollectionsController < ApplicationController
   include Tracking
 
   before_action :require_editor, except: %i(show download print)
-  before_action :set_collection, only: %i(show edit update destroy drag_item)
+  before_action :set_collection, only: %i(show edit update destroy drag_item fix_ordering)
 
   # GET /collections or /collections.json
   def index
@@ -216,7 +216,43 @@ class CollectionsController < ApplicationController
     end
   end
 
+  # this action ensures all items in collection has unique `seqno` and fix it if necessary, as result all items
+  # in collection will have unique sequential `seqno` values starting from 1 (to resolve collisions it uses sorting
+  # by seqno and id).
+  def fix_ordering
+    Collection.transaction do
+      fix_count = reorder_collection(@collection)
+      redirect_to collection_manage_path(@collection),
+                  notice: (t('.no_collisions_found') if fix_count == 0),
+                  alert: (t('.collissions_fixed', fix_count: fix_count) if fix_count > 0)
+    end
+  end
+
   private
+
+  # This method is used to fix possible collisions in ordering of items inside collection, causing problems
+  # with reordering. It ensures no items with same `seqno` is found inside collection. It also applied recursively
+  # for nested collections.
+  # @param collection - collection to be processed
+  # @return number of fixed collisions (including collisions in nested collections)
+  def reorder_collection(collection)
+    prev_seqno = nil
+    fix_count = 0
+
+    collection.collection_items.order(:seqno, :id).each_with_index do |ci, index|
+      fix_count += 1 if ci.seqno == prev_seqno
+      prev_seqno = ci.seqno
+
+      ci.seqno = index + 1
+      ci.save!
+
+      if ci.item.is_a?(Collection)
+        fix_count += reorder_collection(ci.item)
+      end
+    end
+
+    return fix_count
+  end
 
   # Use callbacks to share common setup or constraints between actions.
   def set_collection

--- a/app/views/collections/manage.html.haml
+++ b/app/views/collections/manage.html.haml
@@ -1,6 +1,13 @@
 %div{ style: 'margin-top: 140px !important;' }
 
 .cwrapper{ id: "cwrapper_#{@collection.id}", 'data-nonce' => 'm', 'data-collection-id' => @collection.id }
+  .row
+    .btn-group
+      = link_to t('.fix_ordering'),
+                fix_ordering_collection_path(@collection),
+                method: :post,
+                class: 'by-button-v02 by-button-secondary-v02'
+
   = render partial: 'shared/manage_collection', locals: { collection: @collection, title: @collection.title, nonce: 'm' }
   .master_insert_container
     #collection_insert_section.coll_insert_section{style: 'display: none; border: 1px solid #660248; background-color: rgb(157 157 241); padding: 10px;  scroll-margin-top: 15px;'}

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -58,6 +58,12 @@ en:
       columns:
         db_intellectual_property: Intellectual property in DB
         has_non_public_domain_authority: Has non public domain authority
+  collections:
+    fix_ordering:
+      no_collisions_found: No problems with ordering found
+      collissions_fixed: "%{fix_count} problems with ordering fixed"
+    manage:
+      fix_ordering: Fix ordering
   ingestibles:
     ingestible_locked: Ingestible locked by user %{user}
     # _authorities partial

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -1399,6 +1399,12 @@ he:
       columns:
         db_intellectual_property: מצב זכויות יוצרים במערכת
         has_non_public_domain_authority: זכויות הישות טרם פקעו
+  collections:
+    fix_ordering:
+      no_collisions_found: No problems with ordering found
+      collissions_fixed: "%{fix_count} problems with ordering fixed"
+    manage:
+      fix_ordering: Fix ordering
   ingestibles:
     ingestible_locked: ההעלאה נעולה לטיפול מידֵי %{user}
     replace_with_authority: החלף ביישות קיימת!

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -40,6 +40,7 @@ Bybeconv::Application.routes.draw do
   resources :collections do
     member do
       post :drag_item
+      post :fix_ordering
     end
 
     post 'transplant_item'

--- a/spec/controllers/collections_controller_spec.rb
+++ b/spec/controllers/collections_controller_spec.rb
@@ -149,5 +149,58 @@ describe CollectionsController do
         it_behaves_like 'drags successfully'
       end
     end
+
+    describe '#fix_ordering' do
+      subject(:call) { post :fix_ordering, params: { id: collection.id } }
+
+      let!(:collection) { create(:collection) }
+
+      context 'when collection has collisions on seqno' do
+        let!(:nested_collection) { create(:collection) }
+
+        let!(:first_item) { create(:collection_item, collection: collection, alt_title: Faker::Book.title, seqno: 2) }
+        let!(:second_item) { create(:collection_item, collection: collection, alt_title: Faker::Book.title, seqno: 2) }
+        let!(:third_item) { create(:collection_item, collection: collection, item: nested_collection, seqno: 3) }
+        let!(:fourth_item) { create(:collection_item, collection: collection, alt_title: Faker::Book.title, seqno: 3) }
+
+        let!(:first_subitem) do
+          create(:collection_item, collection: nested_collection, alt_title: Faker::Book.title, seqno: 1)
+        end
+
+        let!(:second_subitem) do
+          create(:collection_item, collection: nested_collection, alt_title: Faker::Book.title, seqno: 1)
+        end
+
+        it 'fixes ordering and redirects to manage page with alert message' do
+          expect(call).to redirect_to collection_manage_path(collection)
+
+          expect(first_item.reload.seqno).to eq(1)
+          expect(second_item.reload.seqno).to eq(2)
+          expect(third_item.reload.seqno).to eq(3)
+          expect(fourth_item.reload.seqno).to eq(4)
+
+          expect(first_subitem.reload.seqno).to eq(1)
+          expect(second_subitem.reload.seqno).to eq(2)
+
+          expect(flash.alert).to eq I18n.t('collections.fix_ordering.collissions_fixed', fix_count: 3)
+          expect(flash.notice).to be_nil
+        end
+      end
+
+      context 'when collection has no collisions on seqno' do
+        let!(:first_item) { create(:collection_item, collection: collection, alt_title: Faker::Book.title, seqno: 3) }
+        let!(:second_item) { create(:collection_item, collection: collection, alt_title: Faker::Book.title, seqno: 5) }
+
+        it 'fixes gaps in ordering and redirects to manage page with notice message' do
+          expect(call).to redirect_to collection_manage_path(collection)
+
+          expect(first_item.reload.seqno).to eq(1)
+          expect(second_item.reload.seqno).to eq(2)
+
+          expect(flash.alert).to be_nil
+          expect(flash.notice).to eq I18n.t('collections.fix_ordering.no_collisions_found')
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
Added fix_ordering button to collections manage page to fix situations when we have non-unique seqno in collection items.
Such situations make it impossible to correctly reorder items, so we need a way to fix it.

It adds new button to manage page. After clicking on it system will ensure all items in colleciton (and nested subcollections) has unique sequential `seqno` values (starting from 1). So it will also removes all gaps in `seqno` values.

if some collision was found it will display, corresponding message, otherwise it will say that no problems were found (like on screenshot):
<img width="2370" height="829" alt="screenshot" src="https://github.com/user-attachments/assets/3fcaabb8-1f44-4a46-bae9-1f58134ef272" />

NOTE: some new translations to locale file are required.