### PR TITLE
Fix ExtractFirstFootnoteReference to handle text immediately after footnote

### DIFF
--- a/app/services/extract_first_footnote_reference.rb
+++ b/app/services/extract_first_footnote_reference.rb
@@ -20,17 +20,19 @@ class ExtractFirstFootnoteReference < ApplicationService
     # MultiMarkdown generates: <a href="#fn:N" id="fnref:N" class="footnote"><sup>N</sup></a>
     # where N is the sequential footnote number (starting from 1)
 
-    # Find the first paragraph that contains only the footnote reference link
-    # The pattern looks for a paragraph containing only whitespace and a footnote link,
-    # and also consumes any immediately following empty paragraphs that may be left behind
-    footnote_link_pattern = %r{<p>\s*(<a[^>]*href="#fn:\d+"[^>]*id="fnref:\d+"[^>]*>.*?</a>)\s*</p>(?:\s*<p>\s*</p>)*}m
+    # Find the first footnote link that appears at the start of a paragraph
+    # It may or may not have additional content after it in the same paragraph
+    footnote_link_pattern = %r{<p>\s*(<a[^>]*href="#fn:\d+"[^>]*id="fnref:\d+"[^>]*>.*?</a>)}m
     html_match = html.match(footnote_link_pattern)
 
     if html_match
       footnote_html = html_match[1] # Extract just the <a> tag
-      # Remove the entire paragraph containing the footnote reference and any immediately
-      # following empty paragraphs that may have been left behind
-      cleaned_html = html.sub(footnote_link_pattern, '').strip
+
+      # Remove just the footnote link from the HTML
+      cleaned_html = html.sub(footnote_html, '')
+
+      # Clean up any empty paragraphs that may result from the removal
+      cleaned_html = cleaned_html.gsub(%r{<p>\s*</p>}, '').strip
 
       { footnote_html: footnote_html, cleaned_html: cleaned_html }
     else

--- a/spec/services/extract_first_footnote_reference_spec.rb
+++ b/spec/services/extract_first_footnote_reference_spec.rb
@@ -136,5 +136,50 @@ describe ExtractFirstFootnoteReference do
         expect(result[:cleaned_html].strip).to eq(expected_cleaned_html)
       end
     end
+
+    context 'when footnote reference is immediately followed by text without blank line' do
+      let(:markdown) do
+        <<~MD
+          [^1]
+          The quick brown fox jumps over the lazy dog.
+
+          [^1]: Footnote text here
+        MD
+      end
+      let(:html) do
+        <<~HTML
+          <p><a href="#fn:1" id="fnref:1" title="see footnote" class="footnote"><sup>1</sup></a>The quick brown fox jumps over the lazy dog.</p>
+
+          <div class="footnotes">
+          <hr />
+          <ol>
+          <li id="fn:1">
+          <span>Footnote text here</span>
+          </li>
+          </ol>
+          </div>
+        HTML
+      end
+      let(:expected_cleaned_html) do
+        <<~HTML.strip
+          <p>The quick brown fox jumps over the lazy dog.</p>
+
+          <div class="footnotes">
+          <hr />
+          <ol>
+          <li id="fn:1">
+          <span>Footnote text here</span>
+          </li>
+          </ol>
+          </div>
+        HTML
+      end
+
+      it 'extracts the footnote link and preserves the following text' do
+        expected_link = '<a href="#fn:1" id="fnref:1" title="see footnote" class="footnote"><sup>1</sup></a>'
+        expect(result[:footnote_html]).to eq(expected_link)
+        expect(result[:cleaned_html].strip).to eq(expected_cleaned_html)
+      end
+    end
   end
 end


### PR DESCRIPTION
## Summary
- Fixed bug where ExtractFirstFootnoteReference failed when footnote reference line was immediately followed by text without a blank line
- Updated regex pattern to match footnote links at the start of paragraphs regardless of following content
- Improved cleanup logic to remove just the footnote link while preserving remaining text in the paragraph

## Test plan
- [x] Added regression test for the bug case (footnote reference immediately followed by text)
- [x] All existing tests pass
- [x] RuboCop passes with no offenses

## Related issues
Fixes by-0uq

🤖 Generated with [Claude Code](https://claude.com/claude-code)