### PR TITLE
Fix slick carousel by upgrading to jQuery 3.7.0

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -4,7 +4,7 @@
 // It's not advisable to add code directly here, but if you do, it'll appear at the bottom of the
 // the compiled file.
 //
-//= require jquery
+//= require jquery3
 //= require jquery-ui/widgets/autocomplete
 //= require rails-ujs
 //= require sortable.min

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -11,9 +11,7 @@
  *= require BY_styles_Max399.css
  *= require_tree .
  *= require_self
-*/
-/*
-*= require slick
+ *= require slick
 */
 /*body{font-size:14px;} /* default */
 /* temporary fix */


### PR DESCRIPTION
## Summary
Fixes the slick carousel error "Uncaught TypeError: $(...).slick is not a function" on the homepage by upgrading from jQuery 1.12.4 to jQuery 3.7.0.

## Root Cause
The application was loading jQuery 1.12.4 via `//= require jquery` in application.js. The jquery-rails gem defaults to the old jquery.js (v1.12.4) when using the generic require directive. jQuery 1.12.4 is incompatible with Bootstrap 4 and modern jQuery plugins like slick carousel.

## Changes
- **app/assets/javascripts/application.js**: Changed `//= require jquery` to `//= require jquery3` to load jQuery 3.7.0
- **app/assets/stylesheets/application.scss**: Uncommented the slick CSS require directive (bonus fix - was inside a comment block)

## Testing
- Assets recompiled successfully
- jQuery 3.7.0 now loads in the browser
- Slick plugin is attached to the correct jQuery instance
- Manual testing: The homepage carousel should now work correctly

## Technical Details
The jquery-rails gem (v4.6.0) provides:
- `jquery.js` - jQuery 1.12.4 (old default)
- `jquery2.js` - jQuery 2.x
- `jquery3.js` - jQuery 3.7.0 (modern)

This change ensures compatibility with:
- Bootstrap 4.2.1 (loaded from CDN)
- jQuery Slick carousel
- Other modern jQuery plugins

Resolves: by-9dk