### PR TITLE
Authorities and Manifestation autocomplete tweaks

### DIFF
--- a/app/controllers/admin/featured_contents_controller.rb
+++ b/app/controllers/admin/featured_contents_controller.rb
@@ -25,16 +25,15 @@ module Admin
       end
     end
 
-    def show
-      return unless @fc.nil?
-
-      flash[:error] = I18n.t(:no_such_item)
-      redirect_to url_for(action: :index)
-    end
+    def show; end
 
     def edit; end
 
     def update
+      # We have few legacy records in DB where `user` is null, and it caused validation failures during update
+      # To avoid this, we set user to current_user if it is empty
+      @fc.user = current_user if @fc.user.nil?
+
       if @fc.update(fc_params)
         flash.notice = I18n.t(:updated_successfully)
         redirect_to admin_featured_content_path(@fc)

--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -10,7 +10,6 @@ class AdminController < ApplicationController
                          merge_tagging approve_tagging reject_tagging escalate_tagging tag_moderation tag_review)
   before_action :require_admin, only: %i(manifestation_batch_tools destroy_manifestation unpublish_manifestation)
   # before_action :require_admin, only: [:missing_languages, :missing_genres, :incongruous_copyright, :missing_copyright, :similar_titles]
-  autocomplete :manifestation, :title, display_value: :title_and_authors, extra_data: [:expression_id] # TODO: also search alternate titles!
   autocomplete :person, :name, scopes: :with_name, full: true
   autocomplete :collection, :title, full: true, display_value: :title_and_authors
   autocomplete :publication, :title
@@ -45,9 +44,19 @@ class AdminController < ApplicationController
 
   def autocomplete_authority_name_and_aliases
     wildcard = "%#{params[:term]}%"
-    render json: Authority.where('name like ? OR other_designation like ?', wildcard, wildcard).map { |au|
-                   { id: au.id, label: au.name, value: au.name }
-                 }
+    items = Authority.where('name like ? OR other_designation like ?', wildcard, wildcard).limit(10)
+
+    render json: json_for_autocomplete(items, :name)
+  end
+
+  def autocomplete_manifestation_title
+    wildcard = "%#{params[:term]}%"
+
+    items = Manifestation.where('title like ? or alternate_titles like ?', wildcard, wildcard)
+                         .with_involved_authorities
+                         .limit(10)
+
+    render json: json_for_autocomplete(items, :title_and_authors, [:expression_id])
   end
 
   ##############################################

--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -11,7 +11,6 @@ class AdminController < ApplicationController
   before_action :require_admin, only: %i(manifestation_batch_tools destroy_manifestation unpublish_manifestation)
   # before_action :require_admin, only: [:missing_languages, :missing_genres, :incongruous_copyright, :missing_copyright, :similar_titles]
   autocomplete :manifestation, :title, display_value: :title_and_authors, extra_data: [:expression_id] # TODO: also search alternate titles!
-  autocomplete :authority, :name, full: true
   autocomplete :person, :name, scopes: :with_name, full: true
   autocomplete :collection, :title, full: true, display_value: :title_and_authors
   autocomplete :publication, :title

--- a/app/controllers/manifestation_controller.rb
+++ b/app/controllers/manifestation_controller.rb
@@ -14,7 +14,6 @@ class ManifestationController < ApplicationController
     c.refuse_unreasonable_page
   end
   autocomplete :manifestation, :title, limit: 20, display_value: :title_and_authors, full: true
-  autocomplete :authority, :name, limit: 2, full: true
   autocomplete :tag, :name, limit: 2
 
   # layout false, only: [:print]
@@ -24,6 +23,7 @@ class ManifestationController < ApplicationController
 
   #############################################
   # public actions
+  #############################################
   def all
     @page_title = t(:all_works) + ' ' + t(:project_ben_yehuda)
     @pagetype = :works
@@ -97,6 +97,17 @@ class ManifestationController < ApplicationController
       flash[:error] = t(:no_such_item)
       redirect_to '/'
     end
+  end
+
+  # Endpoint used to select authority in search filters (can be used by not authenticated visitors)
+  # It differs from admin#autocomplete_authority_name_and_aliases by:
+  #   - does not require editor access rights
+  #   - only shows published authors
+  def autocomplete_authority_name
+    wildcard = "%#{params[:term]}%"
+    items = Authority.published.where('name like ? OR other_designation like ?', wildcard, wildcard).limit(10)
+
+    render json: json_for_autocomplete(items, :name, {})
   end
 
   def autocomplete_works_by_author

--- a/app/views/admin/featured_contents/_form.html.haml
+++ b/app/views/admin/featured_contents/_form.html.haml
@@ -15,7 +15,7 @@
     = f.input :authority do
       = autocomplete_field_tag :authority_autocomplete,
                                fc.authority&.name,
-                               autocomplete_authority_name_path,
+                               autocomplete_authority_name_and_aliases_path,
                                id_element: '#featured_content_authority_id',
                                class: 'form-control',
                                data: { noMatchesLabel: t(:no_matches_found) }

--- a/app/views/bib/pubs_by_authority.html.haml
+++ b/app/views/bib/pubs_by_authority.html.haml
@@ -34,7 +34,7 @@
         .backend-field
           = label_tag t(:linked_author)
           = hidden_field_tag :authority_id
-          = autocomplete_field_tag :authority, '', autocomplete_authority_name_path,
+          = autocomplete_field_tag :authority, '', autocomplete_authority_name_and_aliases_path,
                                    id_element: '#authority_id', scopes: [:bib_not_done],
                                    'data-noMatchesLabel' => t(:no_matches_found)
         = link_to t(:new_person), authors_new_path(type: :person)

--- a/app/views/ingestibles/_form.html.haml
+++ b/app/views/ingestibles/_form.html.haml
@@ -37,7 +37,13 @@
               %b.btn-text-v02= t(:edit)
           .volume-details{style: vid.present? ? 'display:none;' : ''}
             = f.label t('ingestible.volume_by_author')
-            = autocomplete_field_tag :author, '', autocomplete_authority_name_path, 'data-noMatchesLabel' => t(:no_matches_found), id: 'aterm', style: 'width:400px;', id_element: '#authority_id'
+            = autocomplete_field_tag :author,
+                                     '',
+                                     autocomplete_authority_name_and_aliases_path,
+                                     'data-noMatchesLabel' => t(:no_matches_found),
+                                     id: 'aterm',
+                                     style: 'width:400px;',
+                                     id_element: '#authority_id'
             = hidden_field_tag :authority_id, value: '', id: 'authority_id'
             = f.check_box :no_volume
             = f.label t('ingestible.no_volume')

--- a/app/views/involved_authorities/_list.html.haml
+++ b/app/views/involved_authorities/_list.html.haml
@@ -16,7 +16,7 @@
   - unless item.involved_authorities.any?
     %h3= t(:associated_persons)
   = t(:add)
-  = autocomplete_field_tag "#{prefix}_autocomplete", '', autocomplete_authority_name_path,
+  = autocomplete_field_tag "#{prefix}_autocomplete", '', autocomplete_authority_name_and_aliases_path,
                           id_element: "##{prefix}_authority_id", style: 'background-color:white;'
   = hidden_field_tag "#{prefix}_authority_id"
   = t(:in_role)

--- a/app/views/manifestation/list.html.haml
+++ b/app/views/manifestation/list.html.haml
@@ -20,7 +20,7 @@
             /= text_field_tag(:author, session[:mft_q_params][:author])
             = autocomplete_field_tag :author,
                                      session[:mft_q_params][:author],
-                                     autocomplete_authority_name_path,
+                                     autocomplete_authority_name_and_aliases_path,
                                      data: { noMatchesLabel: t(:no_matches_found) }
             = submit_tag(t(:filter))
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -162,7 +162,7 @@ Bybeconv::Application.routes.draw do
   get 'autocomplete_manifestation_title' => 'admin#autocomplete_manifestation_title',
       as: 'autocomplete_manifestation_title'
   get 'autocomplete_person_name' => 'admin#autocomplete_person_name', as: 'autocomplete_person_name'
-  get 'autocomplete_authority_name' => 'admin#autocomplete_authority_name', as: 'autocomplete_authority_name'
+
   get 'autocomplete_tag_name' => 'application#autocomplete_tag_name_name', as: 'autocomplete_tag_name'
   get 'autocomplete_dict_entry' => 'manifestation#autocomplete_dict_entry', as: 'autocomplete_dict_entry'
   get 'admin/featured_author_list'


### PR DESCRIPTION
- Modified all places where we use `autocomplete_authority_name` endpoint to use `autocomplete_authority_name_and_aliases`, and removed first endpoint.
- Updated autocompletion on manifestaion browse filter to also autocomplete by name and aliases, but also added filter by `authority.status` = `published` (I believe on browse form we should not show not yet published authors)
- Updated `autocomplete_manifestation_title` endpoint to also search by `alternate_titles` field

Also I've added a workaround for situation when we try to edit `FeaturedContent` record and it has `user` = null (we have few such records, probably a legacy ones). Such situation started to cause failures after upgrade to Rails 7+ (as `belongs_to` become mandatory). To fix that I set `user` to `current user` if we try to update `FeaturedContent` with `user` = null.