### PR TITLE
Fix authors filter toggle display bug

### DIFF
--- a/app/views/authors/_browse_top.html.haml
+++ b/app/views/authors/_browse_top.html.haml
@@ -10,7 +10,7 @@
             = t(:filter_state)
             -#%a.help{:href => "#"} [?]
             .toggle-background-no
-              .toggle-button-no
+              .toggle-button-no{ style: "display:#{@filters.empty? ? 'block' : 'none'}" }
               .toggle-button-yes{ style: "display:#{@filters.empty? ? 'none' : 'block'}" }
           .author-page-top-sort-mobile
             %button.btn-small-outline-v02.btn-text-v02{:href => "#"} סינון


### PR DESCRIPTION
## Summary
Fixed a visual bug in the `/authors` view where the filtering toggle displayed incorrectly after applying a filter. Both dots would appear or neither would appear instead of showing one dot on the right or left.

## Root Cause
In `app/views/authors/_browse_top.html.haml`, the `.toggle-button-no` element lacked an inline style to control its display, while `.toggle-button-yes` had one. This caused the initial state to be incorrect when filters were applied.

## Changes
- Added missing inline style to `.toggle-button-no` to properly control its visibility:
  - When filters are empty: `.toggle-button-no` shows (block), `.toggle-button-yes` hides (none)
  - When filters are present: `.toggle-button-no` hides (none), `.toggle-button-yes` shows (block)

This matches the pattern already used in other similar views (`anthologies/_browse_top.html.haml`, `manifestation/_browse_top.html.haml`).

## Test Plan
- [x] Existing system specs pass (`spec/system/authors_filter_panel_spec.rb`)
- [x] Tests verify toggle button states in all scenarios:
  - No filters applied: `.toggle-button-no` visible, `.toggle-button-yes` hidden
  - Filter applied: `.toggle-button-yes` visible
  - Filters reset: `.toggle-button-no` visible, `.toggle-button-yes` hidden

## Related Issue
Fixes by-d0e

🤖 Generated with [Claude Code](https://claude.com/claude-code)