### PR TITLE
Removed root collection type

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -435,15 +435,6 @@ class ApplicationController < ActionController::Base
 
   def prep_toc_as_collection
     @top_nodes = GenerateTocTree.call(@author)
-
-    # @root_collection = @author.obtain_root_collection
-    # @toc = @author.toc # may be nil
-    # credits = @author.toc.credit_section || ''
-    # credits.sub!(
-    #   '## הגיהו',
-    #   "<div class=\"by-horizontal-seperator-light\"></div>\n\n## הגיהו") unless credits =~ /by-horizontal/
-    # )
-    # @credits = MultiMarkdown.new(credits).to_html.force_encoding('UTF-8')
   end
 
   def mention_skipped

--- a/app/controllers/collections_controller.rb
+++ b/app/controllers/collections_controller.rb
@@ -196,16 +196,6 @@ class CollectionsController < ApplicationController
 
   def manage
     @collection = Collection.find(params[:collection_id])
-    if @collection.nil?
-      flash[:error] = t(:no_such_item)
-      redirect_to admin_index_path
-    elsif @collection.root? # switch to side-by-side view with legacy author TOC for root collections (for now)
-      @author = Authority.find_by(root_collection_id: @collection.id)
-      if @author.present?
-        redirect_to authors_manage_toc_path(id: @author.id)
-        return
-      end
-    end
   end
 
   private

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -327,13 +327,11 @@ module ApplicationHelper
 
   def collection_types_options
     Collection.collection_types
-              .reject { |x| x == 'root' }
               .map { |k, _v| [textify_collection_type(k), k] }
   end
 
   def collection_item_types_options
     Collection.collection_types
-              .reject { |x| x == 'root' }
               .map { |k, _v| [textify_collection_type(k), k] } +
       [
         [t(:work), 'Manifestation'],

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -4,7 +4,7 @@
 class Collection < ApplicationRecord
   include TrackingEvents
 
-  SYSTEM_TYPES = %w(uncollected root).freeze
+  SYSTEM_TYPES = %w(uncollected).freeze
 
   include RecordWithInvolvedAuthorities
 
@@ -51,7 +51,6 @@ class Collection < ApplicationRecord
     periodical: 1,
     periodical_issue: 2,
     series: 3,
-    root: 4,
     other: 5,
     uncollected: 100
   }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -187,7 +187,6 @@ en:
       periodical: Periodical
       periodical_issue: Periodical Issue
       series: Series
-      root: Root
       other: Other
       uncollected: Uncollected works
     up_link:

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -1570,7 +1570,6 @@ he:
       periodical: כתב עת
       periodical_issue: גליון
       series: סדרה, מחזור, או שער
-      root: כלל היצירה של אדם או גוף
       other: אחר
       uncollected: יצירות שלא כונסו
     up_link:

--- a/db/migrate/20250925100631_remove_root_collection_id_from_authorities.rb
+++ b/db/migrate/20250925100631_remove_root_collection_id_from_authorities.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class RemoveRootCollectionIdFromAuthorities < ActiveRecord::Migration[8.0]
+  def change
+    remove_column :authorities, :root_collection_id, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_07_10_064800) do
+ActiveRecord::Schema[8.0].define(version: 2025_09_25_100631) do
   create_table "aboutnesses", id: :integer, charset: "utf8mb4", collation: "utf8mb4_bin", force: :cascade do |t|
     t.integer "work_id"
     t.integer "user_id"
@@ -160,7 +160,6 @@ ActiveRecord::Schema[7.1].define(version: 2025_07_10_064800) do
     t.string "wikidata_uri"
     t.integer "person_id"
     t.integer "corporate_body_id"
-    t.integer "root_collection_id"
     t.integer "uncollected_works_collection_id"
     t.integer "legacy_toc_id"
     t.text "legacy_credits"
@@ -170,7 +169,6 @@ ActiveRecord::Schema[7.1].define(version: 2025_07_10_064800) do
     t.index ["intellectual_property"], name: "index_authorities_on_intellectual_property"
     t.index ["name"], name: "index_authorities_on_name"
     t.index ["person_id"], name: "index_authorities_on_person_id", unique: true
-    t.index ["root_collection_id"], name: "index_authorities_on_root_collection_id"
     t.index ["sort_name"], name: "index_authorities_on_sort_name"
     t.index ["status", "published_at"], name: "index_authorities_on_status_and_published_at"
     t.index ["toc_id"], name: "people_toc_id_fk"
@@ -727,7 +725,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_07_10_064800) do
     t.index ["task_id"], name: "index_publications_on_task_id"
   end
 
-  create_table "reading_lists", charset: "utf8mb4", collation: "utf8mb4_bin", force: :cascade do |t|
+  create_table "reading_lists", charset: "latin1", force: :cascade do |t|
     t.string "title"
     t.integer "user_id"
     t.integer "access"
@@ -938,7 +936,6 @@ ActiveRecord::Schema[7.1].define(version: 2025_07_10_064800) do
   add_foreign_key "anthologies", "users"
   add_foreign_key "anthology_texts", "anthologies"
   add_foreign_key "anthology_texts", "manifestations"
-  add_foreign_key "authorities", "collections", column: "root_collection_id"
   add_foreign_key "authorities", "collections", column: "uncollected_works_collection_id"
   add_foreign_key "authorities", "corporate_bodies"
   add_foreign_key "authorities", "people"

--- a/spec/models/authority_spec.rb
+++ b/spec/models/authority_spec.rb
@@ -18,33 +18,6 @@ describe Authority do
       expect(a).to be_valid
     end
 
-    describe 'root collection type validation' do
-      let(:authority) { build(:authority, root_collection: root_collection) }
-
-      context 'when root collection is not set' do
-        let(:root_collection) { nil }
-
-        it { expect(authority).to be_valid }
-      end
-
-      context 'when root collection is set and has root type' do
-        let(:root_collection) { create(:collection, collection_type: :root) }
-
-        it { expect(authority).to be_valid }
-      end
-
-      context 'when root collection is set but has wrong type' do
-        let(:root_collection) { create(:collection) }
-
-        it 'fails validation' do
-          expect(authority).not_to be_valid
-          expect(authority.errors[:root_collection]).to eq [
-            I18n.t('activerecord.errors.models.authority.wrong_collection_type', expected_type: :root)
-          ]
-        end
-      end
-    end
-
     describe 'uncollected works collection type validation' do
       let(:authority) { build(:authority, uncollected_works_collection: uncollected_works_collection) }
 


### PR DESCRIPTION
Removed all leftovers of `root` collection type and dropped `Authorites.root_collection_id` column.
We replaced it with autogenerated TOC tree.

P.S. I've checked my db copy beforehand and there were no existing records with 'root' type, but I would doublechecked on production