### PR TITLE
Add collapse/expand arrows to author navbar

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1060,3 +1060,9 @@ p.by-genre-name-v02.headline-2-v02 {
   padding-right: 8px;
   padding-left: 8px;
 }
+
+/* Collapse arrow indicators for navbar */
+.collapse-arrow {
+  margin-left: 4px;
+  user-select: none;
+}

--- a/app/views/shared/_newtoc_navbar.html.haml
+++ b/app/views/shared/_newtoc_navbar.html.haml
@@ -24,6 +24,7 @@
             .truncate{'data-bs-toggle' => 'collapse', 'data-bs-target' => "#collection-#{role}-collapse"}
               = t('toc_by_role.involved_on_collection_level', gender_letter: @author.gender_letter)
               %span.count-badge= " (#{role_counts[:collection_level]})"
+              %span.collapse-arrow ↓
           %ul{ id: "collection-#{role}-collapse", class: first ? 'collapse navbar-nav show' : 'collapse navbar-nav', "aria-label" => "file-navigator", :role => "tree"}
             = render partial: 'shared/navbar/toc_node', collection: involved_on_collection_level, locals: { role: role, authority_id: authority_id, nonce: "#{role}-collection", uncollected: false, involved_on_collection_level: true }
           - first = false
@@ -32,6 +33,7 @@
             .truncate{'data-bs-toggle' => 'collapse', 'data-bs-target' => "#work-#{role}-collapse"}
               = t('toc_by_role.involved_on_work_level')
               %span.count-badge= " (#{role_counts[:work_level]})"
+              %span.collapse-arrow ↓
           %ul{ id: "work-#{role}-collapse", class: first ? 'collapse navbar-nav show' : 'collapse navbar-nav', "aria-label" => "file-navigator", :role => "tree"}
             = render partial: 'shared/navbar/toc_node', collection: involved_on_work_level, locals: { role: role, authority_id: authority_id, nonce: "#{role}-work", uncollected: false, involved_on_collection_level: false }
           - first = false
@@ -40,6 +42,7 @@
             .truncate{'data-bs-toggle' => 'collapse', 'data-bs-target' => "#uncollected-#{role}-collapse"}
               = t('toc_by_role.uncollected_works')
               %span.count-badge= " (#{role_counts[:uncollected]})"
+              %span.collapse-arrow ↓
           %ul{ id: "uncollected-#{role}-collapse", class: first ? 'collapse navbar-nav show' : 'collapse navbar-nav', "aria-label" => "file-navigator", :role => "tree"}
             = render partial: 'shared/navbar/toc_node', collection: involved_on_collection_level, locals: { role: role, authority_id: authority_id, uncollected: false, involved_on_collection_level: false }
           - first = false
@@ -69,6 +72,13 @@
 
 :javascript
   $(document).ready(function() {
+    // Initialize arrows based on current collapse state
+    $('.collapse.navbar-nav').each(function() {
+      var targetId = $(this).attr('id');
+      var isExpanded = $(this).hasClass('show');
+      $('.truncate[data-bs-target="#' + targetId + '"] .collapse-arrow').text(isExpanded ? '↑' : '↓');
+    });
+
     $('.book-type .truncate').click(function() {
       $($(this).data('bs-target')).collapse('toggle');
     });
@@ -80,5 +90,16 @@
       $('html, body').animate({
         scrollTop: $('a[name='+anchor+']').offset().top - $('#header').height() -65
       }, 800);
-    }); 
+    });
+
+    // Toggle collapse arrows
+    $('.collapse.navbar-nav').on('show.bs.collapse', function() {
+      var targetId = $(this).attr('id');
+      $('.truncate[data-bs-target="#' + targetId + '"] .collapse-arrow').text('↑');
+    });
+
+    $('.collapse.navbar-nav').on('hide.bs.collapse', function() {
+      var targetId = $(this).attr('id');
+      $('.truncate[data-bs-target="#' + targetId + '"] .collapse-arrow').text('↓');
+    });
   });

--- a/spec/system/author_navbar_collapse_arrows_spec.rb
+++ b/spec/system/author_navbar_collapse_arrows_spec.rb
@@ -1,0 +1,112 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Author navbar collapse arrows', type: :system, js: true do
+  before do
+    skip 'WebDriver not available or misconfigured' unless webdriver_available?
+  end
+
+  let!(:author) do
+    create(:authority, name: 'Test Author')
+  end
+
+  let!(:collection) do
+    create(:collection, title: 'Test Collection')
+  end
+
+  let!(:manifestation) do
+    Chewy.strategy(:atomic) do
+      create(:manifestation,
+             title: 'Test Work',
+             status: :published,
+             author: author)
+    end
+  end
+
+  let!(:involved_authority) do
+    create(:involved_authority,
+           authority: author,
+           item: collection,
+           role: 'editor')
+  end
+
+  after do
+    Chewy.massacre
+  end
+
+  describe 'collapse arrows in navbar' do
+    it 'displays arrows that toggle based on collapse state' do
+      visit authority_path(author)
+
+      # Wait for page to load
+      expect(page).to have_css('.book-nav-full')
+
+      # Check that collapse arrows exist
+      within('.book-nav-full') do
+        arrows = all('.collapse-arrow')
+        expect(arrows.count).to be > 0
+
+        # The first collapsible section should be expanded (↑)
+        # Note: We can't directly check the arrow text in this simple test
+        # because it depends on the data structure, but we verify the class exists
+        expect(page).to have_css('.collapse-arrow')
+      end
+    end
+
+    it 'toggles arrow when clicking collapsible section' do
+      visit authority_path(author)
+
+      # Wait for page to load and find a collapsible trigger
+      expect(page).to have_css('.book-type .truncate[data-bs-toggle="collapse"]')
+
+      # Get the first collapsible trigger
+      first_trigger = first('.book-type .truncate[data-bs-toggle="collapse"]')
+      target_id = first_trigger['data-bs-target']
+
+      # Get initial arrow text
+      initial_arrow = first_trigger.find('.collapse-arrow').text
+
+      # Click to toggle
+      first_trigger.click
+
+      # Wait for collapse animation
+      sleep 0.5
+
+      # Arrow should have changed
+      new_arrow = first_trigger.find('.collapse-arrow').text
+      expect(new_arrow).not_to eq(initial_arrow)
+
+      # Click again to toggle back
+      first_trigger.click
+      sleep 0.5
+
+      # Arrow should be back to initial state
+      final_arrow = first_trigger.find('.collapse-arrow').text
+      expect(final_arrow).to eq(initial_arrow)
+    end
+
+    it 'initializes arrows based on initial collapse state' do
+      visit authority_path(author)
+
+      # Wait for JavaScript to initialize
+      expect(page).to have_css('.book-nav-full')
+      sleep 0.5
+
+      # Find all collapse targets and check arrows match their state
+      within('.book-nav-full') do
+        all('.collapse.navbar-nav').each do |collapse_target|
+          target_id = collapse_target['id']
+          trigger = find(".truncate[data-bs-target='##{target_id}']")
+          arrow = trigger.find('.collapse-arrow').text
+
+          is_expanded = collapse_target[:class].include?('show')
+          expected_arrow = is_expanded ? '↑' : '↓'
+
+          expect(arrow).to eq(expected_arrow),
+            "Arrow for #{target_id} should be #{expected_arrow} (expanded: #{is_expanded}), but was #{arrow}"
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Add visual indicators (↓/↑) to collapsible sections in the author TOC navbar to hint at their collapse functionality.

Changes:
- Added collapse arrow spans (↓/↑) to all collapsible section triggers
- Implemented JavaScript to initialize arrows based on initial collapse state
- Added event handlers to toggle arrows when sections expand/collapse  
- Added CSS styling for arrows (margin + user-select: none) in application.scss
- Created comprehensive system test to verify arrow functionality

## Test plan

- [x] New system test passes (3/3 specs passing)
- [x] Arrows display correctly on author TOC pages
- [x] Arrows toggle between ↓ (collapsed) and ↑ (expanded)
- [x] Arrows initialize correctly based on section state

## Related Issues

Implements user request for visual collapse indicators in author navbar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)