### PR TITLE
Fix over-escaped square brackets in ingested text titles

### DIFF
--- a/app/controllers/ingestibles_controller.rb
+++ b/app/controllers/ingestibles_controller.rb
@@ -429,21 +429,24 @@ class IngestiblesController < ApplicationController
       # Merge authorities to get the complete list that will be used
       merged_authorities = merge_authorities_per_role(authorities_json, @ingestible.default_authorities)
 
+      # Unescape title for comparison - titles are stored unescaped in the database
+      unescaped_title = unescape_markdown_title(title)
+
       # Find manifestations with the same title and eager load authorities to avoid N+1 queries
-      existing_manifestations = Manifestation.where(title: title).with_involved_authorities
+      existing_manifestations = Manifestation.where(title: unescaped_title).with_involved_authorities
 
       existing_manifestations.each do |manifestation|
         # Get involved authorities for this manifestation
         existing_involved = manifestation.involved_authorities
 
         # Compare authorities - check if they match
-        if same_authorities?(merged_authorities, existing_involved)
-          @potential_duplicates << {
-            title: title,
-            manifestation_id: manifestation.id,
-            manifestation_url: url_for(controller: :manifestation, action: :read, id: manifestation.id, only_path: true)
-          }
-        end
+        next unless same_authorities?(merged_authorities, existing_involved)
+
+        @potential_duplicates << {
+          title: unescaped_title,
+          manifestation_id: manifestation.id,
+          manifestation_url: url_for(controller: :manifestation, action: :read, id: manifestation.id, only_path: true)
+        }
       end
     end
 
@@ -567,10 +570,11 @@ class IngestiblesController < ApplicationController
 
   # add a placeholder (itemless CollectionItem) to the collection
   def create_placeholder(toc_line)
-    return if @collection.collection_items.where(alt_title: toc_line[1]).present? # don't create duplicate placeholders. It is expected they are unique within the collection. Genuine duplicate titles that the user DOES want created should have been disambiguated at the review phase.
+    unescaped_title = unescape_markdown_title(toc_line[1])
+    return if @collection.collection_items.where(alt_title: unescaped_title).present? # don't create duplicate placeholders. It is expected they are unique within the collection. Genuine duplicate titles that the user DOES want created should have been disambiguated at the review phase.
 
-    @collection.append_collection_item(CollectionItem.new(alt_title: toc_line[1]))
-    @changes[:placeholders] << toc_line[1]
+    @collection.append_collection_item(CollectionItem.new(alt_title: unescaped_title))
+    @changes[:placeholders] << unescaped_title
   end
 
   # Merge work-specific authorities with defaults per role
@@ -588,7 +592,7 @@ class IngestiblesController < ApplicationController
     return work_auths if default_auths.empty?
 
     # Get roles present in work authorities
-    work_roles = work_auths.map { |a| a['role'] }.uniq
+    work_roles = work_auths.pluck('role').uniq
 
     # Start with work authorities, then add defaults for roles not present in work authorities
     result = work_auths.dup
@@ -609,12 +613,11 @@ class IngestiblesController < ApplicationController
     # and build sets of (authority_id, role) pairs for comparison
     toc_authorities_set = merged_authorities
                           .select { |auth| auth['authority_id'].present? }
-                          .map { |auth| [auth['authority_id'].to_i, auth['role']] }
-                          .to_set
+                          .to_set { |auth| [auth['authority_id'].to_i, auth['role']] }
 
-    existing_authorities_set = existing_involved.map do |ia|
+    existing_authorities_set = existing_involved.to_set do |ia|
       [ia.authority_id, ia.role]
-    end.to_set
+    end
 
     # They match if both sets are non-empty and equal
     return false if toc_authorities_set.empty? || existing_authorities_set.empty?
@@ -731,7 +734,7 @@ class IngestiblesController < ApplicationController
 
         unless @ingestible.no_volume
           # finally, add to collection, replacing placeholder if appropriate
-          placeholder = @collection.collection_items.reload.where(alt_title: toc_line[1], item: nil)
+          placeholder = @collection.collection_items.reload.where(alt_title: unescaped_title, item: nil)
           if placeholder.present? # we will insert the item just below the placeholder
             # Use the insertion logic from CollectionItemsController#drag_item
             items = @collection.collection_items.order(:seqno).to_a


### PR DESCRIPTION
## Summary
Fixes issue by-cra where titles containing square brackets were being stored with escape backslashes in the database.

When ingesting texts whose titles contain square brackets (e.g., `[abc]`), Pandoc escapes them in markdown output as `\[abc\]`. These escaped backslashes were being stored directly in Work, Expression, and Manifestation records, causing them to appear in displays.

## Changes
- Added `unescape_markdown_title` private method to `IngestiblesController` that removes markdown escape sequences
- Applied unescaping to titles before creating Work, Expression, and Manifestation records in `upload_text` method
- Added comprehensive test to verify the fix works correctly

## Implementation Details
The fix uses the same unescaping regex pattern as the existing `SanitizeHeading` service (`/\\([\[\]\*\_\{\}\(\)\#\+\-\.\!'])/, '\1'`), which was only handling display, not storage.

## Test Plan
- [x] Added new test case for titles with escaped brackets
- [x] Verified all existing tests pass (1426 examples, 0 failures)
- [x] Test confirms that Work, Expression, and Manifestation titles no longer contain backslash escapes

🤖 Generated with [Claude Code](https://claude.com/claude-code)