### PR TITLE
Add Ancient Egyptian language support (egy)

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -900,6 +900,7 @@ en:
   analyzed: Diagnosed
   ancient: Ancient Times and Piyyut
   ancient_greek: Ancient Greek
+  ancient_egyptian: Ancient Egyptian
   ancient_long: Ancient Times and Piyyut (up to 900 CE)
   announcement: Announcement
   another_feature: Show Another Featured Item

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -1472,6 +1472,7 @@ he:
   latin: לטינית
   italian: איטלקית
   ancient_greek: יוונית עתיקה
+  ancient_egyptian: מצרית עתיקה
   polish: פולנית
   romanian: רומנית
   hungarian: הונגרית

--- a/lib/bybe_utils.rb
+++ b/lib/bybe_utils.rb
@@ -619,6 +619,8 @@ module BybeUtils
       return I18n.t(:italian)
     when 'grc'
       return I18n.t(:ancient_greek)
+    when 'egy'
+      return I18n.t(:ancient_egyptian)
     when 'hu'
       return I18n.t(:hungarian)
     when 'cs'
@@ -901,7 +903,7 @@ module BybeUtils
 
   def get_langs
     return %w(he en fr de ru yi pl ar el la grc hu cs da no sv nl it pt fa fi
-              is es ro arc lad zh ka bg sa ta sux unk)
+              is es ro arc lad zh ka bg sa ta sux egy unk)
   end
 
   def get_genres_by_row(row) # just one row at a time


### PR DESCRIPTION
## Summary

Add Ancient Egyptian (מצרית עתיקה) with ISO 639-3 code 'egy' to the known languages array and labels.

## Changes

- Added 'egy' to `get_langs` array in `lib/bybe_utils.rb`
- Added `textify_lang` case for 'egy' mapping to `I18n.t(:ancient_egyptian)`
- Added Hebrew label `ancient_egyptian: מצרית עתיקה` in `config/locales/he.yml`
- Added English label `ancient_egyptian: Ancient Egyptian` in `config/locales/en.yml`

## Test plan

- [ ] Verify that 'egy' appears in language dropdowns for work/expression forms
- [ ] Verify that works with 'egy' as orig_lang display "מצרית עתיקה" in Hebrew locale
- [ ] Verify that works with 'egy' as orig_lang display "Ancient Egyptian" in English locale

Resolves by-j0x

🤖 Generated with [Claude Code](https://claude.com/claude-code)