### PR TITLE
Speeding up Author#TOC page

### DIFF
--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -19,6 +19,8 @@ class Collection < ApplicationRecord
   belongs_to :publication, optional: true
   belongs_to :toc, optional: true
   has_many :collection_items, -> { order(:seqno) }, inverse_of: :collection, dependent: :destroy
+  has_many :parent_collection_items, class_name: 'CollectionItem', as: :item, inverse_of: :item, dependent: :destroy
+
   has_many :inclusions, class_name: 'CollectionItem', as: :item, dependent: :destroy # inclusions of this collection in other collections
   has_many :aboutnesses, as: :aboutable, dependent: :destroy # works that are ABOUT this collection
   # has_many :topics, class_name: 'Aboutness', dependent: :destroy # topics that this work is ABOUT
@@ -483,11 +485,6 @@ class Collection < ApplicationRecord
 
   def parent_collections
     parent_collection_items.preload(:collection).map(&:collection)
-  end
-
-  # returns collection_items where given collection is specified as an item
-  def parent_collection_items
-    CollectionItem.where(item: self)
   end
 
   # update status of ALL manifestations included in this collection, including in nested collections

--- a/app/views/authors/_toc_node.html.haml
+++ b/app/views/authors/_toc_node.html.haml
@@ -57,8 +57,7 @@
     - collection = toc_node.collection
     - type_prefix = collection.collection_type == 'uncollected' ? '' : textify_collection_type(collection.collection_type)
     - uncollected = collection.collection_type == 'uncollected'
-    - any_published = collection.any_published_manifestations?
-    - is_involved = collection.involved_authorities.where(authority_id: authority_id, role: role).present?
+    - is_involved = collection.involved_authorities.any? { |ia| ia.authority_id == authority_id && ia.role == role }
     - unless full_toc
       - full_toc = is_involved # only show full TOC for collections where this particular author is a principal contributor
     - children = full_toc ? toc_node.sorted_children : toc_node.children_by_role(role, authority_id)


### PR DESCRIPTION
This PR includes several changes to make TOC page faster:

- Added preloading of data required for rendering TOC to GenerateTocTree service.
- Optimized some lines in _toc_node.html.haml to get benefit from preloaded data.
- Converted Collection.parent_collection_items method to relation so it could be preloaded