### PR TITLE
Fix URI encoding error with non-ASCII characters in update_param

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,3 +1,5 @@
+require 'addressable/uri'
+
 module ApplicationHelper
   include BybeUtils
 
@@ -238,10 +240,10 @@ module ApplicationHelper
   end
 
   def update_param(uri, key, value)
-    u = URI(uri)
-    pp = URI.decode_www_form(u.query || '').to_h
+    u = Addressable::URI.parse(uri.to_s)
+    pp = u.query_values || {}
     pp[key] = value
-    u.query = URI.encode_www_form(pp.to_a)
+    u.query_values = pp
     u.to_s
   end
 

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ApplicationHelper, type: :helper do
+  describe '#update_param' do
+    it 'updates a parameter in a simple URL' do
+      url = 'https://example.com/path?foo=bar'
+      result = helper.update_param(url, 'baz', 'qux')
+      uri = Addressable::URI.parse(result)
+      params = uri.query_values
+      expect(params['foo']).to eq('bar')
+      expect(params['baz']).to eq('qux')
+    end
+
+    it 'updates an existing parameter' do
+      url = 'https://example.com/path?foo=bar&baz=old'
+      result = helper.update_param(url, 'baz', 'new')
+      uri = Addressable::URI.parse(result)
+      params = uri.query_values
+      expect(params['foo']).to eq('bar')
+      expect(params['baz']).to eq('new')
+    end
+
+    it 'handles URLs without query parameters' do
+      url = 'https://example.com/path'
+      result = helper.update_param(url, 'foo', 'bar')
+      expect(result).to eq('https://example.com/path?foo=bar')
+    end
+
+    it 'handles URLs with non-ASCII characters (Hebrew)' do
+      # Test the exact case from the bug report: Hebrew letter פ
+      # \xD7\xA4 is UTF-8 encoding for פ
+      url = "https://benyehuda.org/dict/24412?page=112&to_letter=\xD7\xA4"
+      result = helper.update_param(url, 'page', '113')
+
+      # The result should have the page updated and preserve the Hebrew character
+      expect(result).to include('page=113')
+      expect(result).to include('to_letter=')
+      # Check that the URL is valid and doesn't raise an error
+      expect { URI.parse(result) }.not_to raise_error
+    end
+
+    it 'properly percent-encodes non-ASCII characters' do
+      url = 'https://example.com/path?letter=א'
+      result = helper.update_param(url, 'page', '1')
+
+      # The Hebrew letter א should be percent-encoded
+      expect(result).to include('page=1')
+      expect(result).to include('letter=')
+    end
+
+    it 'handles multiple non-ASCII characters' do
+      url = 'https://example.com/path?term=שלום&lang=he'
+      result = helper.update_param(url, 'page', '2')
+
+      expect(result).to include('page=2')
+      expect(result).to include('term=')
+      expect(result).to include('lang=he')
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Fixes the `URI::InvalidURIError (URI must be ascii only)` error that occurs when `ApplicationHelper#update_param` receives URLs containing non-ASCII characters (e.g., Hebrew letters).

### Changes Made

- Replaced `URI` with `Addressable::URI` in `update_param` method to properly handle international characters
- Added `require 'addressable/uri'` at the top of the file
- Created comprehensive test suite for `ApplicationHelper#update_param`

### Example Bug

The error was triggered by URLs like:
```
https://benyehuda.org/dict/24412?page=112&to_letter=\xD7\xA4
```

Where `\xD7\xA4` is the UTF-8 encoding for the Hebrew letter פ.

### Test Plan

- [x] Created new spec file with 6 test cases covering:
  - Simple parameter updates
  - Updating existing parameters
  - URLs without query parameters
  - URLs with Hebrew characters (the reported bug)
  - Proper percent-encoding of non-ASCII characters
  - Multiple non-ASCII characters in query strings
- [x] All new tests pass
- [x] Full test suite run (3 pre-existing failures unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)