### PR TITLE
Remove target attribute from converted internal links

### DIFF
--- a/app/helpers/collections_helper.rb
+++ b/app/helpers/collections_helper.rb
@@ -66,6 +66,8 @@ module CollectionsHelper
           relative_path += "##{href_uri.fragment}" if href_uri.fragment.present?
 
           link['href'] = relative_path
+          # Remove target attribute since internal links should not open in new tabs
+          link.remove_attribute('target')
         end
       rescue URI::InvalidURIError
         # Skip malformed URIs

--- a/spec/helpers/collections_helper_spec.rb
+++ b/spec/helpers/collections_helper_spec.rb
@@ -48,6 +48,20 @@ RSpec.describe CollectionsHelper, type: :helper do
         result = helper.convert_internal_links_to_relative(base_url, html)
         expect(result).to include('href="/#section"')
       end
+
+      it 'removes target attribute from internal links' do
+        html = '<a href="https://example.com/path" target="_blank">Link</a>'
+        result = helper.convert_internal_links_to_relative(base_url, html)
+        expect(result).to include('href="/path"')
+        expect(result).not_to include('target=')
+      end
+
+      it 'removes target attribute from root path links' do
+        html = '<a href="https://example.com" target="_blank">Home</a>'
+        result = helper.convert_internal_links_to_relative(base_url, html)
+        expect(result).to include('href="/"')
+        expect(result).not_to include('target=')
+      end
     end
 
     context 'when html contains external links' do
@@ -61,6 +75,13 @@ RSpec.describe CollectionsHelper, type: :helper do
         html = '<a href="http://example.com/path">HTTP Link</a>'
         result = helper.convert_internal_links_to_relative('https://example.com', html)
         expect(result).to include('href="http://example.com/path"')
+      end
+
+      it 'preserves target attribute on external links' do
+        html = '<a href="https://other-domain.com/path" target="_blank">External Link</a>'
+        result = helper.convert_internal_links_to_relative(base_url, html)
+        expect(result).to include('href="https://other-domain.com/path"')
+        expect(result).to include('target="_blank"')
       end
     end
 


### PR DESCRIPTION
## Summary
When converting internal absolute URLs to relative paths, also remove the `target="_blank"` attribute. Internal links should navigate within the same tab for better UX.

## Changes
- Added `link.remove_attribute('target')` when converting internal links in `convert_internal_links_to_relative` helper
- External links preserve their `target` attribute

## Test Coverage
Added 3 new test cases:
- ✅ Verifies target removed from internal links with paths
- ✅ Verifies target removed from root path links  
- ✅ Verifies target preserved on external links

All 21 tests pass.

## Related Issues
Closes by-pvt
Follow-up to #986

🤖 Generated with [Claude Code](https://claude.com/claude-code)