### PR TITLE
Fix race condition creating orphaned uncollected Collections

### DIFF
--- a/app/services/refresh_uncollected_works_collection.rb
+++ b/app/services/refresh_uncollected_works_collection.rb
@@ -3,51 +3,64 @@
 # We want to group all works author was involved into but not belonging to any colleciton into a special
 # 'Uncollected works' collection
 class RefreshUncollectedWorksCollection < ApplicationService
-  # rubocop:disable Style/GuardClause
   def call(authority)
-    collection = authority.uncollected_works_collection
+    # Wrap in transaction and use pessimistic locking to prevent race conditions
+    # where multiple concurrent calls create orphaned collections
+    Authority.transaction do
+      # Lock the authority to prevent concurrent modifications
+      locked_authority = Authority.lock.find(authority.id)
 
-    remove_collected_works(authority) if collection.present?
+      # Re-check for existing collection inside the lock (may have been created by another thread)
+      collection = locked_authority.uncollected_works_collection
 
-    if collection.nil?
-      collection = Collection.new(
-        collection_type: :uncollected,
-        title: I18n.t(:uncollected_works_collection_title)
-      )
-      collection.allow_system_type_change!
-    end
+      remove_collected_works(locked_authority) if collection.present?
 
-    # Disable automatic manifestations_count updates during bulk add
-    collection.skip_manifestations_count_update = true
+      is_new_collection = collection.nil?
 
-    nextseqno = (collection.collection_items.maximum(:seqno) || 0) + 1
-
-    # Checking all manifestations given authority is involved into as author or translator
-    authority.published_manifestations(:author, :translator, :editor) # TODO: consider other roles?
-             .preload(collection_items: :collection)
-             .find_each do |m|
-      # skipping if manifestation is included in some other collection or already included in uncollected works
-      # collection for this authority
-      next if m.collection_items.any? do |ci|
-        !ci.collection.uncollected? || (collection.present? && ci.collection == collection)
+      if is_new_collection
+        collection = Collection.new(
+          collection_type: :uncollected,
+          title: I18n.t(:uncollected_works_collection_title)
+        )
+        collection.allow_system_type_change!
       end
 
-      collection.collection_items.build(item: m, seqno: nextseqno)
-      nextseqno += 1
-    end
+      # Disable automatic manifestations_count updates during bulk add
+      collection.skip_manifestations_count_update = true
 
-    collection.save! # should save all added items
+      nextseqno = (collection.collection_items.maximum(:seqno) || 0) + 1
 
-    # Re-enable automatic updates and manually recalculate the count
-    collection.skip_manifestations_count_update = false
-    collection.recalculate_manifestations_count! if collection.persisted?
+      # Checking all manifestations given authority is involved into as author or translator
+      locked_authority.published_manifestations(:author, :translator, :editor) # TODO: consider other roles?
+                      .preload(collection_items: :collection)
+                      .find_each do |m|
+        # skipping if manifestation is included in some other collection or already included in uncollected works
+        # collection for this authority
+        next if m.collection_items.any? do |ci|
+          !ci.collection.uncollected? || (collection.present? && ci.collection == collection)
+        end
 
-    if authority.uncollected_works_collection.nil?
-      authority.uncollected_works_collection = collection
-      authority.save!
+        collection.collection_items.build(item: m, seqno: nextseqno)
+        nextseqno += 1
+      end
+
+      # Save collection first
+      collection.save!
+
+      # Link collection to authority and save - this ensures referential integrity within transaction
+      # If this was a new collection, link it to the authority now
+      if is_new_collection
+        locked_authority.uncollected_works_collection = collection
+        locked_authority.save!
+      elsif locked_authority.changed?
+        locked_authority.save!
+      end
+
+      # Re-enable automatic updates and manually recalculate the count
+      collection.skip_manifestations_count_update = false
+      collection.recalculate_manifestations_count!
     end
   end
-  # rubocop:enable Style/GuardClause
 
   # removes from uncollected_works collection works which was included in some other collection
   def remove_collected_works(authority)

--- a/lib/tasks/cleanup_orphaned_uncollected_collections.rake
+++ b/lib/tasks/cleanup_orphaned_uncollected_collections.rake
@@ -1,0 +1,147 @@
+# frozen_string_literal: true
+
+desc 'Clean up orphaned uncollected collections created by race conditions'
+task :cleanup_orphaned_uncollected_collections, [:execute] => :environment do |_task, args|
+  execute_mode = args[:execute] == 'execute'
+
+  puts '=' * 80
+  puts 'Cleanup Orphaned Uncollected Collections'
+  puts '=' * 80
+  puts ''
+
+  if execute_mode
+    puts 'Running in EXECUTE mode - changes will be saved to database'
+  else
+    puts 'Running in DRY-RUN mode - no changes will be saved'
+    puts 'To execute changes, run: rake cleanup_orphaned_uncollected_collections[execute]'
+  end
+  puts ''
+
+  stats = {
+    orphaned_found: 0,
+    fixed_by_linking: 0,
+    deleted_empty: 0,
+    deleted_unfixable: 0
+  }
+
+  # Find all uncollected collections NOT linked to any authority
+  linked_collection_ids = Authority.where.not(uncollected_works_collection_id: nil)
+                                   .pluck(:uncollected_works_collection_id)
+  orphaned_collections = Collection.where(collection_type: :uncollected)
+                                   .where.not(id: linked_collection_ids)
+
+  puts "Found #{orphaned_collections.count} orphaned uncollected collection(s)"
+  puts ''
+
+  orphaned_collections.find_each do |collection|
+    stats[:orphaned_found] += 1
+    item_count = collection.collection_items.count
+
+    puts "Processing Collection ID #{collection.id} (#{item_count} items)..."
+
+    # Try to identify authority by examining collection_items
+    potential_authority = identify_authority_from_items(collection)
+
+    if potential_authority && potential_authority.uncollected_works_collection.nil?
+      # Can link it!
+      puts "  → Can link to Authority #{potential_authority.id} (#{potential_authority.name})"
+      if execute_mode
+        potential_authority.update!(uncollected_works_collection: collection)
+        stats[:fixed_by_linking] += 1
+        puts '  ✓ Linked successfully'
+      else
+        puts '  [DRY-RUN] Would link to authority'
+      end
+    elsif potential_authority && potential_authority.uncollected_works_collection.present?
+      # Authority already has a collection
+      collection_id = potential_authority.uncollected_works_collection_id
+      puts "  ⚠ Authority #{potential_authority.id} already has an uncollected collection (ID: #{collection_id})"
+      puts '  → Will delete this orphaned duplicate'
+      if execute_mode
+        collection.destroy!
+        stats[:deleted_unfixable] += 1
+        puts '  ✓ Deleted duplicate collection'
+      else
+        puts '  [DRY-RUN] Would delete duplicate collection'
+      end
+    elsif item_count == 0
+      # Empty orphan - safe to delete
+      puts '  → Empty collection, will delete'
+      if execute_mode
+        collection.destroy!
+        stats[:deleted_empty] += 1
+        puts '  ✓ Deleted empty collection'
+      else
+        puts '  [DRY-RUN] Would delete empty collection'
+      end
+    else
+      # Has items but can't link - delete with warning
+      puts '  ⚠ WARNING: Cannot determine owning authority'
+      puts "  → Will delete collection with #{item_count} item(s)"
+      if execute_mode
+        collection.destroy!
+        stats[:deleted_unfixable] += 1
+        puts '  ✓ Deleted unfixable collection'
+      else
+        puts '  [DRY-RUN] Would delete unfixable collection'
+      end
+    end
+
+    puts ''
+  end
+
+  # Print summary
+  puts '=' * 80
+  puts 'Summary'
+  puts '=' * 80
+  puts ''
+  puts "Orphaned collections found:      #{stats[:orphaned_found]}"
+  puts "Collections linked to authority: #{stats[:fixed_by_linking]}"
+  puts "Empty collections deleted:       #{stats[:deleted_empty]}"
+  puts "Unfixable collections deleted:   #{stats[:deleted_unfixable]}"
+  puts ''
+
+  if execute_mode
+    puts '✓ Cleanup completed successfully'
+  else
+    puts 'ℹ This was a dry-run. No changes were made.'
+    puts '  Run with [execute] argument to apply changes.'
+  end
+
+  puts ''
+end
+
+# Helper method to identify the owning authority from collection items
+def identify_authority_from_items(collection)
+  # Get all authorities from collection items by examining manifestations
+  authority_ids = []
+
+  collection.collection_items.where(item_type: 'Manifestation').includes(item: { expression: :work }).find_each do |ci|
+    next if ci.item.blank?
+
+    manifestation = ci.item
+
+    # Get authorities from both work and expression level (authors, translators, editors)
+    # We prioritize work-level authorities (authors) over expression-level (translators, editors)
+    work_authority_ids = InvolvedAuthority.where(item_id: manifestation.expression.work_id, item_type: 'Work')
+                                          .where(role: %i(author illustrator))
+                                          .pluck(:authority_id)
+    expression_authority_ids = InvolvedAuthority.where(item_id: manifestation.expression_id, item_type: 'Expression')
+                                                .where(role: %i(translator editor))
+                                                .pluck(:authority_id)
+
+    # Prioritize work-level authorities (authors) since uncollected collections typically belong to authors
+    authority_ids += if work_authority_ids.any?
+                       work_authority_ids
+                     else
+                       expression_authority_ids
+                     end
+  end
+
+  authority_ids = authority_ids.uniq
+
+  # If all items belong to same authority, that's likely the owner
+  return nil unless authority_ids.length == 1
+
+  Authority.find_by(id: authority_ids.first)
+end

--- a/spec/lib/tasks/cleanup_orphaned_uncollected_collections_rake_spec.rb
+++ b/spec/lib/tasks/cleanup_orphaned_uncollected_collections_rake_spec.rb
@@ -1,0 +1,204 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'rake'
+
+RSpec.describe 'cleanup_orphaned_uncollected_collections', type: :task do
+  before(:all) do
+    Rake.application.rake_require 'tasks/cleanup_orphaned_uncollected_collections'
+    Rake::Task.define_task(:environment)
+  end
+
+  let(:task) { Rake::Task['cleanup_orphaned_uncollected_collections'] }
+
+  before do
+    task.reenable
+  end
+
+  describe 'dry-run mode' do
+    it 'identifies orphaned collections but does not delete them' do
+      # Create orphaned collection by bypassing validations
+      orphaned = create(:collection, collection_type: :other)
+      orphaned.update_column(:collection_type, Collection.collection_types[:uncollected])
+
+      initial_count = Collection.where(collection_type: :uncollected).count
+
+      # Capture output
+      expect do
+        task.invoke
+      end.to output(/Found 1 orphaned uncollected collection/).to_stdout
+
+      # Verify no changes made
+      expect(Collection.where(collection_type: :uncollected).count).to eq(initial_count)
+      expect { orphaned.reload }.not_to raise_error
+    end
+
+    it 'outputs dry-run notice' do
+      expect do
+        task.invoke
+      end.to output(/DRY-RUN mode/).to_stdout
+    end
+  end
+
+  describe 'execute mode' do
+    context 'with empty orphaned collection' do
+      it 'deletes the empty orphaned collection' do
+        # Create empty orphaned collection
+        orphaned = create(:collection, collection_type: :other)
+        orphaned.update_column(:collection_type, Collection.collection_types[:uncollected])
+        orphaned_id = orphaned.id
+
+        # Run task in execute mode
+        task.invoke('execute')
+
+        # Verify collection was deleted
+        expect { Collection.find(orphaned_id) }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+
+      it 'outputs deletion message' do
+        orphaned = create(:collection, collection_type: :other)
+        orphaned.update_column(:collection_type, Collection.collection_types[:uncollected])
+
+        expect do
+          task.invoke('execute')
+        end.to output(/Empty collections deleted:\s+1/).to_stdout
+      end
+    end
+
+    context 'with orphaned collection that can be linked' do
+      it 'links the collection to the correct authority when identifiable' do
+        # Create authority without uncollected collection
+        authority = create(:authority, uncollected_works_collection: nil)
+
+        # Create orphaned collection
+        orphaned = create(:collection, collection_type: :other)
+        orphaned.update_column(:collection_type, Collection.collection_types[:uncollected])
+
+        # Add manifestation by this authority to the orphaned collection
+        manifestation = create(:manifestation, author: authority)
+        create(:collection_item, collection: orphaned, item: manifestation)
+
+        # Run task
+        task.invoke('execute')
+
+        # Verify collection was linked
+        authority.reload
+        expect(authority.uncollected_works_collection_id).to eq(orphaned.id)
+      end
+
+      it 'outputs linking message' do
+        authority = create(:authority, uncollected_works_collection: nil)
+        orphaned = create(:collection, collection_type: :other)
+        orphaned.update_column(:collection_type, Collection.collection_types[:uncollected])
+        manifestation = create(:manifestation, author: authority)
+        create(:collection_item, collection: orphaned, item: manifestation)
+
+        expect do
+          task.invoke('execute')
+        end.to output(/Collections linked to authority:\s+1/).to_stdout
+      end
+    end
+
+    context 'with orphaned collection when authority already has a collection' do
+      it 'deletes the duplicate orphaned collection' do
+        # Create authority with existing uncollected collection
+        existing_collection = create(:collection, collection_type: :other)
+        existing_collection.update_column(:collection_type, Collection.collection_types[:uncollected])
+        authority = create(:authority, uncollected_works_collection: existing_collection)
+
+        # Create orphaned duplicate collection
+        orphaned = create(:collection, collection_type: :other)
+        orphaned.update_column(:collection_type, Collection.collection_types[:uncollected])
+
+        # Add manifestation by this authority to the orphaned collection
+        manifestation = create(:manifestation, author: authority)
+        create(:collection_item, collection: orphaned, item: manifestation)
+
+        orphaned_id = orphaned.id
+
+        # Run task
+        task.invoke('execute')
+
+        # Verify orphaned duplicate was deleted, existing collection remains
+        expect { Collection.find(orphaned_id) }.to raise_error(ActiveRecord::RecordNotFound)
+        expect { existing_collection.reload }.not_to raise_error
+        authority.reload
+        expect(authority.uncollected_works_collection_id).to eq(existing_collection.id)
+      end
+    end
+
+    context 'with orphaned collection having items from multiple authorities' do
+      it 'deletes the collection when authority cannot be determined' do
+        # Create two authorities
+        auth1 = create(:authority, uncollected_works_collection: nil)
+        auth2 = create(:authority, uncollected_works_collection: nil)
+
+        # Create orphaned collection with ambiguous ownership
+        orphaned = create(:collection, collection_type: :other)
+        orphaned.update_column(:collection_type, Collection.collection_types[:uncollected])
+
+        # Add items from both authorities
+        create(:collection_item, collection: orphaned, item: create(:manifestation, author: auth1))
+        create(:collection_item, collection: orphaned, item: create(:manifestation, author: auth2))
+
+        orphaned_id = orphaned.id
+
+        # Run task
+        expect do
+          task.invoke('execute')
+        end.to output(/WARNING.*Cannot determine owning authority/).to_stdout
+
+        # Verify collection was deleted
+        expect { Collection.find(orphaned_id) }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+
+      it 'outputs deletion count' do
+        auth1 = create(:authority)
+        auth2 = create(:authority)
+        orphaned = create(:collection, collection_type: :other)
+        orphaned.update_column(:collection_type, Collection.collection_types[:uncollected])
+        create(:collection_item, collection: orphaned, item: create(:manifestation, author: auth1))
+        create(:collection_item, collection: orphaned, item: create(:manifestation, author: auth2))
+
+        expect do
+          task.invoke('execute')
+        end.to output(/Unfixable collections deleted:\s+1/).to_stdout
+      end
+    end
+
+    context 'with no orphaned collections' do
+      it 'completes successfully with zero counts' do
+        expect do
+          task.invoke('execute')
+        end.to output(/Found 0 orphaned uncollected collection/).to_stdout
+      end
+    end
+
+    it 'outputs execution mode notice' do
+      expect do
+        task.invoke('execute')
+      end.to output(/EXECUTE mode/).to_stdout
+    end
+
+    it 'outputs summary statistics' do
+      expect do
+        task.invoke('execute')
+      end.to output(/Summary.*Orphaned collections found:/m).to_stdout
+    end
+  end
+
+  describe 'idempotency' do
+    it 'can be run multiple times safely' do
+      # Create orphaned collection
+      orphaned = create(:collection, collection_type: :other)
+      orphaned.update_column(:collection_type, Collection.collection_types[:uncollected])
+
+      # Run task twice
+      task.invoke('execute')
+      task.reenable
+      expect do
+        task.invoke('execute')
+      end.not_to raise_error
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Fixes a race condition in `RefreshUncollectedWorksCollection` service that created thousands of orphaned Collections (type='uncollected') not linked to any Authority.

## Root Cause

When `RefreshUncollectedWorksCollection.call(authority)` was invoked **concurrently** for the same authority:

1. Thread A: Creates Collection, saves it to DB, hasn't linked yet
2. Thread B: Creates Collection, saves it to DB, hasn't linked yet  
3. Thread A: Links its Collection to Authority (wins race)
4. Thread B: Finds Authority already has a collection, skips linking
5. **Result**: Thread B's Collection is orphaned!

This happened because:
- Collection was saved to DB (line 39) **before** linking to Authority (lines 45-48)
- No transaction wrapper or locking prevented concurrent execution
- Service called from multiple places without synchronization

## Solution

### 1. Fixed the Service (app/services/refresh_uncollected_works_collection.rb)

- ✅ Added `Authority.transaction do` wrapper for atomicity
- ✅ Implemented pessimistic locking: `Authority.lock.find(authority.id)`
- ✅ Re-check for existing collection inside lock (prevents race)
- ✅ Save collection and link to authority within same transaction
- ✅ Removed redundant rubocop directives

**Pattern followed:** Similar to `collection_items_controller.rb:100` (locking) and `clean_up_simple_ahoy_events.rb` (transaction)

### 2. Added Concurrency Tests (spec/services/refresh_uncollected_works_collection_spec.rb)

- ✅ Test with 2 concurrent threads - verifies only 1 collection created
- ✅ Test with 3 concurrent threads - verifies no lock contention errors
- ✅ Uses `Chewy.strategy(:bypass)` to handle Elasticsearch in threads
- ✅ Verifies no orphaned collections left after concurrent execution

### 3. Created Cleanup Rake Task (lib/tasks/cleanup_orphaned_uncollected_collections.rake)

- ✅ **Dry-run mode by default** (safe): `rake cleanup_orphaned_uncollected_collections`
- ✅ **Execute mode**: `rake cleanup_orphaned_uncollected_collections[execute]`
- ✅ Identifies orphaned collections (type='uncollected', not linked to Authority)
- ✅ Tries to link them by examining CollectionItems (checks authors via InvolvedAuthority)
- ✅ Handles edge cases:
  - Links to correct Authority when identifiable
  - Deletes empty collections
  - Deletes duplicates when Authority already has a collection
  - Deletes unfixable collections with warning
- ✅ Outputs detailed statistics

### 4. Added Rake Task Tests (spec/lib/tasks/cleanup_orphaned_uncollected_collections_rake_spec.rb)

- ✅ Tests dry-run mode (no changes)
- ✅ Tests all execute mode scenarios (13 examples)
- ✅ Tests linking orphans to correct authority
- ✅ Tests deleting empty/duplicate/unfixable orphans
- ✅ Tests idempotency

## Test Results

✅ **Service tests**: 4 examples, 0 failures  
✅ **Rake task tests**: 13 examples, 0 failures  
✅ **Full test suite**: 1668 examples, 0 failures, 14 pending (expected)  
✅ **RuboCop**: All offenses fixed  
✅ **Test duration**: 15 minutes 26 seconds

## Files Changed

- `app/services/refresh_uncollected_works_collection.rb` - Added transaction + locking
- `spec/services/refresh_uncollected_works_collection_spec.rb` - Added concurrency tests
- `lib/tasks/cleanup_orphaned_uncollected_collections.rake` - NEW cleanup task
- `spec/lib/tasks/cleanup_orphaned_uncollected_collections_rake_spec.rb` - NEW task tests

## Deployment Notes

After merging:
1. Run cleanup task in production: `rake cleanup_orphaned_uncollected_collections[execute]`
2. Monitor output to see how many orphans were fixed/deleted
3. No downtime required - changes are backward compatible

## Related Issues

Addresses the investigation request about thousands of orphaned 'uncollected' Collections in production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)