### PR TITLE
Docker test-app

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -6,7 +6,7 @@ This codebase runs https://benyehuda.org -- the Project Ben-Yehuda digital libra
 
 ## Technology Stack
 
-- **Ruby Version**: 3.3.8
+- **Ruby Version**: 3.3.9
 - **Rails Version**: 8.0.2.1
 - **Database**: MySQL (mysql2 gem)
 - **Testing Framework**: RSpec with FactoryBot
@@ -23,7 +23,7 @@ This codebase runs https://benyehuda.org -- the Project Ben-Yehuda digital libra
 - Maximum line length: 120 characters
 - Maximum method length: 100 lines
 - Maximum class length: 1500 lines
-- Target Ruby version: 3.3.8
+- Target Ruby version: 3.3.9
 - Use rubocop-rails, rubocop-rspec, and rubocop-factory_bot plugins
 
 ### Important Style Notes
@@ -41,15 +41,18 @@ This codebase runs https://benyehuda.org -- the Project Ben-Yehuda digital libra
 - RuboCop integration enabled (except Layout/SpaceInsideParens)
 
 ### Running Linters
-```bash
-# Check single file with RuboCop
-rubocop <path_to_file>
 
-# Auto-correct with safe corrections
-rubocop -a <path_to_file>
+Use `pronto` gem to only lint lines of code changed in given PR
 
-# Check changes only (via Pronto)
-pronto run -c origin/master
+```shell
+# Check changes only (via Pronto) compared to master branch
+bundle exec pronto run -c origin/master
+```
+
+if PR is intended to be merged in a different branch (not a master) use:
+```shell
+# Check changes only (via Pronto) compared to given branch
+bundle exec pronto run -c origin/<TARGET_BRANCH>
 ```
 
 ## Testing Guidelines
@@ -62,6 +65,7 @@ pronto run -c origin/master
 - Up to 20 memoized helpers allowed per spec
 
 ## Common Patterns and Best Practices
+
 
 ### Hebrew Text Handling
 - Always consider right-to-left (RTL) text direction
@@ -78,7 +82,7 @@ pronto run -c origin/master
 ### Controllers
 - Use `before_action` for authorization checks
 - Common authorization methods: `require_editor`, `require_admin`, `require_user`
-- Flash messages use I18n: `flash[:notice] = t(:updated_successfully)`
+- Flash messages use I18n: `flash.notice = t(:updated_successfully)`
 
 ### Models and Associations
 - Property sets are used for key/value properties via the property_sets gem
@@ -133,10 +137,13 @@ Section titles like "שירה" (poetry), "פרוזה" (prose), "מאמרים ו�
 
 ## When Making Changes
 
-1. Run RuboCop on files you modify: `rubocop <path_to_file>`
-2. Use RuboCop auto-correct when appropriate: `rubocop -a <path_to_file>`
-3. Write RSpec tests for new functionality
-4. Consider the impact on Hebrew text rendering and RTL layout
-5. Check for N+1 queries when adding database queries
-6. Update related tests when modifying existing functionality
-7. Use Pronto to check only your changes: `pronto run -c origin/master`
+1. Create a separate branch to work in, never direcly push to master branch.
+1. Consider the impact on Hebrew text rendering and RTL layout
+1. Check for N+1 queries when adding database queries
+1. Write RSpec tests for new functionality
+1. Update related tests when modifying existing functionality
+1. Run rspec using our docker-compose setup `docker compose run --rm test-app rspec`
+1. Use Pronto to lint only your changes: `bundle exec pronto run -c origin/<BRANCH TO MERGE INTO>`
+1. Use RuboCop auto-correct when appropriate: `bundle exec rubocop -a <path_to_file>`
+1. Create a draft PR to merge your changes into a master (or into some other branch if specified explicitely) branch.
+1. Ensure all CI checks are completed successfully.

--- a/README.docker.md
+++ b/README.docker.md
@@ -5,6 +5,19 @@ This document describes our development docker configuration.
 We assume that application itself will be run in host system natively, docker is used to only host services used by app:
 database, elasticsearch, cache, etc.
 
+In some sitations (e.g. when working with CodePilot) we may need an ability to run tests on application. To simplify
+this `docker-compose.yml` declares special service `test-app`
+
+So to run all specs in application you may use command:
+```shell
+docker compose run --rm test-app
+```
+
+Or to run specific spec:
+```shell
+docker compose run --rm test-app rspec <PATH_TO_SPEC>
+```
+
 ## Preparing development environment with docker
 
 ### 1. Installing docker

--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ pronto run -c origin/master
 will run linters only on lines of code which were changed compared to `origin/master` branch. Our CI pipeline uses
 this approach for all PRs.
 
+NOTE: to run pronto tool you need to run `bundle install` first.
+
 License
 -------
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,6 @@
 volumes:
   mysql_data:
+  bundler_data:
   elasticsearch_data:
 services:
   mysql:
@@ -43,3 +44,36 @@ services:
     restart: unless-stopped
     ports:
       - 16379:6379
+  test-app:
+    build:
+      context: .
+      dockerfile: docker/Dockerfile.test
+    command: rspec
+    environment:
+      - RAILS_ENV=test
+    volumes:
+      - ./.git:/app/.git
+      - ./.gitignore:/app/.gitignore
+      - ./app:/app/app
+      - ./bin:/app/bin
+      - ./config:/app/config
+      - ./config/constants.yml.sample:/app/config/constants.yml
+      - ./config/s3.yml.sample:/app/config/s3.yml
+      - ./config/storage.yml.sample:/app/config/storage.yml
+      - ./db:/app/db
+      - ./js:/app/js
+      - ./lib:/app/lib
+      - ./spec:/app/spec
+      - ./vendor:/app/vendor
+      - ./Gemfile:/app/Gemfile
+      - ./Gemfile.lock:/app/Gemfile.lock
+      - ./Rakefile:/app/Rakefile
+      - ./config.ru:/app/config.ru
+      - ./docker/.env.test-app:/app/.env
+      - ./docker/test-app.sh:/app/test-app.sh
+      - bundler_data:/usr/local/bundle/:delegated
+    depends_on:
+      - mysql
+      - redis
+      - elasticsearch
+    restart: no

--- a/docker/.env.test-app
+++ b/docker/.env.test-app
@@ -1,0 +1,4 @@
+# Configuration to be used by test-app declared in Dockerfile (to run specs by CodePilot)
+ELASTICSEARCH_HOST=elasticsearch:9200
+DATABASE_URL=mysql2://root:root@mysql:3306/bybe_test
+REDIS_URL=redis://redis:6379/1

--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -1,0 +1,18 @@
+FROM ruby:3.3.9-bookworm
+
+RUN apt-get update -qq && apt-get install -y \
+    curl \
+    cmake \
+    wkhtmltopdf \
+    yaz \
+    libyaz-dev \
+    libmagickwand-dev \
+    libpcap-dev \
+    && apt-get clean \
+    && rm -rf /tmp/* /var/tmp/*
+
+ADD https://github.com/jgm/pandoc/releases/download/3.8.2.1/pandoc-3.8.2.1-1-amd64.deb /tmp/pandoc.deb
+RUN dpkg -i /tmp/pandoc.deb
+RUN rm /tmp/pandoc.deb
+
+RUN apt-get clean

--- a/docker/Dockerfile.test
+++ b/docker/Dockerfile.test
@@ -1,0 +1,6 @@
+FROM damisul/bybe-base:latest
+
+WORKDIR /app
+
+ENTRYPOINT ["/app/test-app.sh"]
+CMD rspec

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,11 @@
+This folder contains Dockerfiles and associated files used during development
+
+- Dockerfile.base - is a configuration used as the base for other images, it contains proper verison of ruby and all 
+  required binary dependencies we need to build gems or run app. This image is expected to be published as 
+  `damisul/bybe-base:latest`
+- Dockerfile.test - is a configuration used by test-app service in our `docker-compose.yml` (used to run specs by 
+  Copilot in GitHub Codespaces)
+
+NOTE: See [Docker Documentation](https://docs.docker.com/get-started/introduction/build-and-push-first-image/) on how 
+to push images to Docker Hub.
+You'll need to do it every time when ruby version or binary dependencies are changed.

--- a/docker/test-app.sh
+++ b/docker/test-app.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -e
+
+bundle install
+rake db:create RAILS_ENV=test
+rake db:migrate RAILS_ENV=test
+
+exec "$@"


### PR DESCRIPTION
Added test-app to docker-compose.yml so we can use it to run specs e.g. from CodePilot in agent mode.

Created separate dockerfile for basic docker image containing all dependencies we need to build and run bybe app. It is intended for speeding-up test app image build process.

Updated documentation
