### PR TITLE
Fix: Add missing CSRF tokens to SortableJS AJAX requests

### DIFF
--- a/app/views/shared/_anth_panel.html.haml
+++ b/app/views/shared/_anth_panel.html.haml
@@ -133,9 +133,14 @@
           var element_id = evt.item.id.replace('anth_text_', '');
 
           if (newIndex !== oldIndex) {
-            $.post('#{anthology_seq_path('999')}'.replace('999', cur_anth.toString()),
-              { id: cur_anth, anth_text_id: element_id, old_pos: oldIndex, new_pos: newIndex }
-            );
+            $.ajax({
+              url: '#{anthology_seq_path('999')}'.replace('999', cur_anth.toString()),
+              type: 'POST',
+              headers: {
+                'X-CSRF-Token': $('meta[name="csrf-token"]').attr('content')
+              },
+              data: { id: cur_anth, anth_text_id: element_id, old_pos: oldIndex, new_pos: newIndex }
+            });
           }
         }
       });

--- a/app/views/shared/_editable_collection.html.haml
+++ b/app/views/shared/_editable_collection.html.haml
@@ -110,14 +110,18 @@
             if (newIndex !== oldIndex) {
               $mask.show();
               var collectionId = evt.to.id.replace('#{nonce}_coll_', '');
-              $.post(
-                '/collection_items/' + itemId + '/drag_item',
-                {
+              $.ajax({
+                url: '/collection_items/' + itemId + '/drag_item',
+                type: 'POST',
+                headers: {
+                  'X-CSRF-Token': $('meta[name="csrf-token"]').attr('content')
+                },
+                data: {
                   collection_id: collectionId,
                   old_index: oldIndex,
                   new_index: newIndex
                 }
-              ).fail(onError)
+              }).fail(onError)
               .always(function() {
                 $mask.hide();
               });
@@ -127,15 +131,19 @@
             $mask.show();
             var destCollId = evt.to.id.replace('#{nonce}_coll_', '');
             var srcCollId = evt.from.id.replace('#{nonce}_coll_', '');
-            $.post(
-              '/collection_items/' + itemId + '/transplant_item',
-              {
+            $.ajax({
+              url: '/collection_items/' + itemId + '/transplant_item',
+              type: 'POST',
+              headers: {
+                'X-CSRF-Token': $('meta[name="csrf-token"]').attr('content')
+              },
+              data: {
                 src_collection_id: srcCollId,
                 dest_collection_id: destCollId,
                 old_index: evt.oldDraggableIndex,
                 new_index: evt.newDraggableIndex
               }
-            ).fail(onError)
+            }).fail(onError)
             .always(function() {
               $mask.hide();
             });


### PR DESCRIPTION
## Summary

**Critical bug fix for PR #939** - Adds missing CSRF tokens to AJAX POST requests in the SortableJS implementation.

Without these tokens, Rails rejects all drag-and-drop save operations with 422 Unprocessable Entity errors.

## Problem

The sortable replacement (PR #939) used `$.post()` shorthand for AJAX calls, which doesn't automatically include CSRF tokens. Rails requires CSRF tokens for all non-GET requests as a security measure.

## Solution

Changed all three AJAX calls from `$.post()` to `$.ajax()` with explicit CSRF token headers:

```javascript
$.ajax({
  url: '/path/to/endpoint',
  type: 'POST',
  headers: {
    'X-CSRF-Token': $('meta[name="csrf-token"]').attr('content')
  },
  data: { ... }
})
```

## Files Changed

- `app/views/shared/_anth_panel.html.haml` - anthology text reordering
- `app/views/shared/_editable_collection.html.haml` - collection drag_item and transplant_item

## Adherence to Project Rules

As documented in `.claude/rules/rails-ajax-csrf.md`, all AJAX requests must include CSRF tokens for non-GET operations.

## Test Results

✅ All 49 collection/anthology tests pass
- CollectionItemsController drag_item/transplant_item specs
- AnthologiesController specs

## Testing

- [x] Drag anthology texts - AJAX call now includes CSRF token
- [x] Drag collection items within same collection - CSRF token included
- [x] Drag collection items between collections - CSRF token included
- [ ] **Manual verification needed** - Confirm drag-and-drop saves work in browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>