### PR TITLE
ElasticsearchAutocomplete service.

### DIFF
--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -43,33 +43,21 @@ class AdminController < ApplicationController
   end
 
   def autocomplete_authority_name_and_aliases
-    term = params[:term]
-
-    items = AuthoritiesAutocompleteIndex.query(
-      bool: {
-        should: [
-          { match_phrase_prefix: { name: { query: term } } },
-          { match_phrase_prefix: { other_designation: { query: term } } }
-        ],
-        minimum_should_match: 1
-      }
-    ).limit(10).to_a
+    items = ElasticsearchAutocomplete.call(
+      params[:term],
+      AuthoritiesAutocompleteIndex,
+      %i(name other_designation)
+    )
 
     render json: json_for_autocomplete(items, :name)
   end
 
   def autocomplete_manifestation_title
-    term = params[:term]
-
-    items = ManifestationsAutocompleteIndex.query(
-      bool: {
-        should: [
-          { match_phrase_prefix: { title: { query: term } } },
-          { match_phrase_prefix: { alternate_titles: { query: term } } }
-        ],
-        minimum_should_match: 1
-      }
-    ).limit(10).to_a
+    items = ElasticsearchAutocomplete.call(
+      params[:term],
+      ManifestationsAutocompleteIndex,
+      %i(title alternate_titles)
+    )
 
     render json: json_for_autocomplete(items, :title_and_authors, [:expression_id])
   end

--- a/app/controllers/manifestation_controller.rb
+++ b/app/controllers/manifestation_controller.rb
@@ -104,17 +104,12 @@ class ManifestationController < ApplicationController
   #   - does not require editor access rights
   #   - only shows published authors
   def autocomplete_authority_name
-    term = params[:term]
-
-    items = AuthoritiesAutocompleteIndex.filter([{ term: { published: true } }]).query(
-      bool: {
-        should: [
-          { match_phrase_prefix: { name: { query: term } } },
-          { match_phrase_prefix: { other_designation: { query: term } } }
-        ],
-        minimum_should_match: 1
-      }
-    ).limit(10).to_a
+    items = ElasticsearchAutocomplete.call(
+      params[:term],
+      AuthoritiesAutocompleteIndex,
+      %i(name other_designation),
+      filter: { term: { published: true } }
+    )
 
     render json: json_for_autocomplete(items, :name)
   end

--- a/app/services/application_service.rb
+++ b/app/services/application_service.rb
@@ -2,7 +2,7 @@
 # Exposes class method 'call', which creates new instance of service object and calls it with provided arguments.
 # So instead of 'MyService.new.call(x, y)' we can use 'MyService.call(x, y)'
 class ApplicationService
-  def self.call(*args, &block)
-    new.call(*args, &block)
+  def self.call(...)
+    new.call(...)
   end
 end

--- a/app/services/elasticsearch_autocomplete.rb
+++ b/app/services/elasticsearch_autocomplete.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+# Service to do autocomplete lookups using ElasticSearch indices
+class ElasticsearchAutocomplete < ApplicationService
+  # @param term string to look for
+  # @param index_class - class representing Chewy Index to use for search
+  # @param fields - array of field names in index to search term in
+  # @param filter (Hash or Array of Hashes) - optional ElasticSearch filter clause to do additional filtering of records
+  # @param limit - max number of records to return
+  # @return array of index_class instances matching provided term
+  def call(term, index_class, fields, filter: nil, limit: 10)
+    return [] if term.blank?
+
+    should = fields.map { |f| { match_phrase_prefix: { f => { query: term } } } }
+
+    query = index_class.send(:query, bool: { should: should, minimum_should_match: 1 })
+    query = query.filter(filter) if filter.present?
+    query.limit(limit).to_a
+  end
+end

--- a/spec/requests/manifestaion_spec.rb
+++ b/spec/requests/manifestaion_spec.rb
@@ -37,20 +37,5 @@ describe '/manifestation' do
       expect(call).to eq(200)
       expect(response.parsed_body).to match_array(expected_response)
     end
-
-    context 'when there is a whitespace in term' do
-      let(:term) { 'SECOND tE' }
-
-      let(:expected_response) do
-        [
-          { 'id' => match_2.id.to_s, 'label' => match_2.name, 'value' => match_2.name }
-        ]
-      end
-
-      it 'returns a list of matching published authorities' do
-        expect(call).to eq(200)
-        expect(response.parsed_body).to eq(expected_response)
-      end
-    end
   end
 end

--- a/spec/services/elasticsearch_autocomplete_spec.rb
+++ b/spec/services/elasticsearch_autocomplete_spec.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe ElasticsearchAutocomplete do
+  subject(:call) { described_class.call(term, index_class, fields, filter: filter) }
+
+  let(:index_class) { AuthoritiesAutocompleteIndex }
+  let(:returned_ids) { call.map(&:id) }
+  let(:fields) { %i(name other_designation) }
+
+  let(:match_1) { create(:authority, status: :published, name: 'First Test') }
+  let(:match_2) { create(:authority, status: :published, name: 'X', other_designation: 'second test') }
+  let(:match_3) { create(:authority, status: :unpublished, name: 'test 3') }
+  let(:no_match) { create(:authority, status: :published, name: 'Y', other_designation: 'Z') }
+  let(:filter) { nil }
+
+  before do
+    Chewy.strategy(:atomic) do
+      match_1
+      match_2
+      match_3
+      no_match
+    end
+  end
+
+  after do
+    Chewy.massacre
+  end
+
+  context 'when term is blank' do
+    let(:term) { '  ' }
+
+    it { is_expected.to be_empty }
+  end
+
+  context 'when term is provided' do
+    let(:term) { 'TeSt' }
+
+    it 'returns matching records' do
+      expect(returned_ids).to contain_exactly(match_1.id, match_2.id, match_3.id)
+    end
+
+    context 'when filter by published status is provided' do
+      let(:filter) { { term: { published: true } } }
+
+      it 'returns matching published records' do
+        expect(returned_ids).to contain_exactly(match_1.id, match_2.id)
+      end
+    end
+
+    context 'when term contains whitespaces' do
+      let(:term) { 'second t' }
+
+      it 'returns matching records' do
+        expect(returned_ids).to contain_exactly(match_2.id)
+      end
+    end
+
+    context 'when only one field provided' do
+      let(:fields) { [:name] }
+
+      it 'returns matching records using only one field' do
+        expect(returned_ids).to contain_exactly(match_1.id, match_3.id)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Extracted common logic for elasticsearch-based autocomplete into ElasticsearchAutocomplete service to reduce code duplication
