### PR TITLE
Prevent publisher_line/pub_year from being set on series Collections

### DIFF
--- a/app/controllers/collections_migration_controller.rb
+++ b/app/controllers/collections_migration_controller.rb
@@ -25,7 +25,11 @@ class CollectionsMigrationController < ApplicationController
       pub_line = params[:guessed_publisher]
       pub_line = pub_line.gsub(' :', ':').gsub(' ;',';').gsub(/\p{Space}*$/, '') if pub_line.present? # ditto
       # Don't set publisher_line/pub_year for series collections
-      collection_attrs = { title: title, collection_type: params[:collection_type], publication_id: params[:publication_id] }
+      collection_attrs = {
+        title: title,
+        collection_type: params[:collection_type],
+        publication_id: params[:publication_id]
+      }
       unless params[:collection_type] == 'series'
         collection_attrs[:publisher_line] = pub_line
         collection_attrs[:pub_year] = params[:guessed_year]

--- a/app/controllers/ingestibles_controller.rb
+++ b/app/controllers/ingestibles_controller.rb
@@ -511,7 +511,8 @@ class IngestiblesController < ApplicationController
       created_volume = true
     end
     # Populate publisher info if not already set (e.g. in new periodical issue)
-    # Don't set publisher_line/pub_year for series collections (series are groups of manifestations within a volume, not publications themselves)
+    # Don't set publisher_line/pub_year for series collections (series are groups of
+    # manifestations within a volume, not publications themselves)
     if @ingestible.publisher.present? && @collection.publisher_line.blank? && @collection.collection_type != 'series'
       @collection.publisher_line = @ingestible.publisher
       @collection.pub_year = @ingestible.year_published

--- a/spec/controllers/collections_migration_controller_spec.rb
+++ b/spec/controllers/collections_migration_controller_spec.rb
@@ -12,16 +12,18 @@ RSpec.describe CollectionsMigrationController do
   describe 'POST #create_collection' do
     context 'when creating a series collection' do
       it 'does not set publisher_line and pub_year' do
-        post :create_collection, params: {
-          authority: authority.id,
-          title: 'Test Series',
-          collection_type: 'series',
-          role: 'author',
-          guessed_publisher: 'Some Publisher',
-          guessed_year: '2020'
-        }
+        expect do
+          post :create_collection, params: {
+            authority: authority.id,
+            title: 'Test Series',
+            collection_type: 'series',
+            role: 'author',
+            guessed_publisher: 'Some Publisher',
+            guessed_year: '2020'
+          }
+        end.to change(Collection, :count).by(1)
 
-        collection = Collection.last
+        collection = assigns(:collection)
         expect(collection.collection_type).to eq 'series'
         expect(collection.publisher_line).to be_nil
         expect(collection.pub_year).to be_nil
@@ -30,16 +32,18 @@ RSpec.describe CollectionsMigrationController do
 
     context 'when creating a volume collection' do
       it 'sets publisher_line and pub_year' do
-        post :create_collection, params: {
-          authority: authority.id,
-          title: 'Test Volume',
-          collection_type: 'volume',
-          role: 'author',
-          guessed_publisher: 'Some Publisher',
-          guessed_year: '2020'
-        }
+        expect do
+          post :create_collection, params: {
+            authority: authority.id,
+            title: 'Test Volume',
+            collection_type: 'volume',
+            role: 'author',
+            guessed_publisher: 'Some Publisher',
+            guessed_year: '2020'
+          }
+        end.to change(Collection, :count).by(1)
 
-        collection = Collection.last
+        collection = assigns(:collection)
         expect(collection.collection_type).to eq 'volume'
         expect(collection.publisher_line).to eq 'Some Publisher'
         expect(collection.pub_year).to eq '2020'

--- a/spec/controllers/ingestibles_controller_spec.rb
+++ b/spec/controllers/ingestibles_controller_spec.rb
@@ -734,6 +734,35 @@ describe IngestiblesController do
           end
         end
       end
+
+      context 'when ingesting into a series collection' do
+        let(:series_collection) { create(:collection, collection_type: :series, title: 'Test Series') }
+        let(:series_ingestible) do
+          create(:ingestible,
+                 markdown: markdown,
+                 toc_buffer: toc_buffer,
+                 prospective_volume_id: series_collection.id.to_s,
+                 publisher: 'Test Publisher',
+                 year_published: '2024',
+                 no_volume: false)
+        end
+
+        before do
+          series_ingestible.update_parsing
+        end
+
+        it 'does not set publisher_line and pub_year on the series collection' do
+          # Ensure collection starts with blank publisher info
+          expect(series_collection.publisher_line).to be_nil
+          expect(series_collection.pub_year).to be_nil
+
+          post :ingest, params: { id: series_ingestible.id }
+
+          series_collection.reload
+          expect(series_collection.publisher_line).to be_nil
+          expect(series_collection.pub_year).to be_nil
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
## Summary
When ingesting into a Collection of type 'series', the publisher_line and pub_year fields should not be populated (unlike when ingesting into Collections of types like 'volume').

## Changes
- **IngestiblesController**: Added condition to skip setting publisher_line/pub_year when the collection type is 'series' (lines 513-518)
- **CollectionsMigrationController**: Modified create_collection to conditionally exclude these fields for series collections (lines 28-32)
- **Tests**: Added comprehensive tests in CollectionsMigrationController spec to verify the behavior

## Why
Series collections represent groups of manifestations within a volume (like a sonnet cycle or section of essays), not publications themselves. They should not have publication-level metadata like publisher or publication year.

## Test Plan
- ✅ All IngestiblesController tests pass (47 examples)
- ✅ All CollectionsMigrationController tests pass (2 examples)
- ✅ New tests verify that series collections don't get publisher_line/pub_year set

## Related Issue
Closes by-9eu

🤖 Generated with [Claude Code](https://claude.com/claude-code)