### PR TITLE
Fix bib shopping pagination spec

### DIFF
--- a/app/views/bib/shopping.html.haml
+++ b/app/views/bib/shopping.html.haml
@@ -12,7 +12,8 @@
         = submit_tag t(:filter)
     .row
       .col-md-12
-        = page_entries_info @holdings
+        .page_entries_info
+          = page_entries_info @holdings
         = paginate @holdings
     .row
       %table


### PR DESCRIPTION
## Summary
- Fixed failing spec `./spec/system/bib_shopping_pagination_spec.rb`
- The spec was expecting to find `.page_entries_info` CSS class
- Wrapped the `page_entries_info` helper output in a div with the proper CSS class

## What Changed
- Modified `app/views/bib/shopping.html.haml` to wrap `page_entries_info @holdings` in a `.page_entries_info` div
- This ensures the spec can find the expected CSS class

## Test Plan
- [x] All 9 examples in the spec now pass
- [x] No new lint issues introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)