### PR TITLE
Add other_designation field to LexEntry (by-ead)

### DIFF
--- a/app/controllers/lexicon/people_controller.rb
+++ b/app/controllers/lexicon/people_controller.rb
@@ -63,7 +63,7 @@ module Lexicon
           :birthdate,
           :deathdate,
           :bio,
-          { entry_attributes: [:title] }
+          { entry_attributes: %i(title other_designation) }
         ]
       )
     end

--- a/app/controllers/lexicon/publications_controller.rb
+++ b/app/controllers/lexicon/publications_controller.rb
@@ -50,7 +50,7 @@ module Lexicon
           :description,
           :toc,
           :az_navbar,
-          { entry_attributes: [:title] }
+          { entry_attributes: %i(title other_designation) }
         ]
       )
     end

--- a/app/models/lex_entry.rb
+++ b/app/models/lex_entry.rb
@@ -127,17 +127,25 @@ class LexEntry < ApplicationRecord
     verification_percentage == 100
   end
 
-  # Mark entry as verified (only if verification is complete)
+  # Mark entry as verified (only if verification is complete).
+  # If the entry belongs to a LexPerson linked to an Authority, copies
+  # the Authority's other_designation into this entry's other_designation.
   def mark_verified!
     raise 'Verification not complete' unless verification_complete?
 
-    update!(
+    updates = {
       status: :verified,
       verification_progress: verification_progress.merge(
         'ready_for_publish' => true,
         'completed_at' => Time.current.iso8601
       )
-    )
+    }
+
+    if lex_item.is_a?(LexPerson) && lex_item.authority&.other_designation.present?
+      updates[:other_designation] = lex_item.authority.other_designation
+    end
+
+    update!(updates)
   end
 
   # Update a specific checklist item

--- a/app/views/lexicon/people/_form.html.haml
+++ b/app/views/lexicon/people/_form.html.haml
@@ -2,6 +2,7 @@
 = simple_form_for @lex_person, url: url, remote: true do |f|
   = f.simple_fields_for :entry do |ef|
     = ef.input :title
+    = ef.input :other_designation
     = ef.input :status do
       .form-control
         %span.badge.badge-primary= LexEntry.human_enum_name(:status, @lex_person.entry.status)

--- a/app/views/lexicon/publications/_form.html.haml
+++ b/app/views/lexicon/publications/_form.html.haml
@@ -2,6 +2,7 @@
 = simple_form_for @lex_publication, url: url, remote: true do |f|
   = f.simple_fields_for :entry do |ef|
     = ef.input :title
+    = ef.input :other_designation
     = ef.input :status do
       .form-control
         %span.badge.badge-primary= LexEntry.human_enum_name(:status, @lex_publication.entry.status)

--- a/config/locales/active_record.en.yml
+++ b/config/locales/active_record.en.yml
@@ -120,6 +120,7 @@ en:
       lex_entry:
         title: Title
         english_title: English Title
+        other_designation: Other Designation
         statuses:
           draft: Draft
           deprecated: Deprecated

--- a/config/locales/active_record.he.yml
+++ b/config/locales/active_record.he.yml
@@ -126,6 +126,7 @@ he:
       lex_entry:
         title: כותרת
         english_title: כותרת באנגלית
+        other_designation: כינויים אחרים
         statuses:
           draft: טיוטה
           deprecated: מבוטל

--- a/db/migrate/20260227223414_add_other_designation_to_lex_entries.rb
+++ b/db/migrate/20260227223414_add_other_designation_to_lex_entries.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddOtherDesignationToLexEntries < ActiveRecord::Migration[8.0]
+  def change
+    add_column :lex_entries, :other_designation, :string, limit: 1024
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_02_25_010000) do
+ActiveRecord::Schema[8.0].define(version: 2026_02_27_223414) do
   create_table "aboutnesses", id: :integer, charset: "utf8mb4", collation: "utf8mb4_bin", force: :cascade do |t|
     t.integer "work_id"
     t.integer "user_id"
@@ -662,6 +662,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_02_25_010000) do
     t.string "english_title"
     t.json "external_identifiers"
     t.bigint "profile_image_id"
+    t.string "other_designation", limit: 1024
     t.index ["lex_item_type", "lex_item_id"], name: "index_lex_entries_on_lex_item_type_and_lex_item_id", unique: true
     t.index ["profile_image_id"], name: "index_lex_entries_on_profile_image_id"
     t.index ["sort_title"], name: "index_lex_entries_on_sort_title"

--- a/spec/models/lex_entry_spec.rb
+++ b/spec/models/lex_entry_spec.rb
@@ -262,4 +262,75 @@ RSpec.describe LexEntry, type: :model do
       end
     end
   end
+
+  describe '#other_designation' do
+    it 'can be read and written' do
+      entry = create(:lex_entry, other_designation: 'alias1; alias2')
+      expect(entry.reload.other_designation).to eq('alias1; alias2')
+    end
+  end
+
+  describe '#mark_verified! other_designation copy' do
+    let(:person) { create(:lex_person) }
+    let(:entry) { create(:lex_entry, lex_item: person) }
+
+    before do
+      # Stub verification_complete? so we can test mark_verified! behaviour
+      # without going through the full checklist flow.
+      allow(entry).to receive(:verification_complete?).and_return(true)
+      entry.update!(verification_progress: { 'checklist' => {}, 'overall_notes' => '',
+                                             'ready_for_publish' => false })
+    end
+
+    context 'when the LexPerson is linked to an Authority with other_designation' do
+      let(:authority) { create(:authority, other_designation: 'שם א; שם ב') }
+
+      before { person.update!(authority: authority) }
+
+      it 'copies other_designation from the Authority onto the entry' do
+        entry.mark_verified!
+        expect(entry.reload.other_designation).to eq('שם א; שם ב')
+      end
+
+      it 'sets status to verified' do
+        entry.mark_verified!
+        expect(entry.reload).to be_status_verified
+      end
+    end
+
+    context 'when the LexPerson has no linked Authority' do
+      it 'leaves other_designation unchanged' do
+        entry.mark_verified!
+        expect(entry.reload.other_designation).to be_nil
+      end
+    end
+
+    context 'when the linked Authority has blank other_designation' do
+      let(:authority) { create(:authority, other_designation: '') }
+
+      before { person.update!(authority: authority) }
+
+      it 'does not overwrite other_designation' do
+        entry.update!(other_designation: 'existing value')
+        entry.mark_verified!
+        expect(entry.reload.other_designation).to eq('existing value')
+      end
+    end
+
+    context 'when the entry belongs to a LexPublication (not LexPerson)' do
+      let(:publication) { create(:lex_publication) }
+      let(:pub_entry) { create(:lex_entry, lex_item: publication, other_designation: nil) }
+
+      before do
+        allow(pub_entry).to receive(:verification_complete?).and_return(true)
+        pub_entry.update!(verification_progress: { 'checklist' => {}, 'overall_notes' => '',
+                                                   'ready_for_publish' => false })
+      end
+
+      it 'does not raise and leaves other_designation nil' do
+        expect { pub_entry.mark_verified! }.not_to raise_error
+        expect(pub_entry.reload.other_designation).to be_nil
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Summary

- Adds a 1024-character `other_designation` string column to the `lex_entries` table via migration
- Exposes the field for editing in both the LexPerson and LexPublication property forms (via `entry` nested attributes), with I18n labels
- On `mark_verified!`, automatically copies the linked Authority's `other_designation` into the LexEntry when the LexPerson is associated with an Authority

## Test plan

- [x] Model spec: `other_designation` can be persisted on `LexEntry`
- [x] Model spec: `mark_verified!` copies `other_designation` from Authority when LexPerson has a linked Authority with a non-blank value
- [x] Model spec: `mark_verified!` leaves `other_designation` unchanged when no Authority is linked
- [x] Model spec: `mark_verified!` does not overwrite a pre-existing value when Authority's `other_designation` is blank
- [x] Model spec: `mark_verified!` works correctly for LexPublication entries (no copy attempted)
- [x] All 23 model specs pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)