### PR TITLE
Fixed encoding and collation for reading_lists table

### DIFF
--- a/db/migrate/20251001092328_change_reading_lists_encoding.rb
+++ b/db/migrate/20251001092328_change_reading_lists_encoding.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class ChangeReadingListsEncoding < ActiveRecord::Migration[8.0]
+  def change
+    execute 'ALTER TABLE reading_lists CHARACTER SET "utf8mb4" COLLATE "utf8mb4_bin"'
+    execute 'ALTER TABLE reading_lists MODIFY title varchar(255) CHARACTER SET "utf8mb4" COLLATE "utf8mb4_bin"'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_09_25_100631) do
+ActiveRecord::Schema[8.0].define(version: 2025_10_01_092328) do
   create_table "aboutnesses", id: :integer, charset: "utf8mb4", collation: "utf8mb4_bin", force: :cascade do |t|
     t.integer "work_id"
     t.integer "user_id"
@@ -725,7 +725,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_09_25_100631) do
     t.index ["task_id"], name: "index_publications_on_task_id"
   end
 
-  create_table "reading_lists", charset: "latin1", force: :cascade do |t|
+  create_table "reading_lists", charset: "utf8mb4", collation: "utf8mb4_bin", force: :cascade do |t|
     t.string "title"
     t.integer "user_id"
     t.integer "access"


### PR DESCRIPTION
This PR fixes wrong encoding and collation for READING_LISTS table we have on production server.