### PR TITLE
upgraded grape from 1.6.0 to 2.4.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -86,12 +86,10 @@ gem 'momentjs-rails' # for date picker in filters
 gem 'ahoy_matey' # for recording events
 gem 'blazer' # for exploring Ahoy events
 
-gem 'grape', '1.6.0' # 1.6.1 adds a Validators module damisul's patch isn't ready for
-gem 'grape-entity', '~> 0.10.1'
-# TODO: Replace to standard version of gem after PR will be accepted https://github.com/jagaapple/grape-extra_validators/pull/10
-gem 'grape-extra_validators', '~> 2.1.0', git: 'https://github.com/damisul/grape-extra_validators'
-gem 'grape-swagger', '~> 1.4.2'
-gem 'grape-swagger-entity', '~> 0.5.1'
+gem 'grape', '~> 2.4.0'
+gem 'grape-entity', '~> 1.0.1'
+gem 'grape-swagger', '~> 2.1.2'
+gem 'grape-swagger-entity', '~> 0.6.2'
 
 gem 'puma'
 gem 'puma_worker_killer' # cycle workers when they bloat

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,12 +1,4 @@
 GIT
-  remote: https://github.com/damisul/grape-extra_validators
-  revision: 26f125aa6d9fa85548b5724ab84d604b7151d13d
-  specs:
-    grape-extra_validators (2.1.0)
-      activesupport
-      grape (>= 1.0.0)
-
-GIT
   remote: https://github.com/jquery-ui-rails/jquery-ui-rails
   revision: 7ca2fdba43405c6f593be52a792fac3ea9d24d4b
   specs:
@@ -147,10 +139,10 @@ GEM
       aws-eventstream (~> 1, >= 1.0.2)
     base64 (0.3.0)
     bcrypt_pbkdf (1.1.1)
-    benchmark (0.4.0)
+    benchmark (0.4.1)
     benchmark-ips (2.14.0)
     better_sjr (1.0.0)
-    bigdecimal (3.1.9)
+    bigdecimal (3.2.2)
     bindex (0.8.1)
     blazer (3.0.4)
       activerecord (>= 6.1)
@@ -228,7 +220,7 @@ GEM
       rubyzip (~> 2.0)
     domain_name (0.6.20240107)
     dotenv (3.1.8)
-    drb (2.2.1)
+    drb (2.2.3)
     dry-core (1.1.0)
       concurrent-ruby (~> 1.0)
       logger
@@ -239,7 +231,7 @@ GEM
       concurrent-ruby (~> 1.0)
       dry-core (~> 1.1)
       zeitwerk (~> 2.6)
-    dry-types (1.8.2)
+    dry-types (1.8.3)
       bigdecimal (~> 3.0)
       concurrent-ruby (~> 1.0)
       dry-core (~> 1.0)
@@ -294,21 +286,21 @@ GEM
       terminal-table (>= 1.5.1)
     globalid (1.2.1)
       activesupport (>= 6.1)
-    grape (1.6.0)
-      activesupport
-      builder
+    grape (2.4.0)
+      activesupport (>= 6.1)
       dry-types (>= 1.1)
-      mustermann-grape (~> 1.0.0)
-      rack (>= 1.3.0)
-      rack-accept
-    grape-entity (0.10.2)
+      mustermann-grape (~> 1.1.0)
+      rack (>= 2)
+      zeitwerk
+    grape-entity (1.0.1)
       activesupport (>= 3.0.0)
       multi_json (>= 1.3.2)
-    grape-swagger (1.4.2)
-      grape (~> 1.3)
-    grape-swagger-entity (0.5.3)
-      grape-entity (>= 0.6.0)
-      grape-swagger (>= 1.2.0)
+    grape-swagger (2.1.2)
+      grape (>= 1.7, < 3.0)
+      rack-test (~> 2)
+    grape-swagger-entity (0.6.2)
+      grape-entity (~> 1)
+      grape-swagger (~> 2)
     haml (6.3.0)
       temple (>= 0.8.2)
       thor
@@ -414,12 +406,12 @@ GEM
       momentjs-rails (>= 2.10.5, <= 3.0.0)
     momentjs-rails (2.29.4.1)
       railties (>= 3.1)
-    multi_json (1.15.0)
+    multi_json (1.17.0)
     multi_xml (0.7.2)
       bigdecimal (~> 3.1)
     mustermann (3.0.3)
       ruby2_keywords (~> 0.0.1)
-    mustermann-grape (1.0.2)
+    mustermann-grape (1.1.0)
       mustermann (>= 1.0.0)
     mutex_m (0.3.0)
     mysql2 (0.5.6)
@@ -540,8 +532,6 @@ GEM
     raabro (1.4.0)
     racc (1.8.1)
     rack (2.2.17)
-    rack-accept (0.4.5)
-      rack (>= 0.4)
     rack-attack (6.7.0)
       rack (>= 1.0, < 4)
     rack-cors (2.0.2)
@@ -828,11 +818,10 @@ DEPENDENCIES
   faker (~> 2.19.0)
   gared (>= 0.1.2)
   gepub
-  grape (= 1.6.0)
-  grape-entity (~> 0.10.1)
-  grape-extra_validators (~> 2.1.0)!
-  grape-swagger (~> 1.4.2)
-  grape-swagger-entity (~> 0.5.1)
+  grape (~> 2.4.0)
+  grape-entity (~> 1.0.1)
+  grape-swagger (~> 2.1.2)
+  grape-swagger-entity (~> 0.6.2)
   haml
   haml-rails
   haml_lint (~> 0.57.0)

--- a/app/api/v1/api.rb
+++ b/app/api/v1/api.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-Grape::Validations.register_validator('v1_auth_key', V1::Validations::AuthKey)
-
 module V1
   # Rest API v1
   class Api < ApplicationApi

--- a/app/api/v1/application_api.rb
+++ b/app/api/v1/application_api.rb
@@ -1,14 +1,12 @@
 # frozen_string_literal: true
 
-Grape::Validations.register_validator('v1_auth_key', V1::Validations::AuthKey)
-
 # Absrtract base class for all V1 API implementations
 module V1
   # Base class for application APIs v1
   class ApplicationApi < Grape::API
     helpers do
       params :key_param do
-        requires :key, type: String, v1_auth_key: true
+        requires :key, type: String, auth_key: true
       end
     end
 

--- a/app/api/v1/entities/authority.rb
+++ b/app/api/v1/entities/authority.rb
@@ -19,11 +19,11 @@ module V1
                documentation: { desc: 'semicolon-separated list of additional names or spellings for this authority' }
         expose :intellectual_property, documentation: { values: ::Authority.intellectual_properties.keys }
         expose :person,
-               using: Api::V1::Entities::Person,
+               using: V1::Entities::Person,
                expose_nil: false,
                documentation: { desc: 'person-specific data (omitted for corporate bodies)' }
         expose :corporate_body,
-               using: Api::V1::Entities::CorporateBody,
+               using: V1::Entities::CorporateBody,
                expose_nil: false,
                documentation: { desc: 'corporate bodies-specific data (omitted for people)' }
         expose :wikipedia_snippet, as: :bio_snippet

--- a/app/api/v1/texts_api.rb
+++ b/app/api/v1/texts_api.rb
@@ -41,7 +41,7 @@ module V1
         params do
           requires :ids,
                    type: [Integer],
-                   maximum_length: 25,
+                   length: { max: 25 },
                    allow_blank: false,
                    desc: 'array of text IDs to fetch',
                    documentation: { param_type: 'body' }

--- a/app/api/v1/validations/auth_key.rb
+++ b/app/api/v1/validations/auth_key.rb
@@ -3,7 +3,7 @@
 module V1
   module Validations
     # Auth key check
-    class AuthKey < Grape::Validations::Base
+    class AuthKey < Grape::Validations::Validators::Base
       class AuthFailed < StandardError; end
 
       def validate_param!(attr_name, params)

--- a/config/locales/grape.he.yml
+++ b/config/locales/grape.he.yml
@@ -1,0 +1,5 @@
+he:
+  grape:
+    errors:
+      messages:
+        length_max: 'is expected to have length less than or equal to %{max}'

--- a/config/locales/grape.he.yml
+++ b/config/locales/grape.he.yml
@@ -2,4 +2,4 @@ he:
   grape:
     errors:
       messages:
-        length_max: 'is expected to have length less than or equal to %{max}'
+        length_max: 'חייב להיות באורך %{max} תווים או פחות'

--- a/spec/api/v1/authorities_api_spec.rb
+++ b/spec/api/v1/authorities_api_spec.rb
@@ -9,17 +9,15 @@ describe V1::AuthoritiesApi do
     subject(:call) { get path }
 
     let(:detail) { 'metadata' }
-    let(:authority_id) { -1 }
+    let(:authority_id) { 100_001 }
     let(:path) { "/api/v1/authorities/#{authority_id}?key=#{key}&author_detail=#{detail}" }
 
     include_context 'API Key Check'
 
     context 'when wrong id provided' do
-      let(:authority_id) { -1 }
-
       it 'fails with Not Found status' do
         expect(call).to eq 404
-        expect(error_message).to eq "Couldn't find Authority with 'id'=-1"
+        expect(error_message).to eq "Couldn't find Authority with 'id'=100001"
       end
     end
 

--- a/spec/support/shared_examples/api_key_validation.rb
+++ b/spec/support/shared_examples/api_key_validation.rb
@@ -1,6 +1,6 @@
 RSpec.shared_examples 'Unauthorized API call' do
   it 'fails with unauthorized status' do
-    expect(subject).to eq 401
+    expect(call).to eq 401
     expect(error_message).to eq 'key not found or disabled'
   end
 end


### PR DESCRIPTION
removed grape_extra_validators dependency and replaced it with new standard validators, introduced in grape 2.x

I've did a quick test and it seems to work. The only difference is that wording in a case of validation error is changed (translation required)