### PR TITLE
Fix verification stuck at 98%: sync life_years with title quickVerify

### DIFF
--- a/app/controllers/lexicon/verification_controller.rb
+++ b/app/controllers/lexicon/verification_controller.rb
@@ -71,6 +71,10 @@ module Lexicon
         @entry.mark_all_works_verified!(notes)
       else
         @entry.update_checklist_item(path, verified, notes)
+        # For LexPerson, the 'title' section encompasses life years, so keep them in sync
+        if path == 'title' && @entry.lex_item_type == 'LexPerson'
+          @entry.update_checklist_item('life_years', verified, notes)
+        end
       end
 
       @entry.reload # Ensure we have the latest data

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -8,6 +8,7 @@ require 'rspec/rails'
 require 'chewy'
 require 'chewy/rspec'
 Chewy.strategy(:bypass)
+Chewy.request_strategy = :bypass # prevent Chewy middleware from triggering ES indexing in request specs
 
 # Add additional requires below this line. Rails is not loaded until this point!
 

--- a/spec/requests/lexicon/verification_spec.rb
+++ b/spec/requests/lexicon/verification_spec.rb
@@ -7,6 +7,51 @@ RSpec.describe 'Lexicon::Verification', type: :request do
     login_as_lexicon_editor
   end
 
+  describe 'PATCH /lex/verification/:id/update_checklist' do
+    context 'when verifying the title section for a LexPerson' do
+      let(:entry) do
+        e = create(:lex_entry, :person, status: :verifying)
+        e.start_verification!('editor@example.com')
+        e
+      end
+      let(:url) { "/lex/verification/#{entry.id}/update_checklist" }
+
+      it 'also marks life_years as verified when title is verified' do
+        patch url, params: { path: 'title', verified: 'true' }, as: :json
+
+        expect(response).to have_http_status(:success)
+        entry.reload
+        expect(entry.verification_progress.dig('checklist', 'title', 'verified')).to be true
+        expect(entry.verification_progress.dig('checklist', 'life_years', 'verified')).to be true
+      end
+
+      it 'also unverifies life_years when title is unverified' do
+        # First verify both
+        entry.update_checklist_item('title', true)
+        entry.update_checklist_item('life_years', true)
+
+        patch url, params: { path: 'title', verified: 'false' }, as: :json
+
+        expect(response).to have_http_status(:success)
+        entry.reload
+        expect(entry.verification_progress.dig('checklist', 'title', 'verified')).to be false
+        expect(entry.verification_progress.dig('checklist', 'life_years', 'verified')).to be false
+      end
+
+      it 'allows verification_percentage to reach 100 when all items are verified via quickVerify' do
+        # Simulate user clicking quickVerify on every section (title path covers life_years)
+        patch url, params: { path: 'title', verified: 'true' }, as: :json
+        patch url, params: { path: 'bio', verified: 'true' }, as: :json
+        patch url, params: { path: 'attachments', verified: 'true' }, as: :json
+
+        # Verify all collection items (citations, links, works are empty for this entry)
+        entry.reload
+        expect(entry.verification_percentage).to eq(100)
+        expect(entry.verification_complete?).to be true
+      end
+    end
+  end
+
   describe 'PATCH /lex/verification/:id/set_profile_image' do
     let(:entry) { create(:lex_entry) }
     let(:url) { "/lex/verification/#{entry.id}/set_profile_image" }


### PR DESCRIPTION
## Summary

- **Root cause**: The "Title and Life Years" section quickVerify button sends `path: 'title'`, which only marked `title` as verified in the checklist. `life_years` is a separate checklist item counted by `verification_percentage` but has no independent UI button — the only way to verify it was via the edit+save form flow (`update_section`). Users who clicked quickVerify ended up with `title=verified, life_years=unverified`, permanently stuck at ~98%.
- **Fix**: Added the same `title → life_years` sync logic to `update_checklist` that already existed in `update_section` (both verifying and unverifying are synced).
- **Also fixed**: `Chewy.request_strategy = :bypass` in `spec/rails_helper.rb` — the existing `Chewy.strategy(:bypass)` was ineffective for request specs because the Chewy middleware reads `request_strategy` dynamically per-request and was using `:atomic`, causing 5 pre-existing request spec failures on machines with full disks.

## Test plan

- [x] New request specs for the `update_checklist` title/life_years sync behaviour (3 tests)
- [x] All 12 tests in `spec/requests/lexicon/verification_spec.rb` pass (previously 8 failed)
- [x] Existing ES-dependent request specs (admin, manifestation, noindex) still pass

Closes by-483

🤖 Generated with [Claude Code](https://claude.com/claude-code)