### PR TITLE
Async refresh of uncollected collection from manifestation#read

### DIFF
--- a/app/controllers/manifestation_controller.rb
+++ b/app/controllers/manifestation_controller.rb
@@ -1189,7 +1189,9 @@ class ManifestationController < ApplicationController
     @volumes = @m.volumes
     if !@volumes.empty? && @containments.any? { |ci| ci.collection.uncollected? }
       # if the text is in a volume, its inclusion in an uncollected collection is stale
-      @m.trigger_uncollected_recalculation # async update the uncollected collection this text was still in
+      uncollected_collection_ids = @m.collection_items.select { |ci| ci.collection.uncollected? }.map(&:collection_id)
+      # async update the uncollected collection this text was still in
+      RefreshUncollectedWorksCollectionJob.perform_async(uncollected_collection_ids)
       @containments.reject! { |ci| ci.collection.uncollected? }
     end
     @single_text_volume = @containments.size == 1 && !@containments.first.collection.has_multiple_manifestations?

--- a/app/models/manifestation.rb
+++ b/app/models/manifestation.rb
@@ -150,19 +150,6 @@ class Manifestation < ApplicationRecord
     )
   end
 
-  # async update the uncollected collection this text was still in
-  def trigger_uncollected_recalculation
-    return if collection_items.empty?
-
-    collection_items.joins(:collection).where(collection: { collection_type: 'uncollected' }).each do |ci|
-      au = Authority.where(uncollected_works_collection_id: ci.collection.id)
-      if au.present?
-        # RefreshUncollectedWorksJob.perform_async(au.first.id) # must be at most one
-        RefreshUncollectedWorksCollection.call(au.first)
-      end
-    end
-  end
-
   # return containing collections of collection_type volume or periodical_issue
   def volumes
     ret = []

--- a/app/sidekiq/refresh_uncollected_works_collection_job.rb
+++ b/app/sidekiq/refresh_uncollected_works_collection_job.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+# Sidekiq job to asynchronously refresh uncollected works collections for given authorities
+class RefreshUncollectedWorksCollectionJob
+  include Sidekiq::Job
+
+  def perform(uncollected_works_collection_ids)
+    Authority.where(uncollected_works_collection_id: uncollected_works_collection_ids).find_each do |authority|
+      RefreshUncollectedWorksCollection.call(authority)
+    end
+  end
+end

--- a/spec/sidekiq/refresh_uncollected_works_collection_job_spec.rb
+++ b/spec/sidekiq/refresh_uncollected_works_collection_job_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe RefreshUncollectedWorksCollectionJob do
+  describe '#perform' do
+    subject(:call) { described_class.new.perform(uncollected_works_collection_ids) }
+
+    let!(:uncollected_collection_1) { create(:collection, :uncollected) }
+    let!(:uncollected_collection_2) { create(:collection, :uncollected) }
+    let!(:uncollected_collection_3) { create(:collection, :uncollected) }
+
+    let!(:authority_1) { create(:authority, uncollected_works_collection: uncollected_collection_1) }
+    let!(:authority_2) { create(:authority, uncollected_works_collection: uncollected_collection_2) }
+    let!(:non_matching_authority) { create(:authority, uncollected_works_collection: uncollected_collection_3) }
+
+    before do
+      allow(RefreshUncollectedWorksCollection).to receive(:call)
+      call
+    end
+
+    context 'when valid collection IDs are given' do
+      let(:uncollected_works_collection_ids) { [uncollected_collection_1.id, uncollected_collection_2.id] }
+
+      it 'calls RefreshUncollectedWorksCollection for each matching authority' do
+        expect(RefreshUncollectedWorksCollection).to have_received(:call).with(authority_1)
+        expect(RefreshUncollectedWorksCollection).to have_received(:call).with(authority_2)
+        expect(RefreshUncollectedWorksCollection).to have_received(:call).exactly(2).times
+      end
+    end
+
+    context 'when invalid collection IDs are given' do
+      let(:uncollected_works_collection_ids) { [-1] }
+
+      it 'does not call RefreshUncollectedWorksCollection' do
+        expect(RefreshUncollectedWorksCollection).not_to have_received(:call)
+      end
+    end
+
+    context 'when empty array is given' do
+      let(:uncollected_works_collection_ids) { [] }
+
+      it 'does not call RefreshUncollectedWorksCollection' do
+        expect(RefreshUncollectedWorksCollection).not_to have_received(:call)
+      end
+    end
+  end
+end


### PR DESCRIPTION
We had an update of uncollected works collection called from manifestation#prep_for_read if manifestation was included both in regular and uncollected collections.

The problem was that this call was performed synchronously.

Now it is scheduled as Sidekiq job.