### PR TITLE
Add pagination to public /tags view

### DIFF
--- a/app/controllers/taggings_controller.rb
+++ b/app/controllers/taggings_controller.rb
@@ -65,15 +65,16 @@ class TaggingsController < ApplicationController
     @page_title = "#{t(:tags_list)} – #{t(:project_ben_yehuda)}"
     @sort = params[:sort_by] || 'alphabetical'
 
-    @tags = Tag.approved
-    @tags = case @sort
-            when 'popularity'
-              @tags.order(approved_taggings_count: :desc, name: :asc)
-            else # 'alphabetical'
-              @tags.order(name: :asc)
-            end
+    tags_query = Tag.approved
+    tags_query = case @sort
+                 when 'popularity'
+                   tags_query.order(approved_taggings_count: :desc, name: :asc)
+                 else # 'alphabetical'
+                   tags_query.order(name: :asc)
+                 end
 
-    @total = @tags.count
+    @total = tags_query.count
+    @tags = tags_query.page(params[:page])
   end
 
   def list_tags # for backend

--- a/app/views/taggings/browse.html.haml
+++ b/app/views/taggings/browse.html.haml
@@ -22,6 +22,8 @@
                 = link_to tag.name, tag_path(tag.id)
                 %span.text-muted{style: 'font-size: 80%'}
                   = "(#{tag.approved_taggings_count})"
+        .pagination-container{style: 'margin-top: 20px;'}
+          != paginate @tags
 
 :javascript
   $(document).ready(function() {
@@ -29,6 +31,7 @@
       const sortBy = $('#sort_by_select option:selected').val();
       const url = new URL(window.location);
       url.searchParams.set('sort_by', sortBy);
+      url.searchParams.delete('page'); // Reset to page 1 when sort changes
       window.location = url.toString();
     });
   });

--- a/spec/controllers/taggings_controller_spec.rb
+++ b/spec/controllers/taggings_controller_spec.rb
@@ -59,4 +59,75 @@ describe TaggingsController do
 
     it { is_expected.to be_successful }
   end
+
+  describe '#browse' do
+    subject { get :browse, params: params }
+
+    let(:params) { {} }
+
+    context 'with no tags' do
+      it { is_expected.to be_successful }
+
+      it 'assigns empty tags' do
+        subject
+        expect(assigns(:tags)).to be_empty
+      end
+    end
+
+    context 'with approved tags' do
+      let!(:tag1) { create(:tag, name: 'Alpha', status: :approved) }
+      let!(:tag2) { create(:tag, name: 'Beta', status: :approved) }
+      let!(:pending_tag) { create(:tag, name: 'Pending', status: :pending) }
+
+      it { is_expected.to be_successful }
+
+      it 'only includes approved tags' do
+        subject
+        expect(assigns(:tags)).to include(tag1, tag2)
+        expect(assigns(:tags)).not_to include(pending_tag)
+      end
+
+      it 'sorts alphabetically by default' do
+        subject
+        expect(assigns(:tags).to_a).to eq([tag1, tag2])
+      end
+
+      context 'when sorting by popularity' do
+        let(:params) { { sort_by: 'popularity' } }
+
+        before do
+          tag1.update!(approved_taggings_count: 5)
+          tag2.update!(approved_taggings_count: 10)
+        end
+
+        it 'sorts by taggings count descending' do
+          subject
+          expect(assigns(:tags).to_a).to eq([tag2, tag1])
+        end
+      end
+
+      context 'with pagination' do
+        before do
+          # Create enough tags to trigger pagination (assuming default is 25 per page)
+          30.times do |i|
+            create(:tag, name: "Tag#{i.to_s.rjust(3, '0')}", status: :approved)
+          end
+        end
+
+        it 'paginates results' do
+          subject
+          expect(assigns(:tags).count).to be <= 25
+        end
+
+        context 'when requesting page 2' do
+          let(:params) { { page: 2 } }
+
+          it 'returns second page of results' do
+            subject
+            expect(assigns(:tags).current_page).to eq(2)
+          end
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Summary

This PR adds pagination to the public `/tags` view to improve performance and user experience when browsing the growing list of approved tags.

### Changes Made

- **Controller**: Updated `TaggingsController#browse` to paginate tags using Kaminari
- **View**: Added pagination controls to `browse.html.haml` 
- **JavaScript**: Modified sort selector to reset to page 1 when sort order changes (better UX)
- **Tests**: Added comprehensive controller specs covering:
  - Empty tags list
  - Approved tags filtering (excludes pending tags)
  - Alphabetical sorting (default)
  - Popularity sorting
  - Pagination behavior
  - Specific page requests

### Test Results

✅ All tests pass (1199 examples, 0 failures, 10 pending)
✅ No regressions detected

### Related Issue

Closes by-dgv

🤖 Generated with [Claude Code](https://claude.com/claude-code)