### PR TITLE
Author page refactoring

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -340,21 +340,6 @@ class ApplicationController < ActionController::Base
     authors
   end
 
-  def cached_textify_titles(manifestations, au)
-    Rails.cache.fetch("textify_titles_#{au.id}", expires_in: 12.hours) do # memoize
-      textify_titles(manifestations)
-    end
-  end
-
-  def textify_titles(manifestations)
-    # translations will be marked as translations, without mentioning the author names, for performance reasons
-    titles = Manifestation.preload(:expression).find(manifestations.pluck(:id)).map do |m|
-      appendix = m.expression.translation ? " (#{I18n.t(:translation)})" : ''
-      "<a href=\"#{url_for(controller: :manifestation, action: :read, id: m.id)}\">#{m.title}</a>#{appendix}"
-    end
-    titles.join('; ')
-  end
-
   def textify_new_pubs(author)
     ret = ''
     author.each do |genre|

--- a/app/controllers/authors_controller.rb
+++ b/app/controllers/authors_controller.rb
@@ -339,7 +339,6 @@ class AuthorsController < ApplicationController
     @published_xlats = @author.translations.count
     @total_orig_works = @author.manifestations(:author).count
     @total_xlats = @author.manifestations(:translator).count
-    @aboutnesses = @author.aboutnesses
 
     if @author.nil?
       flash[:error] = t(:no_such_item)
@@ -474,9 +473,8 @@ class AuthorsController < ApplicationController
 
       @og_image = @author.profile_image.url(:thumb)
       @featured = @author.featured_work
-      @aboutnesses = @author.aboutnesses
       @external_links = @author.external_links.status_approved
-      @any_curated = @featured.present? || @aboutnesses.count > 0
+      @any_curated = @featured.present? || !@author.aboutnesses.empty?
       unless @featured.empty?
         (@fc_snippet, @fc_rest) = snippet(@featured[0].body, 500) # prepare snippet for collapsible
       end

--- a/app/controllers/authors_controller.rb
+++ b/app/controllers/authors_controller.rb
@@ -480,7 +480,7 @@ class AuthorsController < ApplicationController
       unless @featured.empty?
         (@fc_snippet, @fc_rest) = snippet(@featured[0].body, 500) # prepare snippet for collapsible
       end
-      @taggings = @author.taggings
+      @taggings = @author.taggings.preload(:tag)
 
       @credits = render_to_string(partial: 'authors/credits', locals: { author: @author })
       if @author.toc.present?

--- a/app/models/authority.rb
+++ b/app/models/authority.rb
@@ -287,13 +287,7 @@ class Authority < ApplicationRecord
   end
 
   def latest_stuff
-    published_manifestations(:author, :translator).order(created_at: :desc).limit(20).to_a
-  end
-
-  def cached_latest_stuff
-    Rails.cache.fetch("au_#{id}_latest_stuff", expires_in: 24.hours) do
-      latest_stuff
-    end
+    published_manifestations(:author, :translator).order(created_at: :desc).limit(20)
   end
 
   def cached_original_works_by_genre

--- a/app/models/authority.rb
+++ b/app/models/authority.rb
@@ -107,7 +107,7 @@ class Authority < ApplicationRecord
   end
 
   def approved_tags
-    approved_taggings.joins(:tag).where(tag: { status: Tag.statuses[:approved] }).map(&:tag)
+    approved_taggings.joins(:tag).preload(:tag).where(tag: { status: Tag.statuses[:approved] }).map(&:tag)
   end
 
   def approved_taggings

--- a/app/models/manifestation.rb
+++ b/app/models/manifestation.rb
@@ -374,11 +374,8 @@ class Manifestation < ApplicationRecord
 
   def self.cached_work_counts_by_genre
     Rails.cache.fetch('m_count_by_genre', expires_in: 24.hours) do
-      ret = {}
-      get_genres.each do |g|
-        ret[g] = Manifestation.all_published.genre(g).distinct.count
-      end
-      ret
+      counts = Manifestation.published.joins(expression: :work).group(work: :genre).count
+      Work::GENRES.index_with { |g| counts[g] || 0 }
     end
   end
 

--- a/app/views/authors/_aboutnesses.html.haml
+++ b/app/views/authors/_aboutnesses.html.haml
@@ -1,19 +1,19 @@
-- if @aboutnesses.count > 0
+- unless author.aboutnesses.empty?
   .by-card-v02.left-side-card-v02
     .by-card-header-left-v02
-      %span.headline-1-v02= t(:works_about_this_author, gender_suffix: @author.person&.gender == 'female' ? '/ת' : '')
+      %span.headline-1-v02= t(:works_about_this_author, gender_suffix: author.person&.gender == 'female' ? '/ת' : '')
     .by-card-content-v02
       %div
         %div
           %ul.ul-inside
-            - @aboutnesses.each do |ab|
+            - author.aboutnesses.each do |ab|
               - m = ab.work.expressions[0].manifestations[0] # TODO: handle multiple expressions/manifestations intelligently
               - if m.published? # Only show published works
                 %li
                   = link_to ab.work.expressions[0].title, work_show_path(id: ab.work_id)
-                  = ' / '+m.authors_string
+                  = ' / ' + m.authors_string
                   - if ab.work.expressions[0].translation
-                    = ' / '+m.translators_string
+                    = ' / ' + m.translators_string
       -#.link-to-all-v02
       -#  %a.notyet
       -#    %span.linkcolor{:style => "font-weight: bold"}= t(:to_full_list)

--- a/app/views/authors/show.html.haml
+++ b/app/views/authors/show.html.haml
@@ -126,7 +126,7 @@
         - if @total_xlats != @published_xlats
           = " #{t(:published)} + #{@total_xlats - @published_xlats} #{t(:unpublished)}"
         %br
-        = render partial: 'aboutnesses'
+        = render partial: 'aboutnesses', locals: { author: @author }
       %td
         %p
           = image_tag @author.profile_image.url(:thumb), alt: @author.name

--- a/app/views/authors/toc.html.haml
+++ b/app/views/authors/toc.html.haml
@@ -110,19 +110,7 @@
                   = t(:latest_updates)
                   -#= link_to t(:latest_updates), whatsnew_path # TODO: re-enable when main whatsnew can be filtered by author
               .by-card-content-v02
-                .new-card-v02.last-item
-                  -#.new-info-v02 !
-                  .new-card-right-v02
-                    .new-card-type-v02 q
-                  .new-card-left-v02
-                    %p.headline-2-v02
-                      %span.new-headline-v02= t(:latest_added_works, gender_letter: @author.gender_letter)
-                    %p.text-height-new#clamped_author_whatsnew
-                      != @latest
-                  .link-to-all-v02#author_latest_popup_link{style: 'display:none'}
-                    .author_latest_popup_button.linkcolor.pointer
-                      %span{:style => "font-weight: bold"}= t(:to_latest_x_works, x: @author.cached_latest_stuff.count)
-                      %span.left-arrow 1
+                = render partial: 'shared/latest_works_by_author', locals: { author: @author }
           - unless @featured.empty?
             - featured = @featured[0]
             .by-card-v02.flash-work-v02
@@ -208,16 +196,7 @@
   = render partial: 'shared/anth_stuff'
 
 :javascript
-  $(document).ready(function(){
-    var offsetTop = #{ @readmode ? 40 : 250 };
-    if(is_clamped('clamped_author_whatsnew')) {
-      $('#author_latest_popup_link').show();
-      $('.author_latest_popup_button').click(function(e){
-        e.stopPropagation();
-        $('#generalDlg').load("#{ author_latest_popup_path(id: @author.id) }");
-        $('#generalDlg').modal('show');
-      });
-    }
+  $(function() {
     $('.all_links_btn').click(function(e){
       e.preventDefault();
       $('#generalDlg').load("#{author_links_popup_path(id: @author.id)}");

--- a/app/views/authors/toc.html.haml
+++ b/app/views/authors/toc.html.haml
@@ -157,7 +157,7 @@
                     .metadata-link-icon.small-icon.pointer &amp;
                     %div= t(:suggest_new_tag)
           
-          = render partial: 'aboutnesses', cached: true
+          = render partial: 'aboutnesses', cached: true, locals: { author: @author }
           - if @external_links.count > 0
             - cache "au_#{@author.id}_links", expires_in: 24.hours do
               .by-card-v02.left-side-card-v02

--- a/app/views/shared/_latest_works_by_author.html.haml
+++ b/app/views/shared/_latest_works_by_author.html.haml
@@ -1,7 +1,7 @@
 = cache author, expires_in: 12.hours do
   - latest_stuff = author.latest_stuff.preload(:expression).to_a
   .new-card-v02.last-item
-    -#.new-info-v02 !
+    -# .new-info-v02 !
     .new-card-right-v02
       .new-card-type-v02 q
     .new-card-left-v02
@@ -13,9 +13,9 @@
           = link_to manifestation.title, manifestation_path(manifestation)
           = " (#{I18n.t(:translation)})" if manifestation.expression.translation?
           ;
-    .link-to-all-v02#author_latest_popup_link{style: 'display:none'}
+    .link-to-all-v02#author_latest_popup_link{ style: 'display:none;' }
       .author_latest_popup_button.linkcolor.pointer
-        %span{:style => "font-weight: bold"}= t('.to_latest_x_works', x: latest_stuff.count)
+        %span{ style: 'font-weight: bold;' }= t('.to_latest_x_works', x: latest_stuff.count)
         %span.left-arrow 1
 :javascript
   $(function() {
@@ -23,7 +23,7 @@
       $('#author_latest_popup_link').show();
       $('.author_latest_popup_button').click(function(e){
         e.stopPropagation();
-        $('#generalDlg').load("#{ author_latest_popup_path(author) }");
+        $('#generalDlg').load("#{author_latest_popup_path(author)}");
         $('#generalDlg').modal('show');
       });
     }

--- a/app/views/shared/_latest_works_by_author.html.haml
+++ b/app/views/shared/_latest_works_by_author.html.haml
@@ -1,0 +1,30 @@
+= cache author, expires_in: 12.hours do
+  - latest_stuff = author.latest_stuff.preload(:expression).to_a
+  .new-card-v02.last-item
+    -#.new-info-v02 !
+    .new-card-right-v02
+      .new-card-type-v02 q
+    .new-card-left-v02
+      %p.headline-2-v02
+        %span.new-headline-v02= t('.latest_added_works', gender_letter: author.gender_letter)
+      %p.text-height-new#clamped_author_whatsnew
+        -# translations will be marked as translations, without mentioning the author names, for performance reasons
+        - latest_stuff.each do |manifestation|
+          = link_to manifestation.title, manifestation_path(manifestation)
+          = " (#{I18n.t(:translation)})" if manifestation.expression.translation?
+          ;
+    .link-to-all-v02#author_latest_popup_link{style: 'display:none'}
+      .author_latest_popup_button.linkcolor.pointer
+        %span{:style => "font-weight: bold"}= t('.to_latest_x_works', x: latest_stuff.count)
+        %span.left-arrow 1
+:javascript
+  $(function() {
+    if(is_clamped('clamped_author_whatsnew')) {
+      $('#author_latest_popup_link').show();
+      $('.author_latest_popup_button').click(function(e){
+        e.stopPropagation();
+        $('#generalDlg').load("#{ author_latest_popup_path(author) }");
+        $('#generalDlg').modal('show');
+      });
+    }
+  });

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -18,6 +18,7 @@ en:
   updated_successfully: Updated Successfully
   deleted_successfully: Deleted Successfully
   original_works: Original Works
+  translation: Translation
   translations: Translations
   edited_works: Edited Works
   alefbet: Alphabetical
@@ -100,6 +101,9 @@ en:
       intro: "Please check ordering of items in following collections:"
       n_problems_fixed: "%{n} problems fixed"
   shared:
+    latest_works_by_author:
+      latest_added_works: latest works published in the project
+      to_latest_x_works: to latest %{x} works
     filters:
       pagination:
         page_x_of_total: Page %{page} of %{total}

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -6,10 +6,8 @@ he:
   not_public_yet: '(עדיין לא פומבי)'
   author_list: רשימת היוצרים
   first_last_name: "שם פרטי / משפחה"
-  to_latest_x_works: הצג %{x} יצירות אחרונות
   don_footer_title: אנו שמחים שאתם משתמשים באתר פרויקט בן־יהודה
   don_footer_mobile_text: רוב מוחלט של העבודה נעשה בהתנדבות, אולם אנו צריכים לממן שירותי אירוח ואחסון, פיתוח תוכנה, אפיון ממשק משתמש, ועיצוב גרפי. נשמח אם תעזרו לנו להמשיך לשרת אתכם!
-
   don_footer_desktop_html: עד כה העלינו למאגר %{total_works} יצירות מאת %{total_authors} יוצרים, בעברית ובתרגום מ־%{total_langs} שפות. העלינו גם %{total_headwords} ערכים מילוניים. רוב מוחלט של העבודה נעשה בהתנדבות, אולם אנו צריכים לממן שירותי אירוח ואחסון, פיתוח תוכנה, אפיון ממשק משתמש, ועיצוב גרפי. <br /> <br /> בזכות תרומות מהציבור הוספנו לאחרונה אפשרות ליצירת מקראות הניתנות לשיתוף עם חברים או תלמידים, <a href="/page/api">ממשק API לגישה ממוכנת לאתר</a>, ואנו עובדים על פיתוחים רבים נוספים, כגון הוספת כתבי עת עבריים, לרבות עכשוויים. <br /><br /> נשמח אם תעזרו לנו להמשיך לשרת אתכם!
   contact_name: שם
   contact_email: דואל
@@ -713,7 +711,6 @@ he:
   new_author: יוצר חדש
   latest_facebook: עדכונים אחרונים בעמוד הפייסבוק
   latest_updates: עדכונים אחרונים
-  latest_added_works: יצירותי%{gender_letter} האחרונות שראו אור בפרויקט
   insert_all_siblings: הכנסת כל הפריטים האחים מרמה זו פנימה
   focus_on_this_collection: ניהול אוסף זה
   collapse_collection: קיפול/פריסת האוסף
@@ -1490,6 +1487,9 @@ he:
     list:
       select_authority: נא לבחור ישות אחראית
   shared:
+    latest_works_by_author:
+      latest_added_works: יצירותי%{gender_letter} האחרונות שראו אור בפרויקט
+      to_latest_x_works: הצג %{x} יצירות אחרונות
     manage_collection:
       select_manifestation: יש לבחור יצירה להלן
     manage_toc:


### PR DESCRIPTION
I've did some refactoring on Author page to easier reuse this functionality on Lexicon pages:
- extracted block used to show latest works by author into a partial: `shared/_latest_works_by_author`
- modified `author/_aboutnesses` partial to use local variables instead of member vars

Also it contains couple of speed improvements:
- added preloading of tagging tags to avoid N+1 problem
- optimized Manifestation.cached_works_count_by_genre to use single query with group by instead of separate query by each genre
