### PR TITLE
Add English title and external identifiers to lexicon migration

### DIFF
--- a/app/services/lexicon/ingest_base.rb
+++ b/app/services/lexicon/ingest_base.rb
@@ -11,6 +11,8 @@ module Lexicon
       Lexicon::ProcessLinks.call(html_doc, lex_entry)
 
       lex_entry.lex_item = create_lex_item(html_doc)
+      lex_entry.english_title = extract_english_title(html_doc)
+      lex_entry.external_identifiers = extract_external_identifiers(html_doc)
       lex_entry.status_draft!
 
       lex_file.status_ingested!
@@ -19,6 +21,46 @@ module Lexicon
 
     def create_lex_item(_html_doc)
       raise('Not implemented')
+    end
+
+    private
+
+    # Extract English title from the header table
+    def extract_english_title(html_doc)
+      # Look for table cell with dir="ltr" containing the English title
+      # The pattern is: <td><p align="center" dir="ltr"><font size="5" color="#FF0000">English Name</font></td>
+      english_cell = html_doc.at_css('table td p[dir="ltr"] font[size="5"][color="#FF0000"]')
+      english_cell&.text&.strip
+    end
+
+    # Extract external identifiers from the footer table
+    def extract_external_identifiers(html_doc)
+      identifiers = {}
+
+      # Find all table cells with external identifier links
+      html_doc.css('table td[dir="ltr"]').each do |cell|
+        text = cell.text.strip
+        link = cell.at_css('a')
+        next unless link
+
+        # Extract identifier type and value based on the text pattern
+        case text
+        when /^OpenLibrary\s*–\s*/
+          identifiers['openlibrary'] = link.text.strip
+        when /^Wikidata\s*–\s*/
+          identifiers['wikidata'] = link.text.strip
+        when /^J9U\s*–\s*/
+          identifiers['j9u'] = link.text.strip
+        when /^NLI\s*–\s*/
+          identifiers['nli'] = link.text.strip
+        when /^LC\s*–\s*/
+          identifiers['lc'] = link.text.strip
+        when /^VIAF\s*–\s*/
+          identifiers['viaf'] = link.text.strip
+        end
+      end
+
+      identifiers.presence # Return nil if empty, otherwise return the hash
     end
   end
 end

--- a/db/migrate/20251227044202_add_english_title_and_external_identifiers_to_lex_entry.rb
+++ b/db/migrate/20251227044202_add_english_title_and_external_identifiers_to_lex_entry.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+# Add english_title and external_identifiers fields to lex_entries for lexicon migration
+class AddEnglishTitleAndExternalIdentifiersToLexEntry < ActiveRecord::Migration[8.0]
+  def change
+    change_table :lex_entries, bulk: true do |t|
+      t.string :english_title
+      t.json :external_identifiers
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_12_26_060307) do
+ActiveRecord::Schema[8.0].define(version: 2025_12_27_044202) do
   create_table "aboutnesses", id: :integer, charset: "utf8mb4", collation: "utf8mb4_bin", force: :cascade do |t|
     t.integer "work_id"
     t.integer "user_id"
@@ -653,6 +653,8 @@ ActiveRecord::Schema[8.0].define(version: 2025_12_26_060307) do
     t.bigint "lex_item_id"
     t.string "sort_title"
     t.json "verification_progress"
+    t.string "english_title"
+    t.json "external_identifiers"
     t.index ["lex_item_type", "lex_item_id"], name: "index_lex_entries_on_lex_item_type_and_lex_item_id", unique: true
     t.index ["sort_title"], name: "index_lex_entries_on_sort_title"
     t.index ["status"], name: "index_lex_entries_on_status"

--- a/spec/services/lexicon/ingest_person_spec.rb
+++ b/spec/services/lexicon/ingest_person_spec.rb
@@ -29,6 +29,25 @@ describe Lexicon::IngestPerson do
       expect(person).to have_attributes(birthdate: '1946', deathdate: nil)
       expect(person.citations.count).to eq(53)
     end
+
+    it 'extracts English title' do
+      call
+      entry = file.lex_entry.reload
+      expect(entry.english_title).to eq('Gabriela Avigur-Rotem')
+    end
+
+    it 'extracts external identifiers' do
+      call
+      entry = file.lex_entry.reload
+      expect(entry.external_identifiers).to include(
+        'openlibrary' => 'OL4181279A',
+        'wikidata' => 'Q12404844',
+        'j9u' => '987007258174105171',
+        'nli' => '000013455',
+        'lc' => 'n82204318',
+        'viaf' => '22255259'
+      )
+    end
   end
 
   context 'when both birthdate and deathdate provided', vcr: { cassette_name: 'lexicon/ingest_person/00024' } do
@@ -55,6 +74,18 @@ describe Lexicon::IngestPerson do
       expect(person).to be_an_instance_of(LexPerson)
       expect(person).to have_attributes(birthdate: '1899', deathdate: '1949')
       expect(person.citations.count).to eq(4)
+    end
+
+    it 'extracts English title when available' do
+      call
+      entry = file.lex_entry.reload
+      expect(entry.english_title).to eq('Samuel Bass')
+    end
+
+    it 'returns nil for external identifiers when not available' do
+      call
+      entry = file.lex_entry.reload
+      expect(entry.external_identifiers).to be_nil
     end
   end
 end


### PR DESCRIPTION
## Summary

This PR enhances the lexicon migration process to extract and store additional metadata from legacy PHP files:

- **English titles**: Extracts English names from the header table and stores them in `lex_entries.english_title`
- **External identifiers**: Extracts external authority identifiers (OpenLibrary, Wikidata, J9U, NLI, LC, VIAF) from the footer table and stores them as JSON in `lex_entries.external_identifiers`

## Changes

1. **Database migration**: Added `english_title` (string) and `external_identifiers` (JSON) columns to `lex_entries`
2. **Extraction logic**: Implemented `extract_english_title` and `extract_external_identifiers` methods in `IngestBase`
3. **Tests**: Added comprehensive tests to verify extraction for both cases (with and without identifiers)

## Technical Details

The extraction uses CSS selectors to find:
- English title: `table td p[dir="ltr"] font[size="5"][color="#FF0000"]`
- External identifiers: Parses table cells with format `<Identifier Type> – <Value Link>`

## Test Plan

- [x] All existing ingest_person tests pass (6/6)
- [x] New tests verify English title extraction
- [x] New tests verify external identifier extraction  
- [x] Tests handle cases where identifiers are absent (returns nil)

## Related Issues

Resolves by-bi2
Resolves by-2g0

🤖 Generated with [Claude Code](https://claude.com/claude-code)