### PR TITLE
Fix parse_person_links skipping <a href> links with no extra attributes

### DIFF
--- a/app/services/lexicon/ingest_person.rb
+++ b/app/services/lexicon/ingest_person.rb
@@ -125,7 +125,7 @@ module Lexicon
           ''
         end
       end.map do |linkstring|
-        next unless linkstring =~ %r{(.*?)<a .*? href="(.*?)".*?>(.*?)</a>(.*)}m
+        next unless linkstring =~ %r{(.*?)<a .*?href="(.*?)".*?>(.*?)</a>(.*)}m
 
         person.links.build(
           url: ::Regexp.last_match(2),

--- a/spec/data/lexicon/href_only_link.php
+++ b/spec/data/lexicon/href_only_link.php
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>test person with href-only link</title>
+</head>
+<body dir="rtl">
+<table border="0" width="100%">
+  <tr>
+    <td><p align="center"><font size="5" color="#FF0000">ישראלי, ישראל</font><font size="4" color="#FF0000">(1970)</font></p></td>
+  </tr>
+</table>
+<p>פרטים ביוגרפיים.</p>
+<p><font size="4" color="#0000FF"><a name="Books">ספריו:</a></font></p>
+<ul>
+  <li>ספר לדוגמה (תל אביב : הוצאה לדוגמה, 1990)</li>
+</ul>
+<p><font size="4" color="#0000FF"><a name="Bib.">על המחבר ויצירתו:</a></font></p>
+<p>לא נמצאו מקורות.</p>
+<font size="4" color="#0000FF"><a name="links">קישורים:</a></font>
+<ul>
+  <li><a target="_blank" href="http://www.example.com/with-target">דוגמה עם target</a> באתר example</li>
+  <li>ה<a href="http://www.ynet.co.il/articles/0,7340,L-3132749,00.html">פרק הפותח</a> באתר ynet</li>
+</ul>
+</body>
+</html>

--- a/spec/services/lexicon/ingest_person_spec.rb
+++ b/spec/services/lexicon/ingest_person_spec.rb
@@ -51,6 +51,32 @@ describe Lexicon::IngestPerson do
     end
   end
 
+  context 'when a link has href as its only attribute (no target="_blank")' do
+    let!(:file) do
+      create(
+        :lex_file,
+        {
+          entrytype: :person,
+          status: :classified,
+          title: 'Test Person',
+          fname: 'href_only_link.php',
+          full_path: Rails.root.join('spec/data/lexicon/href_only_link.php')
+        }
+      )
+    end
+
+    it 'migrates all links including href-only links' do
+      expect { call }.to change(LexPerson, :count).by(1)
+
+      person = file.lex_entry.lex_item
+      expect(person.links.count).to eq(2)
+      expect(person.links.map(&:url)).to include(
+        'http://www.example.com/with-target',
+        'http://www.ynet.co.il/articles/0,7340,L-3132749,00.html'
+      )
+    end
+  end
+
   context 'when both birthdate and deathdate provided', vcr: { cassette_name: 'lexicon/ingest_person/00024' } do
     let(:file) do
       create(


### PR DESCRIPTION
## Problem

When migrating `00016.php` (and potentially other lexicon entries), links written as `<a href="...">` with `href` as the sole attribute were silently not migrated.

The `parse_person_links` method in `Lexicon::IngestPerson` used this regex to find links in the קישורים section:

```ruby
next unless linkstring =~ %r{(.*?)<a .*? href="(.*?)".*?>(.*?)</a>(.*)}m
```

The pattern `<a .*? href="` requires a **space before `href=`** in the pattern, meaning it can only match if there is at least one attribute before `href`. For example:
- ✅ `<a target="_blank" href="...">` — matched (has `target="_blank"` before `href`)
- ❌ `<a href="...">` — **not matched** (href is the first attribute, no space+attribute before it)

In `00016.php`, the second link in the קישורים section is:
```html
<li>ה<a href="http://www.ynet.co.il/articles/0,7340,L-3132749,00.html">פרק הפותח מתוך "עדן"</a> באתר ynet של ידיעות אחרונות</li>
```
This link was silently dropped.

## Fix

Remove the erroneous leading space from the pattern: `.*? href="` → `.*?href="`.

The fixed pattern `<a .*?href="` works for both cases:
- `<a href="..."` → after `<a `, `.*?` matches zero chars, then `href="` matches
- `<a target="_blank" href="..."` → after `<a `, `.*?` matches `target="_blank" `, then `href="` matches

## Changes

- `app/services/lexicon/ingest_person.rb`: remove space before `href=` in `parse_person_links` regex
- `spec/services/lexicon/ingest_person_spec.rb`: add regression test for href-only links
- `spec/data/lexicon/href_only_link.php`: minimal fixture with both link types

## Test plan

- [x] New spec context verifies both links (with and without `target="_blank"`) are migrated
- [x] All 3 `Lexicon::IngestPerson` specs pass
- [x] RuboCop passes on changed files