### PR TITLE
Fix prospective_volume_title incorrectly populated when selecting collection

### DIFF
--- a/app/views/ingestibles/_form.html.haml
+++ b/app/views/ingestibles/_form.html.haml
@@ -347,7 +347,7 @@
     });
     $('#cterm').on('railsAutocomplete.select', function(event, data){
       $('#prospective_volume_id').val(data.item.id);
-      $('#ingestible_prospective_volume_title').val(data.item.value);
+      $('#ingestible_prospective_volume_title').val('');
       $('#volume_title').text(data.item.value);
       $('#ingestible_no_volume').prop('checked', false);
       $('#need_to_save').show();

--- a/spec/system/ingestible_sub_collection_selector_spec.rb
+++ b/spec/system/ingestible_sub_collection_selector_spec.rb
@@ -92,7 +92,7 @@ RSpec.describe 'Ingestible sub-collection selector', :js, :system do
 
     it 'hides dropdown when no sub-collections exist' do
       # Create a collection with no children
-      empty_collection = create(:collection, collection_type: :volume, title: 'Empty Volume')
+      create(:collection, collection_type: :volume, title: 'Empty Volume')
 
       visit new_ingestible_path
 
@@ -184,6 +184,40 @@ RSpec.describe 'Ingestible sub-collection selector', :js, :system do
 
       # Dropdown should be hidden
       expect(page).to have_css('#sub_collection_selector', visible: false, wait: 5)
+    end
+
+    it 'does not populate prospective_volume_title when selecting existing collection' do
+      visit new_ingestible_path
+
+      begin
+        find('#change_volume', wait: 5).click
+      rescue Capybara::ElementNotFound
+        # Volume details already visible
+      end
+
+      # Check no_volume first
+      check 'ingestible_no_volume', wait: 5
+
+      # Verify prospective_volume_title is empty
+      expect(find('#ingestible_prospective_volume_title', wait: 5).value).to eq('')
+
+      # Now select a collection via autocomplete
+      fill_in 'volume', with: 'Complete Works'
+      expect(page).to have_css('.ui-autocomplete', visible: true, wait: 5)
+
+      within('.ui-autocomplete', wait: 5) do
+        find('li', text: 'Complete Works', wait: 5).click
+      end
+
+      # The prospective_volume_title field should remain empty
+      # (it's for creating NEW volumes, not selecting existing ones)
+      expect(find('#ingestible_prospective_volume_title', wait: 5).value).to eq('')
+
+      # But the autocomplete field should show the selection
+      expect(find('#cterm', wait: 5).value).to eq('Complete Works')
+
+      # And the no_volume checkbox should be unchecked
+      expect(find('#ingestible_no_volume', wait: 5)).not_to be_checked
     end
   end
 end


### PR DESCRIPTION
## Summary
Fixed a bug where the `prospective_volume_title` field was incorrectly populated when selecting an existing collection via autocomplete, especially after checking the `no_volume` checkbox.

## Problem
The `prospective_volume_title` field is designed for creating NEW volumes. When selecting an EXISTING collection via autocomplete, this field should remain empty. However, the autocomplete handler was setting it to the selected collection's title.

This was particularly visible when:
1. Checking the `no_volume` checkbox (which clears all fields)
2. Then selecting a collection via autocomplete
3. The `prospective_volume_title` field would incorrectly show the collection title

## Solution
- Changed the autocomplete handler to **clear** the `prospective_volume_title` field instead of setting it
- This matches the behavior of other collection selection handlers (`authority_volumes` and `periodical_issues`)
- Added a regression test to verify the fix

## Test Plan
- [x] Run existing test suite - all tests pass
- [x] Run new regression test - passes
- [x] Verify manually: check `no_volume`, select collection, confirm `prospective_volume_title` stays empty

## Files Changed
- `app/views/ingestibles/_form.html.haml` - Fixed autocomplete handler (1 line changed)
- `spec/system/ingestible_sub_collection_selector_spec.rb` - Added regression test

🤖 Generated with Claude Code