### PR TITLE
Fix JS error and no display update after adding link in verification workbench (by-axb)

### DIFF
--- a/app/assets/javascripts/lexicon_backend.js
+++ b/app/assets/javascripts/lexicon_backend.js
@@ -22,7 +22,9 @@ $(function() {
 });
 
 function reloadContent(tabContent) {
+    if (!tabContent.length) return;
     const loadUrl = tabContent.data('load-url');
+    if (!loadUrl) return;
     tabContent.load(
         loadUrl,
         function( response, status, xhr ) {

--- a/app/views/lexicon/verification/_person_sections.html.haml
+++ b/app/views/lexicon/verification/_person_sections.html.haml
@@ -228,7 +228,7 @@
     - else
       %p.text-muted= t('lexicon.verification.sections.no_links')
   .section-actions
-    = link_to t('lexicon.verification.migrated.add_link'), new_lexicon_entry_link_path(entry), class: 'btn btn-sm btn-success', onclick: "event.preventDefault(); openModal(this.href);"
+    = link_to t('lexicon.verification.migrated.add_link'), new_lexicon_entry_link_path(entry), class: 'btn btn-sm btn-success', onclick: "event.preventDefault(); openModal(this.href, function() { location.reload(); });"
 
 -# Section 6: Attachments
 .section.verification-section{id: 'section-attachments', class: checklist['attachments']&.dig('verified') ? 'verified' : 'not-verified'}

--- a/app/views/lexicon/verification/_publication_sections.html.haml
+++ b/app/views/lexicon/verification/_publication_sections.html.haml
@@ -106,7 +106,7 @@
     - else
       %p.text-muted= t('lexicon.verification.sections.no_links')
   .section-actions
-    = link_to t('lexicon.verification.migrated.add_link'), new_lexicon_entry_link_path(entry), class: 'btn btn-sm btn-success', onclick: "event.preventDefault(); openModal(this.href);"
+    = link_to t('lexicon.verification.migrated.add_link'), new_lexicon_entry_link_path(entry), class: 'btn btn-sm btn-success', onclick: "event.preventDefault(); openModal(this.href, function() { location.reload(); });"
 
 -# Section 6: Attachments
 .section.verification-section{id: 'section-attachments', class: checklist['attachments']&.dig('verified') ? 'verified' : 'not-verified'}

--- a/spec/system/lexicon/verification_workbench_spec.rb
+++ b/spec/system/lexicon/verification_workbench_spec.rb
@@ -438,6 +438,35 @@ describe 'Lexicon Verification Workbench' do
     end
   end
 
+  describe 'Add Link modal', :js do
+    before do
+      skip 'WebDriver not available or misconfigured' unless webdriver_available?
+      visit "/lex/verification/#{entry.id}"
+    end
+
+    it 'adds a new link and refreshes the links section without JS errors' do
+      new_url = 'https://newlink.example.com'
+
+      within('#section-links') do
+        # Open the Add Link modal
+        find('a', text: I18n.t('lexicon.verification.migrated.add_link')).click
+      end
+
+      # Wait for modal to open and fill in the form
+      expect(page).to have_css('#generalDlg', visible: true, wait: 5)
+      within('#generalDlgBody') do
+        fill_in 'lex_link[url]', with: new_url
+        find('[type="submit"]').click
+      end
+
+      # Page should reload and show the new link (location.reload() callback)
+      expect(page).to have_css('#section-links', wait: 10)
+      within('#section-links') do
+        expect(page).to have_link(new_url, wait: 10)
+      end
+    end
+  end
+
   describe 'Profile Image Selection', :js do
     before do
       skip 'WebDriver not available or misconfigured' unless webdriver_available?


### PR DESCRIPTION
## Summary

Two related bugs in the verification workbench "Add Link" flow:

- **JS error**: `create.js`, `update.js`, and `destroy.js` all call `reloadContent($('#links'))`. In the verification workbench there is no `#links` element with `data-load-url`, so `loadUrl` is `undefined`. jQuery's `.load(undefined)` immediately throws `TypeError: can't access property "indexOf", url is undefined`. Since this error fires before the `ajax:success` event, the modal never closes and the page never updates.

- **No display update**: The `openModal()` call in both person and publication section views was invoked without an `onSuccess` callback, so even if the JS error hadn't blocked the event, the links section would still not refresh.

## Fix

- `lexicon_backend.js`: Added early-return guards to `reloadContent()` when the element is missing (`!tabContent.length`) or has no `data-load-url`. This prevents the crash and future-proofs other callers.
- `_person_sections.html.haml` / `_publication_sections.html.haml`: Pass `function() { location.reload(); }` as the `onSuccess` callback to `openModal()` for the "Add Link" button, so the page reloads after a link is successfully created.

## Test plan

- [x] New system spec (`Add Link modal`) verifies that after submitting the form the new link appears in the section
- [x] All 8 `spec/requests/lexicon/links_spec.rb` tests continue to pass
- [x] Pre-existing system spec failures are all unrelated locale issues (confirmed baseline)

🤖 Generated with [Claude Code](https://claude.com/claude-code)