### PR TITLE
Hide multi-select button from non-logged-in users in /works browse view

### DIFF
--- a/app/views/manifestation/_browse_list.html.haml
+++ b/app/views/manifestation/_browse_list.html.haml
@@ -23,11 +23,12 @@
   = render partial: 'shared/filters/pagination', locals: { form_id: 'works_filters', add_js: false }
   %hr
   .select-all-with-buttons.desktop-only
-    .select-text-checkbox-area
-      .select-all-checkbox
-        %input#select-all{type: 'checkbox', style:'display:none'}
-    %button.btn-small-outline-v02#multiselect_btn{title: t(:worklist_multi_tt)}
-      .by-icon-v02.purple-v02 \
+    - if current_user
+      .select-text-checkbox-area
+        .select-all-checkbox
+          %input#select-all{type: 'checkbox', style:'display:none'}
+      %button.btn-small-outline-v02#multiselect_btn{title: t(:worklist_multi_tt)}
+        .by-icon-v02.purple-v02 \
     .headline-4-v02= t(:sort_by)
     #sort-by
       %div

--- a/spec/system/works_multiselect_button_spec.rb
+++ b/spec/system/works_multiselect_button_spec.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Works browse multiselect button', type: :system, js: true do
+  before do
+    skip 'WebDriver not available or misconfigured' unless webdriver_available?
+  end
+
+  after do
+    Chewy.massacre
+  end
+
+  before do
+    Chewy.strategy(:atomic) do
+      create_list(:manifestation, 3, status: :published)
+    end
+  end
+
+  describe 'multi-select button visibility' do
+    context 'when user is not logged in' do
+      it 'does not display the multi-select button' do
+        visit '/works'
+
+        expect(page).not_to have_css('#multiselect_btn')
+        expect(page).not_to have_css('#select-all')
+      end
+
+      it 'still displays the sort-by dropdown' do
+        visit '/works'
+
+        expect(page).to have_css('#sort_by_dd')
+        expect(page).to have_text(/מיון לפי/)
+      end
+    end
+
+    context 'when user is logged in' do
+      let(:user) { create(:user) }
+
+      before do
+        allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
+      end
+
+      it 'displays the multi-select button' do
+        visit '/works'
+
+        expect(page).to have_css('#multiselect_btn')
+      end
+
+      it 'displays the select-all checkbox when multi-select is activated' do
+        visit '/works'
+
+        # Initially hidden
+        expect(page).to have_css('#select-all', visible: :hidden)
+
+        # Click multi-select button
+        find('#multiselect_btn').click
+
+        # Now visible
+        expect(page).to have_css('#select-all', visible: :visible)
+      end
+
+      it 'still displays the sort-by dropdown' do
+        visit '/works'
+
+        expect(page).to have_css('#sort_by_dd')
+        expect(page).to have_text(/מיון לפי/)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Hide the multi-select button from non-logged-in (guest) users on the /works browse page
- The button now only appears when a user is logged in
- Sort-by dropdown remains visible to all users

## Changes Made
- Modified `app/views/manifestation/_browse_list.html.haml` to add conditional check for `current_user`
- Added comprehensive system specs to verify button visibility for both logged-in and guest users

## Test Plan
- [x] Run new system specs - all pass
- [x] Run full test suite - all 1317 examples pass, 0 failures
- [x] Verified multi-select button is hidden for guests
- [x] Verified multi-select button is visible for logged-in users
- [x] Verified sort-by dropdown remains visible for all users

Fixes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)