### PR TITLE
Auto-select next image after insertion in Manifestation#edit

### DIFF
--- a/app/views/manifestation/edit.html.haml
+++ b/app/views/manifestation/edit.html.haml
@@ -143,11 +143,14 @@
 
       // Auto-select next image in the dropdown
       var ddData = $('#images').data('ddslick');
-      if (ddData) {
+      if (ddData && ddData.settings && ddData.settings.data) {
         var currentIndex = ddData.selectedIndex;
-        var totalOptions = $('#images option').length;
+        var totalOptions = ddData.settings.data.length;
         if (currentIndex < totalOptions - 1) {
-          $('#images').ddslick('select', {index: currentIndex + 1});
+          // Use setTimeout to ensure DOM is ready for the selection change
+          setTimeout(function() {
+            $('#images').ddslick('select', {index: currentIndex + 1});
+          }, 0);
         }
       }
     });

--- a/spec/system/manifestation_edit_ddslick_spec.rb
+++ b/spec/system/manifestation_edit_ddslick_spec.rb
@@ -149,19 +149,18 @@ RSpec.describe 'Manifestation edit ddslick dropdown', :js, type: :system do
       visit manifestation_edit_path(manifestation)
       expect(page).to have_css('.dd-select', wait: 5)
 
+      # Wait for initial selection to be set (ddslick initializes asynchronously)
+      expect(page).to have_css('.dd-selected-text', text: 'test_image_1.jpg', wait: 5)
+
       # Get the initial selected index (should be 0)
       initial_index = page.evaluate_script("$('#images').data('ddslick').selectedIndex")
       expect(initial_index).to eq(0)
 
-      # Get the initial selected filename
-      initial_filename = page.evaluate_script("$('#images').data('ddslick').selectedData.text")
-      expect(initial_filename).to eq('test_image_1.jpg')
-
       # Click the add image button
       find('#add_image').click
 
-      # Wait for the selection to change
-      expect(page).to have_css('.dd-select', wait: 5)
+      # Wait for the selection to change by checking the selected text
+      expect(page).to have_css('.dd-selected-text', text: 'test_image_2.jpg', wait: 5)
 
       # Verify the next image is now selected
       new_index = page.evaluate_script("$('#images').data('ddslick').selectedIndex")
@@ -183,8 +182,8 @@ RSpec.describe 'Manifestation edit ddslick dropdown', :js, type: :system do
       # Select the last image (index 1, since we have 2 images)
       page.execute_script("$('#images').ddslick('select', {index: 1})")
 
-      # Wait for selection to update
-      expect(page).to have_css('.dd-select', wait: 5)
+      # Wait for selection to update by checking the selected text
+      expect(page).to have_css('.dd-selected-text', text: 'test_image_2.jpg', wait: 5)
 
       # Verify we're on the last image
       current_index = page.evaluate_script("$('#images').data('ddslick').selectedIndex")
@@ -193,9 +192,11 @@ RSpec.describe 'Manifestation edit ddslick dropdown', :js, type: :system do
       # Click the add image button
       find('#add_image').click
 
+      # Verify we're still on the last image by checking the text hasn't changed
+      # (it should remain test_image_2.jpg)
+      expect(page).to have_css('.dd-selected-text', text: 'test_image_2.jpg', wait: 5)
+
       # Verify we're still on the last image (didn't wrap around or error)
-      # Use a wait condition instead of sleep
-      expect(page).to have_css('.dd-select', wait: 5)
       final_index = page.evaluate_script("$('#images').data('ddslick').selectedIndex")
       expect(final_index).to eq(1)
 


### PR DESCRIPTION
## Summary
After inserting an image from the dd-select dropdown in Manifestation#edit, automatically select the next image in the list to improve UX when inserting multiple images in order (which is the common workflow).

## Changes
- Enhanced the `#add_image` click handler to automatically advance to the next image in the ddslick dropdown after insertion
- Added logic to prevent advancing beyond the last image (stays on last image if already at the end)
- Added comprehensive system specs to test the auto-selection behavior

## Test Plan
- [x] Run new system specs - all pass
- [x] Test manually that clicking "Add Image" advances to the next image
- [x] Test manually that when on the last image, it doesn't advance or error
- [x] Verify image insertion still works correctly
- [x] Verify ddslick dropdown initialization is not affected

## Technical Details
- Uses ddslick's API (`$('#images').data('ddslick')`) to access current selection
- Calls `ddslick('select', {index: currentIndex + 1})` to advance to next image
- Checks if current index is less than total options before advancing

Closes by-7r7

🤖 Generated with [Claude Code](https://claude.com/claude-code)