### PR TITLE
Resolved performance issues on welcome page while getting popular authors and works

### DIFF
--- a/db/migrate/20251110022619_add_index_to_ahoy_events.rb
+++ b/db/migrate/20251110022619_add_index_to_ahoy_events.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddIndexToAhoyEvents < ActiveRecord::Migration[8.0]
+  def change
+    add_index :ahoy_events, [:time, :name, :item_type, :item_id]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_11_04_200111) do
+ActiveRecord::Schema[8.0].define(version: 2025_11_10_022619) do
   create_table "aboutnesses", id: :integer, charset: "utf8mb4", collation: "utf8mb4_bin", force: :cascade do |t|
     t.integer "work_id"
     t.integer "user_id"
@@ -65,6 +65,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_11_04_200111) do
     t.virtual "item_type", type: :string, limit: 50, as: "json_unquote(json_extract(`properties`,_utf8mb4'$.type'))"
     t.index ["item_id", "item_type", "name"], name: "index_ahoy_events_on_item_id_and_item_type_and_name"
     t.index ["name", "time"], name: "index_ahoy_events_on_name_and_time"
+    t.index ["time", "name", "item_type", "item_id"], name: "index_ahoy_events_on_time_and_name_and_item_type_and_item_id"
     t.index ["user_id"], name: "index_ahoy_events_on_user_id"
     t.index ["visit_id"], name: "index_ahoy_events_on_visit_id"
   end


### PR DESCRIPTION
## Problems
- for popular manifestations it fetched all view events for last months and looped over them to get most popular works
- for authorities it was the same, but result was ignored and old logic was used.

## Changes

- updated both places to use SQL with group by to get 10 most viewed records
- refactored popular_authors page to use Rails Caching instead of memoizing in class variable
- added new index to ahoy_events table to further speedup process