### PR TITLE
Use match_phrase_prefix operator for autocomplete fields

### DIFF
--- a/app/chewy/authorities_autocomplete_index.rb
+++ b/app/chewy/authorities_autocomplete_index.rb
@@ -4,7 +4,7 @@
 class AuthoritiesAutocompleteIndex < Chewy::Index
   index_scope Authority.all
   field :id, type: 'integer'
-  field :name
-  field :other_designation
+  field :name, type: 'search_as_you_type'
+  field :other_designation, type: 'search_as_you_type'
   field :published, type: 'boolean', value: ->(a) { a.published? }
 end

--- a/app/chewy/manifestations_autocomplete_index.rb
+++ b/app/chewy/manifestations_autocomplete_index.rb
@@ -4,8 +4,8 @@
 class ManifestationsAutocompleteIndex < Chewy::Index
   index_scope Manifestation.with_involved_authorities
   field :id, type: 'integer'
-  field :title
-  field :alternate_titles
+  field :title, type: 'search_as_you_type'
+  field :alternate_titles, type: 'search_as_you_type'
   field :title_and_authors
   field :expression_id, type: 'integer' # Not sure if we need this, but it was returned by SQL autocomplete
   field :published, type: 'boolean', value: ->(m) { m.published? }

--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -43,13 +43,13 @@ class AdminController < ApplicationController
   end
 
   def autocomplete_authority_name_and_aliases
-    term = "*#{params[:term]}*"
+    term = params[:term]
 
     items = AuthoritiesAutocompleteIndex.query(
       bool: {
         should: [
-          { wildcard: { name: { value: term, case_insensitive: true } } },
-          { wildcard: { other_designation: { value: term, case_insensitive: true } } }
+          { match_phrase_prefix: { name: { query: term } } },
+          { match_phrase_prefix: { other_designation: { query: term } } }
         ],
         minimum_should_match: 1
       }
@@ -59,13 +59,13 @@ class AdminController < ApplicationController
   end
 
   def autocomplete_manifestation_title
-    term = "*#{params[:term]}*"
+    term = params[:term]
 
     items = ManifestationsAutocompleteIndex.query(
       bool: {
         should: [
-          { wildcard: { title: { value: term, case_insensitive: true } } },
-          { wildcard: { alternate_titles: { value: term, case_insensitive: true } } }
+          { match_phrase_prefix: { title: { query: term } } },
+          { match_phrase_prefix: { alternate_titles: { query: term } } }
         ],
         minimum_should_match: 1
       }

--- a/app/controllers/manifestation_controller.rb
+++ b/app/controllers/manifestation_controller.rb
@@ -104,13 +104,13 @@ class ManifestationController < ApplicationController
   #   - does not require editor access rights
   #   - only shows published authors
   def autocomplete_authority_name
-    term = "*#{params[:term]}*"
+    term = params[:term]
 
     items = AuthoritiesAutocompleteIndex.filter([{ term: { published: true } }]).query(
       bool: {
         should: [
-          { wildcard: { name: { value: term, case_insensitive: true } } },
-          { wildcard: { other_designation: { value: term, case_insensitive: true } } }
+          { match_phrase_prefix: { name: { query: term } } },
+          { match_phrase_prefix: { other_designation: { query: term } } }
         ],
         minimum_should_match: 1
       }

--- a/spec/requests/admin_spec.rb
+++ b/spec/requests/admin_spec.rb
@@ -7,7 +7,7 @@ describe '/admin' do
     subject(:call) { get '/autocomplete_authority_name_and_aliases?term=TeSt' }
 
     let(:match_1) { create(:authority, status: :published, name: 'First Test') }
-    let(:match_2) { create(:authority, status: :published, name: 'X', other_designation: 'second_test') }
+    let(:match_2) { create(:authority, status: :published, name: 'X', other_designation: 'second test') }
     let(:match_3) { create(:authority, status: :unpublished, name: 'test 3') }
     let(:no_match) { create(:authority, status: :published, name: 'Y', other_designation: 'Z') }
 
@@ -47,7 +47,7 @@ describe '/admin' do
 
       it 'returns a list of matching authorities including not published' do
         expect(call).to eq(200)
-        expect(response.parsed_body).to eq(expected_response)
+        expect(response.parsed_body).to match_array(expected_response)
       end
     end
   end
@@ -56,7 +56,7 @@ describe '/admin' do
     subject(:call) { get '/autocomplete_manifestation_title?term=TeSt' }
 
     let(:match_1) { create(:manifestation, status: :published, title: 'First Test') }
-    let(:match_2) { create(:manifestation, status: :published, title: 'X', alternate_titles: 'second_test') }
+    let(:match_2) { create(:manifestation, status: :published, title: 'X', alternate_titles: 'second test') }
     let(:match_3) { create(:manifestation, status: :nonpd, title: 'test 3') }
     let(:no_match) { create(:manifestation, status: :published, title: 'Y', alternate_titles: 'Z') }
 
@@ -111,7 +111,7 @@ describe '/admin' do
 
       it 'returns a list of matching authorities including not published' do
         expect(call).to eq(200)
-        expect(response.parsed_body).to eq(expected_response)
+        expect(response.parsed_body).to match_array(expected_response)
       end
     end
   end

--- a/spec/requests/manifestaion_spec.rb
+++ b/spec/requests/manifestaion_spec.rb
@@ -4,10 +4,12 @@ require 'rails_helper'
 
 describe '/manifestation' do
   describe 'GET /manifestation/autocomplete_authority_name' do
-    subject(:call) { get '/manifestation/autocomplete_authority_name?term=TeSt' }
+    subject(:call) { get "/manifestation/autocomplete_authority_name?term=#{term}" }
+
+    let(:term) { 'TeSt' }
 
     let(:match_1) { create(:authority, status: :published, name: 'First Test') }
-    let(:match_2) { create(:authority, status: :published, name: 'X', other_designation: 'second_test') }
+    let(:match_2) { create(:authority, status: :published, name: 'X', other_designation: 'second test') }
     let(:no_match_unpublished) { create(:authority, status: :unpublished, name: 'test 3') }
     let(:no_match_published) { create(:authority, status: :published, name: 'Y', other_designation: 'Z') }
 
@@ -33,7 +35,22 @@ describe '/manifestation' do
 
     it 'returns a list of matching published authorities' do
       expect(call).to eq(200)
-      expect(response.parsed_body).to eq(expected_response)
+      expect(response.parsed_body).to match_array(expected_response)
+    end
+
+    context 'when there is a whitespace in term' do
+      let(:term) { 'SECOND tE' }
+
+      let(:expected_response) do
+        [
+          { 'id' => match_2.id.to_s, 'label' => match_2.name, 'value' => match_2.name }
+        ]
+      end
+
+      it 'returns a list of matching published authorities' do
+        expect(call).to eq(200)
+        expect(response.parsed_body).to eq(expected_response)
+      end
     end
   end
 end


### PR DESCRIPTION
- use match_phrase_prefix operator instead of wildcard match for autocomplete endpoints.
- optimized ES indices used for autocomplete to use `search_as_you_type` datatype instead of plain string for searchable fields