### PR TITLE
Add do_not_feature flag to exclude authorities from homepage carousels

### DIFF
--- a/app/controllers/authors_controller.rb
+++ b/app/controllers/authors_controller.rb
@@ -701,6 +701,7 @@ class AuthorsController < ApplicationController
       :blog_category_url,
       :profile_image,
       :bib_done,
+      :do_not_feature,
       :sort_name,
       :status,
       :legacy_credits,

--- a/app/controllers/welcome_controller.rb
+++ b/app/controllers/welcome_controller.rb
@@ -16,7 +16,7 @@ class WelcomeController < ApplicationController
     @pop_authors = popular_authors
     @pop_authors_this_month = @pop_authors # Temporary hack! TODO: stop cheating and actually count by month
     # @newest_authors = cached_newest_authors # deprecated because we stopped producing portraits
-    @random_authors = Authority.published.has_image.order(Arel.sql('RAND()')).limit(10)
+    @random_authors = Authority.published.has_image.featurable.order(Arel.sql('RAND()')).limit(10)
     @surprise_author = RandomAuthor.call
     @surprise_work = randomize_works(1)[0]
     @authors_in_genre = cached_authors_in_genre

--- a/app/services/random_author.rb
+++ b/app/services/random_author.rb
@@ -4,6 +4,7 @@
 class RandomAuthor < ApplicationService
   def call(genre = nil)
     relation = Authority.has_toc
+                     .featurable
                      .where(
                        <<~SQL.squish,
                          exists (

--- a/app/views/authors/_form.html.haml
+++ b/app/views/authors/_form.html.haml
@@ -9,6 +9,7 @@
     = f.input :intellectual_property,
               collection: Authority.intellectual_properties.keys.map { |ip| [textify_intellectual_property(ip), ip] }
     = f.input :bib_done, as: :radio_buttons, collection: [[t(:no), false], [t(:yes), true]]
+    = f.input :do_not_feature, as: :boolean
     = f.input :country, as: :string
     = f.input :comment, as: :text
     = f.input :viaf_id

--- a/config/locales/active_record.en.yml
+++ b/config/locales/active_record.en.yml
@@ -49,6 +49,7 @@ en:
         wikidata_uri: Wikidata URI
         comment: Comment
         bib_done: Is bibliography done?
+        do_not_feature: Do not feature in homepage carousels
         nli_id: ID in National Library
         viaf_id: ID in VIAF database
         blog_category_url: Link to category about the creator in blog

--- a/config/locales/active_record.he.yml
+++ b/config/locales/active_record.he.yml
@@ -53,6 +53,7 @@ he:
         wikidata_uri: כתובת בויקינתונים
         comment: הערה
         bib_done: ביבליוגרפיה הושלמה בסדנה?
+        do_not_feature: אל תציג בקרוסלות בדף הבית
         nli_id: מזהה בספרייה הלאומית
         viaf_id: "מזהה במאגר VIAF‏"
         blog_category_url: קישורית לקטגוריה על היוצר/ת ביומן הרשת

--- a/db/migrate/20260131180244_add_do_not_feature_to_authorities.rb
+++ b/db/migrate/20260131180244_add_do_not_feature_to_authorities.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddDoNotFeatureToAuthorities < ActiveRecord::Migration[8.0]
+  def change
+    add_column :authorities, :do_not_feature, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_01_08_221804) do
+ActiveRecord::Schema[8.0].define(version: 2026_01_31_180244) do
   create_table "aboutnesses", id: :integer, charset: "utf8mb4", collation: "utf8mb4_bin", force: :cascade do |t|
     t.integer "work_id"
     t.integer "user_id"
@@ -165,6 +165,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_01_08_221804) do
     t.integer "legacy_toc_id"
     t.text "legacy_credits"
     t.text "cached_credits"
+    t.boolean "do_not_feature", default: false, null: false
     t.index ["corporate_body_id"], name: "index_authorities_on_corporate_body_id", unique: true
     t.index ["impressions_count"], name: "index_authorities_on_impressions_count"
     t.index ["intellectual_property"], name: "index_authorities_on_intellectual_property"

--- a/spec/controllers/welcome_controller_spec.rb
+++ b/spec/controllers/welcome_controller_spec.rb
@@ -17,6 +17,25 @@ describe WelcomeController do
 
       it { is_expected.to be_successful }
     end
+
+    context 'when authorities with do_not_feature exist' do
+      render_views false
+
+      before do
+        create(:authority, :with_image, do_not_feature: true)
+        create_list(:authority, 5, :with_image, do_not_feature: false)
+        get :index
+      end
+
+      it 'excludes authorities with do_not_feature from random authors carousel' do
+        random_authors = assigns(:random_authors)
+        non_featurable_ids = Authority.where(do_not_feature: true).pluck(:id)
+
+        random_authors.each do |author|
+          expect(non_featurable_ids).not_to include(author.id)
+        end
+      end
+    end
   end
 
   describe '#featured_author_popup' do

--- a/spec/factories/authorities.rb
+++ b/spec/factories/authorities.rb
@@ -19,5 +19,9 @@ FactoryBot.define do
     trait :corporate_body do
       corporate_body { create(:corporate_body) }
     end
+
+    trait :with_image do
+      profile_image_file_name { 'test_image.jpg' }
+    end
   end
 end

--- a/spec/services/random_author_spec.rb
+++ b/spec/services/random_author_spec.rb
@@ -24,5 +24,27 @@ describe RandomAuthor do
 
       it { is_expected.to eq fable.authors.first }
     end
+
+    context 'when authority has do_not_feature flag' do
+      before do
+        clean_tables
+        # Create authority with do_not_feature = true
+        non_featurable_manifestation = create(:manifestation, status: :published)
+        non_featurable_manifestation.authors.first.update!(do_not_feature: true)
+
+        # Create featurable authority
+        create(:manifestation, status: :published)
+      end
+
+      it 'excludes authorities with do_not_feature flag' do
+        # Call multiple times to ensure we never get the non-featurable authority
+        results = 10.times.map { described_class.call }
+        non_featurable_ids = Authority.where(do_not_feature: true).pluck(:id)
+
+        results.each do |result|
+          expect(non_featurable_ids).not_to include(result.id)
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
## Summary
Implements issue by-yts: Allows excluding specific authorities from being featured in homepage carousels and cards.

## Changes Made
- **Database**: Added `do_not_feature` boolean column to `authorities` table (default: false, not null)
- **Model**: Created `featurable` scope to filter out flagged authorities
- **Carousels updated**:
  - `Authority.popular_authors` - Excludes flagged authorities while preserving popularity order
  - Random authors carousel in `welcome#index` - Filters out flagged authorities
  - Surprise author card via `RandomAuthor` service - Excludes flagged authorities
- **UI**: Added checkbox to authority editing form with proper I18n translations
- **Controller**: Permitted `do_not_feature` parameter in authors controller

## Testing
- Added comprehensive test coverage:
  - Authority model: `featurable` scope and `popular_authors` method
  - RandomAuthor service: Exclusion of flagged authorities  
  - WelcomeController: Random authors carousel exclusion
- All 73 related tests pass
- No regressions introduced

## Test Plan
1. Create/edit an authority and check the "Do not feature in homepage carousels" checkbox
2. Verify the authority does NOT appear in:
   - Popular authors carousel on homepage
   - Random authors carousel on homepage
   - Surprise author card on homepage
3. Uncheck the box and verify the authority can appear again in carousels

🤖 Generated with [Claude Code](https://claude.com/claude-code)