### PR TITLE
removed transaction from track_view method.

### DIFF
--- a/app/controllers/concerns/tracking.rb
+++ b/app/controllers/concerns/tracking.rb
@@ -27,21 +27,19 @@ module Tracking
   def track_view(record)
     return if spider?
 
-    Ahoy::Event.transaction do
-      props = object_properties_for_tracking(record)
-      track_event('view', props)
-      record.increment!(:impressions_count) # we simply increase impressions_count here
+    props = object_properties_for_tracking(record)
+    track_event('view', props)
+    record.increment!(:impressions_count) # we simply increase impressions_count here
 
-      # increment! method does not trigger Chewy index update so we do it explicitly here
-      # for performance purpose we specify only single field to be updated
-      index_class = case record.class.name
-                    when 'Collection' then CollectionsIndex
-                    when 'Manifestation' then ManifestationsIndex
-                    when 'Authority' then AuthoritiesIndex
-                    end
+    # increment! method does not trigger Chewy index update so we do it explicitly here
+    # for performance purpose we specify only single field to be updated
+    index_class = case record.class.name
+                  when 'Collection' then CollectionsIndex
+                  when 'Manifestation' then ManifestationsIndex
+                  when 'Authority' then AuthoritiesIndex
+                  end
 
-      index_class&.send(:import, record, import_fields: [:impressions_count])
-    end
+    index_class&.send(:import, record, import_fields: [:impressions_count])
   end
 
   # Download event should be triggered when we download file associated with object


### PR DESCRIPTION
To address https://asaf-bartov.sentry.io/issues/7016034958/?query=is%3Aunresolved&referrer=issue-stream

Recently we seen number of lock wait timeours in track view event.

I believe the reason was that we wrapped tracking in transactional block.
This block included:
- creating of ahoy_event record
- updating of impressions_count in Authorities or Manifestation table
- updating impressions_count in corresponding ElasticSearch index

All operations should be pretty fast but it seems on high load we seen situations when same object was viewed multiple times by a short period and it produced this error.

I've removed transaction block from track view.
As result during high load impressions_count can went a little bit off in ElasticSearch, but I believe in DB it should stay valid.
So ElasticSearch will be updated on a next object view with a proper value. 

But we should resolve this issue:
https://asaf-bartov.sentry.io/issues/7016034958/?query=is%3Aunresolved&referrer=issue-stream


