### PR TITLE
removed secret_token.rb initializer (deprecated since Rails 4.1)

### DIFF
--- a/config/constants.yml.sample
+++ b/config/constants.yml.sample
@@ -8,7 +8,6 @@ development: &default
   twitter_consumer_key: 'bla'
   twitter_consumer_secret: 'bla'
   project_honeypot_api_key: 'bla'
-  secret_key_base: 'bla'
   our_publisher: 'name to put in Manifestation entities'
   our_place_of_publication: 'yourdomain.com'
   google_cse_cx: 'your CSE code'

--- a/config/initializers/secret_token.rb
+++ b/config/initializers/secret_token.rb
@@ -1,7 +1,0 @@
-# Be sure to restart your server when you modify this file.
-
-# Your secret key for verifying the integrity of signed cookies.
-# If you change this key, all old signed cookies will become invalid!
-# Make sure the secret is at least 30 characters and all random,
-# no regular words or you'll be exposed to dictionary attacks.
-Bybeconv::Application.config.secret_key_base = Rails.configuration.constants['secret_key_base']


### PR DESCRIPTION
This file set SECRET_KEY_BASE value, but this approach is deprecated

In production we use value from Rails credentials.

In development enviroment this value can be set in file `tmp/local_secret.txt`

Removed this file to avoid confusion (and probably it is the source of problems after upgrading to Rails 7.2)