### PR TITLE
Add migration to reset cached_credits on all Collections

### DIFF
--- a/app/controllers/ingestibles_controller.rb
+++ b/app/controllers/ingestibles_controller.rb
@@ -760,6 +760,7 @@ class IngestiblesController < ApplicationController
           else
             @collection.append_item(m) # append the new text to the (current) end of the collection if there were no placeholders already
           end
+          @collection.invalidate_cached_credits!
         end
       end
     end
@@ -777,9 +778,9 @@ class IngestiblesController < ApplicationController
 
   def invalidate_whatsnew_cache
     # Delete cache for all sort orders and locales
-    %w[alpha recent].each do |sort_order|
+    %w(alpha recent).each do |sort_order|
       I18n.available_locales.each do |locale|
-        Rails.cache.delete(%w[whatsnew_data] + [sort_order, locale.to_s])
+        Rails.cache.delete(%w(whatsnew_data) + [sort_order, locale.to_s])
       end
     end
   end

--- a/db/migrate/20260202035920_reset_cached_credits_on_collections.rb
+++ b/db/migrate/20260202035920_reset_cached_credits_on_collections.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+# Reset cached_credits for all Collections to ensure the invalidation fix in
+# IngestiblesController is properly reflected in production data
+class ResetCachedCreditsOnCollections < ActiveRecord::Migration[8.0]
+  def up
+    # Update all collections to have nil cached_credits
+    # This will force recalculation on next fetch_credits call
+    Collection.update_all(cached_credits: nil)
+  end
+
+  def down
+    # No-op: cached_credits will be regenerated on demand via fetch_credits
+    # We cannot restore the old cached values
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_01_31_180244) do
+ActiveRecord::Schema[8.0].define(version: 2026_02_02_035920) do
   create_table "aboutnesses", id: :integer, charset: "utf8mb4", collation: "utf8mb4_bin", force: :cascade do |t|
     t.integer "work_id"
     t.integer "user_id"


### PR DESCRIPTION
## Summary
- Adds data migration to set `cached_credits` to `nil` for all Collections
- Ensures the invalidation fix in IngestiblesController is reflected in production data

## Context
The recent fix in IngestiblesController added a call to `invalidate_cached_credits!` after appending items during ingestion. This migration ensures existing Collections in production will have their stale cached credits cleared, forcing recalculation on next access.

## Changes
- New migration: `ResetCachedCreditsOnCollections`
- Updates all Collections to have `nil` cached_credits
- Down migration is a no-op (values regenerate on demand)

## Testing
- ✅ Migration runs successfully in development
- ✅ Verified all Collections have nil cached_credits after migration
- ✅ Tested rollback and re-migration

🤖 Generated with [Claude Code](https://claude.com/claude-code)