### PR TITLE
Fixed flaky spec

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -547,6 +547,7 @@ en:
       periodical_issue: to issue
       series: to whole series
       volume_series: to volume series
+      other: to whole collection
   genre_values:
     poetry: Poetry
     prose: Prose
@@ -1315,8 +1316,8 @@ en:
   items_to_save: Items to save
   items_to_print: Items to print
   included_items: Included items
-  download_full_collection: Save the collection in the selected format
-  download_n_selected_items: Save %{count} items in the selected format
+  download_full_collection: Download collection in the selected format
+  download_n_selected_items: Download %{count} items in the selected format
   print_full_collection: Print the collection
   print_n_selected_items: Print %{count} selected items
   select_all: Select all

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -1987,6 +1987,7 @@ he:
       periodical_issue: לתצוגת הגליון
       series: לתצוגת המחזור/שער כולו
       volume_series: לתצוגת סדרת הכרכים
+      other: לאוסף המלא
   genre_values:
     poetry: שירה
     prose: פרוזה


### PR DESCRIPTION
There were flaky spec failure:
```
 Download modal works correctly for collections
     Failure/Error: "#{t("collection.up_link.#{coll.collection_type}")} - #{coll.title.truncate(35)}"
     
     ActionView::Template::Error:
       Translation missing: he.collection.up_link.other
```

The reason was that sometimes collection created in spec got `collection_type = 'other'` and we missed i18n resource for this type.
I've added lines to it.

Also fixed couple of wrongly translated lines in english locale.