### PR TITLE
Add LexCitations card to Author#toc view

### DIFF
--- a/app/controllers/authors_controller.rb
+++ b/app/controllers/authors_controller.rb
@@ -488,6 +488,7 @@ class AuthorsController < ApplicationController
       if @author.lex_person.present? && @author.lex_person.entry.status_published?
         @lexicon_entry = @author.lex_person.entry
       end
+      @lex_citations = @author.lex_person&.general_citations || []
       prep_user_content(:author)
       @scrollspy_target = 'genrenav'
     else

--- a/app/models/lex_person.rb
+++ b/app/models/lex_person.rb
@@ -15,6 +15,10 @@ class LexPerson < ApplicationRecord
 
   belongs_to :authority, optional: true # link to an Authority record representing this person in BYP
 
+  def general_citations
+    citations.where(item: nil).includes(:authors, :manifestation)
+  end
+
   def intellectual_property
     copyrighted? ? 'copyrighted' : 'public_domain'
   end

--- a/app/views/authors/toc.html.haml
+++ b/app/views/authors/toc.html.haml
@@ -187,6 +187,17 @@
                     %div= t(:suggest_new_tag)
           
           = render partial: 'aboutnesses', cached: true, locals: { author: @author }
+
+          -# LexCitations
+          - if @lex_citations.any?
+            .by-card-v02.left-side-card-v02
+              .by-card-header-left-v02
+                %span.headline-1-v02= t(:lex_citations_about_author)
+              .by-card-content-v02
+                %ul
+                  - @lex_citations.each do |citation|
+                    %li= render_citation(citation)
+
           = render partial: 'shared/external_links_panel', locals: { linkable: @author }
 
           .by-card-v02#text-volunteers-mobile

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1919,6 +1919,7 @@ en:
   tags: Tags
   tags_count: Tags Count
   lex_citations_about_collection: Citations about this collection
+  lex_citations_about_author: Citations about this author
   task: Task
   tasks: Tasks
   template: Template

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -837,6 +837,7 @@ he:
   taggings: תיוגים
   tag: תגית
   lex_citations_about_collection: מראי מקום על כותר זה מלקסיקון הספרות העברית החדשה
+  lex_citations_about_author: מראי מקום על מחבר זה מלקסיקון הספרות העברית החדשה
   moderate_tags: ניטור תיוגים מהציבור
   link_moderation: ניטור קישוריות מהציבור
   edit_lexicon: עריכת הלקסיקון

--- a/spec/controllers/authors_controller_spec.rb
+++ b/spec/controllers/authors_controller_spec.rb
@@ -124,6 +124,44 @@ describe AuthorsController do
           expect(request).to be_successful
         end
       end
+
+      context 'when author has lex_person with general citations' do
+        let(:lex_entry) { create(:lex_entry, :person, status: 'draft') }
+        let(:lex_person) { lex_entry.lex_item }
+        let!(:citation) { create(:lex_citation, person: lex_person, item: nil) }
+
+        before do
+          author.update(lex_person: lex_person)
+        end
+
+        it 'assigns @lex_citations with general citations only' do
+          request
+          expect(assigns(:lex_citations)).to eq([citation])
+        end
+      end
+
+      context 'when author has lex_person with work-specific citation' do
+        let(:lex_entry) { create(:lex_entry, :person, status: 'draft') }
+        let(:lex_person) { lex_entry.lex_item }
+        let(:lex_person_work) { create(:lex_person_work, person: lex_person) }
+        let!(:work_citation) { create(:lex_citation, person: lex_person, item: lex_person_work, title: 'About a Work') }
+
+        before do
+          author.update(lex_person: lex_person)
+        end
+
+        it 'does not include work-specific citations in @lex_citations' do
+          request
+          expect(assigns(:lex_citations)).to eq([])
+        end
+      end
+
+      context 'when author has no lex_person' do
+        it 'assigns empty @lex_citations' do
+          request
+          expect(assigns(:lex_citations)).to eq([])
+        end
+      end
     end
 
     describe '#whatsnew_popup' do

--- a/spec/requests/author_lex_citations_spec.rb
+++ b/spec/requests/author_lex_citations_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Author LexCitations display', type: :request do
+  let(:uncollected_collection) { create(:collection, :uncollected) }
+  let(:author) { create(:authority, :published, uncollected_works_collection: uncollected_collection) }
+
+  context 'when author has lex_person with general citations' do
+    let(:lex_entry) { create(:lex_entry, :person, status: 'draft') }
+    let(:lex_person) { lex_entry.lex_item }
+    let!(:citation1) { create(:lex_citation, person: lex_person, item: nil, title: 'General Citation') }
+    let!(:citation2) do
+      lex_person_work = create(:lex_person_work, person: lex_person)
+      create(:lex_citation, person: lex_person, item: lex_person_work, title: 'Work Citation')
+    end
+
+    before do
+      author.update(lex_person: lex_person)
+    end
+
+    it 'displays only general citations (item nil)' do
+      get authority_path(author)
+      expect(response.body).to include('General Citation')
+      expect(response.body).not_to include('Work Citation')
+      expect(response.body).to include(I18n.t(:lex_citations_about_author))
+    end
+  end
+
+  context 'when author has no general citations or no lex_person' do
+    it 'does not display citations card when author has no general citations' do
+      get authority_path(author)
+      expect(response.body).not_to include(I18n.t(:lex_citations_about_author))
+    end
+
+    it 'does not display citations card when author has no lex_person' do
+      author_without_lex = create(:authority, :published, uncollected_works_collection: uncollected_collection)
+      get authority_path(author_without_lex)
+      expect(response.body).not_to include(I18n.t(:lex_citations_about_author))
+    end
+  end
+end

--- a/spec/system/author_lex_citations_spec.rb
+++ b/spec/system/author_lex_citations_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Author LexCitations card', :js, type: :system do
+  before do
+    skip 'WebDriver not available or misconfigured' unless webdriver_available?
+    author.update(lex_person: lex_person)
+  end
+
+  let(:uncollected_collection) { create(:collection, :uncollected) }
+  let(:author) do
+    create(:authority, :published, name: 'Test Author', uncollected_works_collection: uncollected_collection)
+  end
+  let(:lex_entry) { create(:lex_entry, :person, status: 'draft') }
+  let(:lex_person) { lex_entry.lex_item }
+
+  context 'with general citations' do
+    let!(:citation) { create(:lex_citation, person: lex_person, item: nil, title: 'About the Author') }
+
+    it 'displays citations card with general citations' do
+      visit authority_path(author)
+
+      within('.by-card-v02.left-side-card-v02', text: I18n.t(:lex_citations_about_author)) do
+        expect(page).to have_content('About the Author')
+      end
+    end
+  end
+
+  context 'with work-specific citation only' do
+    let(:lex_person_work) { create(:lex_person_work, person: lex_person) }
+    let!(:work_citation) { create(:lex_citation, person: lex_person, item: lex_person_work, title: 'About a Work') }
+
+    it 'does not display citations card' do
+      visit authority_path(author)
+      expect(page).not_to have_content(I18n.t(:lex_citations_about_author))
+    end
+  end
+
+  context 'without general citations' do
+    it 'does not display citations card' do
+      visit authority_path(author)
+      expect(page).not_to have_content(I18n.t(:lex_citations_about_author))
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Adds an optional card on the left sidebar of the Author#toc view that displays LexCitations generally about the author (not about specific works/publications). The card only appears when general citations exist for the author.

## Changes

- **Model**: Added `LexPerson#general_citations` method to filter citations where `item` is nil (citations about the person in general)
- **Controller**: Updated `AuthorsController#toc` to assign `@lex_citations` instance variable
- **View**: Added LexCitations card to `toc.html.haml` (positioned after aboutnesses and before external links)
- **I18n**: Added translations for card header in English and Hebrew
- **Tests**: Added comprehensive test coverage:
  - Controller spec tests (3 examples)
  - Request spec tests (3 examples)
  - System spec tests (3 examples)

## Test Plan

- [x] All new tests pass (9 examples, 0 failures)
- [x] Card displays only general citations (item nil)
- [x] Card hidden when no general citations exist
- [x] Card hidden when author has no lex_person
- [x] Citations formatted correctly using existing `render_citation` helper
- [x] Positioned correctly in sidebar (after aboutnesses, before external links)

## Pattern

This implementation follows the exact pattern from the recent Collections#show implementation (commit 63e3e4f8):
- Same card HTML structure (`.by-card-v02.left-side-card-v02`)
- Same helper method (`render_citation`)
- Same eager loading (`:authors, :manifestation`)
- Same conditional rendering (`if @lex_citations.any?`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)