### PR TITLE
Fix date picker clipping in /works browse filters

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1009,3 +1009,12 @@ small p{
 p.by-genre-name-v02.headline-2-v02 {
     text-wrap: wrap;
 }
+
+/* Fix for date picker clipping in browse filters */
+#filters_panel {
+  overflow: visible !important;
+}
+
+.bootstrap-datetimepicker-widget {
+  z-index: 9999 !important;
+}


### PR DESCRIPTION
## Summary
Fixed the date picker widget clipping issue in the /works browse filters. The date selection widget was being cut off at the edge of the filter panel, making some controls impossible to click.

## Changes
- Modified `app/assets/stylesheets/application.scss` to:
  - Allow `#filters_panel` to overflow (changed from `hidden` to `visible`)
  - Set `.bootstrap-datetimepicker-widget` z-index to 9999 to ensure it appears on top

## Test Plan
- [x] Verified the fix with Capybara system tests
- [x] Confirmed that the date picker widget now displays fully without clipping
- [x] Checked that the widget has proper z-index and overflow behavior
- [x] Tested both `fromdate` and `todate` fields

## Related Issue
Fixes by-p4s

🤖 Generated with [Claude Code](https://claude.com/claude-code)