### PR TITLE
Add canonical URL link tag for SEO

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -2,6 +2,7 @@
 <html>
 <head>
   <title><%= @page_title ? @page_title : t(:default_page_title)%></title>
+  <link rel="canonical" href="https://benyehuda.org<%= request.path %>">
   <% if Rails.env.production? %>
     <!-- Global site tag (gtag.js) - Google Analytics -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=UA-4865013-2"></script>


### PR DESCRIPTION
## Summary

- Adds `<link rel="canonical" href="https://benyehuda.org/...">` to the `<head>` of every public page via the application layout
- The canonical URL always uses `https://benyehuda.org` (no `www`, no `http`) regardless of how the request arrived
- Uses `request.path` (without query string), which is standard SEO practice

## Why

The site is accessible via multiple URL variants (`http://`, `https://`, `www.`, non-www). Without a canonical tag, search engines may split ranking signals across these duplicates. This change consolidates everything under the authoritative `https://benyehuda.org` origin.

## Test plan

- [ ] Load any public page and inspect the `<head>` — verify `<link rel="canonical">` is present with the correct URL
- [ ] Check a few different pages (homepage, author page, work page) to confirm the path segment is correct for each
- [ ] Confirm backend/admin pages (using `backend.html.haml`) are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)