### PR TITLE
reorganized i18n of genre values

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -360,7 +360,7 @@ class ApplicationController < ActionController::Base
     author.each do |genre|
       next unless genre[1].class == Array # skip the :latest key
 
-      worksbuf = "<strong>#{I18n.t(genre[0])}:</strong> "
+      worksbuf = "<strong>#{textify_genre(genre[0])}:</strong> "
       first = true
       genre[1].each do |m|
         title = m.expression.title

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -67,7 +67,7 @@ module ApplicationHelper
   def textify_genre(genre)
     return I18n.t(:unknown) if genre.nil? or genre.empty?
 
-    return I18n.t(genre)
+    return I18n.t("genre_values.#{genre}")
   end
 
   def textify_intellectual_property(value)

--- a/app/views/authors/_browse_filters.html.haml
+++ b/app/views/authors/_browse_filters.html.haml
@@ -36,7 +36,8 @@
              locals: { group_name: :genre,
                        title: t(:genres),
                        field_name: :ckb_genres,
-                       all_values: get_genres,
+                       all_values: Work::GENRES,
+                       labels: Work::GENRES.index_with { |genre| textify_genre(genre) },
                        selected_values: @genres,
                        facet: @genre_facet,
                        icons: Work::GENRES.index_with { |g| glyph_for_genre(g) } }

--- a/app/views/authors/_toc_node.html.haml
+++ b/app/views/authors/_toc_node.html.haml
@@ -7,7 +7,7 @@
     - w = e.work
     - genre = w.genre
     %span.sorting-metadata{ 'data-impressions': m.impressions_count, 'data-title': m.sort_title, 'data-pubdate': e.normalized_pub_date.present? ? e.normalized_pub_date.to_date.jd : nil, 'data-creation-date': w.normalized_creation_date.present? ? w.normalized_creation_date.to_date.jd : nil, 'data-upload-date': m.publication_date.to_date.jd }
-    %span.by-icon-v02{ title: t(genre) }>= glyph_for_genre(genre)
+    %span.by-icon-v02{ title: textify_genre(genre) }>= glyph_for_genre(genre)
     &nbsp;&rlm;
     :ruby
       label = m.title

--- a/app/views/authors/edit_toc.html.haml
+++ b/app/views/authors/edit_toc.html.haml
@@ -13,7 +13,7 @@
     .right
       = t(:toc_order_reminder)
       - get_genres.each do |g|
-        = textify_genre(g)+'; '
+        = textify_genre(g) + '; '
       = t(:translation)
       %br
       %b.by-button-v02#add_work_link{style:'display:inline;width:200px'}= t(:add_work_link)

--- a/app/views/html_file/_form.html.haml
+++ b/app/views/html_file/_form.html.haml
@@ -15,7 +15,9 @@
     = f.text_field :title, required: true
   .backend-field
     = f.label t(:genre)
-    = select_tag 'html_file[genre]', options_for_select(get_genres.map {|genre| [I18n.t(genre), genre]}, @text.genre), {include_blank: true}
+    = select_tag 'html_file[genre]',
+                 options_for_select(get_genres.map { |genre| [textify_genre(genre), genre] }, @text.genre),
+                 { include_blank: true }
   .backend-field
     = f.label t(:first_author)
     %br

--- a/app/views/html_file/edit_markdown.html.haml
+++ b/app/views/html_file/edit_markdown.html.haml
@@ -32,7 +32,9 @@
           %b= label_tag t(:orig_lang)
           = select_tag 'orig_lang', options_for_select(get_langs.map {|lang| [textify_lang(lang), lang]}, @text.orig_lang)
           %b= label_tag(:genre, t(:genre))
-          = select_tag(:genre, options_for_select(get_genres.map {|genre| [I18n.t(genre), genre]}, @text.genre), {include_blank: true})
+          = select_tag(:genre,
+                       options_for_select(Work::GENRES.map { |genre| [textify_genre(genre), genre] }, @text.genre),
+                       { include_blank: true })
       .row
         .col-md-12
           .markdown_container.row

--- a/app/views/ingestibles/_form.html.haml
+++ b/app/views/ingestibles/_form.html.haml
@@ -73,7 +73,7 @@
           = f.hidden_field :status, value: @ingestible.status
         %h2= t('ingestible.defaults')
         = f.label t(:genre)
-        - genres = [[t(:mixed_genres), 'mixed']]+get_genres.map {|genre| [I18n.t(genre), genre]}
+        - genres = (['mixed'] + Work::GENRES).map { |genre| [textify_genre(genre), genre] }
         = f.select :genre, options_for_select(genres, @ingestible.genre), {include_blank: true}
         = f.label t(:publisher)
         = f.text_field :publisher, style: 'width:400px;'

--- a/app/views/manifestation/_browse_filters.html.haml
+++ b/app/views/manifestation/_browse_filters.html.haml
@@ -63,7 +63,8 @@
              locals: { group_name: :genre,
                        title: t(:genres),
                        field_name: :ckb_genres,
-                       all_values: get_genres,
+                       all_values: Work::GENRES,
+                       labels: Work::GENRES.index_with { |genre| textify_genre(genre) },
                        selected_values: @genres,
                        facet: @genre_facet,
                        icons: Work::GENRES.index_with { |g| glyph_for_genre(g) } }

--- a/app/views/manifestation/edit_metadata.html.haml
+++ b/app/views/manifestation/edit_metadata.html.haml
@@ -8,7 +8,9 @@
       = text_field_tag :wtitle, @w.title, size: 75
     %p
       %b= t(:genre) + ': '
-      = select_tag :genre, options_for_select(get_genres.map {|genre| [I18n.t(genre), genre]}, @w.genre), {include_blank: true}
+      = select_tag :genre,
+                   options_for_select(Work::GENRES.map { |genre| [textify_genre(genre), genre] }, @w.genre),
+                   { include_blank: true }
     %p
       %b= t(:primary) + ': '
       = select_tag :primary, options_for_select([[t(:yes), 'true'], [t(:false), 'false']], @w.primary.to_s)

--- a/app/views/manifestation/whatsnew.html.haml
+++ b/app/views/manifestation/whatsnew.html.haml
@@ -20,7 +20,7 @@
                       - works.each do |genre|
                         - next if genre[0] == :latest
                         %p
-                          %b= t(genre[0])+': '
+                          %b= textify_genre(genre[0]) + ': '
                           - worksbuf = genre[1].map{ |m| link_to(m.expression.title + (m.expression.translation ? ' / '+m.authors_string : ''), url_for(controller: :manifestation, action: :read, id: m.id))}
                           - worksbuf = worksbuf.join('; ')
                           != worksbuf

--- a/app/views/shared/_tabs.html.haml
+++ b/app/views/shared/_tabs.html.haml
@@ -39,10 +39,10 @@
             %a.by-nav-item-v02#nav-genres{'data-toggle' =>'dropdown', 'data-boundary' => 'ddgenres', tabindex: '3'}= t(:genres)
             .by-dropdown-content-v02.dropdown-menu#menu-genres
               .by-dropdown-header-v02= combined_totals
-              - get_genres.each do |g|
+              - Work::GENRES.each do |g|
                 %a{href: manifestation_genre_path(genre: g)}
                   %span.by-icon-v02= glyph_for_genre(g)
-                  = t(g)
+                  = textify_genre(g)
                   %span{style:'color:black'}= " - #{Manifestation.cached_work_counts_by_genre[g]} #{t(:works)}"
               .by-dropdown-divider
               %a{href: translations_path}
@@ -148,11 +148,11 @@
         %li.topMenuItemMobile-v02
           %span.caret= t(:genres)
           %ul.nested
-            - get_genres.each do |g|
+            - Work::GENRES.each do |g|
               %li
                 %a{href: manifestation_genre_path(genre: g)}
                   %span.by-icon-v02.iconInMenu= glyph_for_genre(g)
-                  = t(g)
+                  = textify_genre(g)
                   %span{style:'color:black; font-weight: normal;'}= " - #{Manifestation.cached_work_counts_by_genre[g]} #{t(:works)}"
             .by-dropdown-divider
             %li

--- a/app/views/welcome/_works.html.haml
+++ b/app/views/welcome/_works.html.haml
@@ -12,7 +12,7 @@
           %a{href: manifestation_genre_path(genre: 'lexicon')}
             .genre-nav
               %p.by-genre-icon-v02= 'f'
-              %p.by-genre-name-v02.headline-2-v02= t(:lexicon)
+              %p.by-genre-name-v02.headline-2-v02= textify_genre('lexicon')
               %p.by-genre-details-v02= @authors_in_genre['lexicon'].to_s+' '+t(:authors)
               %p.by-genre-details-v02= get_total_headwords.to_s.to_s+' '+t(:entries)
         -#.by-card-content-seapartor

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -176,6 +176,17 @@ en:
       periodical: to periodical
       periodical_issue: to issue
       series: to whole series
+  genre_values:
+    poetry: Poetry
+    prose: Prose
+    article: Article
+    drama: Drama
+    memoir: Memoir
+    letters: Letters
+    reference: Reference
+    lexicon: Lexicon
+    fables: Fable
+    mixed: Mixed
   intellectual_property:
     public_domain: public domain
     by_permission: by permission

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -169,7 +169,6 @@ he:
   ltr: משמאל לימין
   parse: הסבה
   remove_line_nums: הסר מספרי שורות
-  fables: משלים
   analyze: אבחן
   crowdsourcing: העבודה והמלאכה
   crowdsourcing_intro: את פרויקט בן־יהודה בונות ובונים מתנדבות ומתנדבים כמוך! הנה כמה משימות שבהן אנו זקוקים לעזרה. בכל משימה יש הדרכה מפורטת, והכל בלי התחייבות ובלי הגבלות זמן.
@@ -373,15 +372,6 @@ he:
   # genre key names are currently hard-coded in ApplicationController
   genres: סוגות
   genres_and_types: סוגות וסוגים
-  poetry: שירה
-  prose: פרוזה
-  article: מאמרים ומסות
-  drama: מחזות
-  memoir: זכרונות ויומנים
-  letters: מכתבים
-  reference: עיון
-  lexicon: מילונים ולקסיקונים
-  mixed_genres: סוגות שונות
   # end genres
   anth_grows: המקראה צומחת!
   most_popular_works_this_month: היצירות הנקראות ביותר החודש
@@ -1587,7 +1577,17 @@ he:
       periodical: לתצוגת כתב העת
       periodical_issue: לתצוגת הגליון
       series: לתצוגת המחזור/שער כולו
-
+  genre_values:
+    poetry: שירה
+    prose: פרוזה
+    article: מאמרים ומסות
+    drama: מחזות
+    memoir: זכרונות ויומנים
+    letters: מכתבים
+    reference: עיון
+    lexicon: מילונים ולקסיקונים
+    fables: משלים
+    mixed: סוגות שונות
   intellectual_property:
     public_domain: נחלת הכלל
     by_permission: מוגש ברשות פרסום


### PR DESCRIPTION
While working on Lexicon branch I've faced one problem: we have `lexicon` genre and new lexicon-related entities.
It caused conflicts in i18n file, as genre values was declared as the top-level resources.

I've moved all genres i18n strings to be under new `genre_values` node and replaced all direct usage of i18n with `textify_genre` helper. 
