### PR TITLE
replaced jquery_ujs js lib with rails_ujs

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -5,7 +5,7 @@
 // the compiled file.
 //
 //= require jquery
-//= require jquery_ujs
+//= require rails-ujs
 //= require jquery-ui
 //= require jquery.slick
 //= require jquery-ui/widgets/autocomplete


### PR DESCRIPTION
This switch should have been done during Rails 5.1 migration.

I've did some quick testing and it seems to work, but some additional testing is welcome.

See referenced issue for details