### PR TITLE
Fix sitewide search crash on Elasticsearch special characters

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -43,7 +43,7 @@ class SearchController < ApplicationController
   protected
 
   def sanitize_term(term)
-    term = term.gsub(/(\S)\"(\S)/, '\1\2').gsub('׳', "'").gsub('״', '"')
+    term = term.gsub(/(\S)"(\S)/, '\1\2').gsub('׳', "'").gsub('״', '"')
     quote_special_char_tokens(term)
   end
 
@@ -57,7 +57,11 @@ class SearchController < ApplicationController
   def quote_special_char_tokens(query)
     query.gsub(/"[^"]*"|[^\s"]+/) do |token|
       next token if token.start_with?('"')
-      next "\"#{token}\"" if token.match?(ELASTICSEARCH_SPECIAL_CHARS)
+
+      if token.match?(ELASTICSEARCH_SPECIAL_CHARS)
+        escaped_token = token.gsub('\\', '\\\\\\\\')
+        next "\"#{escaped_token}\""
+      end
 
       token
     end

--- a/spec/controllers/search_controller_spec.rb
+++ b/spec/controllers/search_controller_spec.rb
@@ -119,6 +119,11 @@ describe SearchController do
         end
       end
 
+      it 'does not crash on a trailing backslash' do
+        get :results, params: { q: 'שלום\\' }
+        expect(response).to be_successful
+      end
+
       it 'leaves already-quoted phrases untouched' do
         get :results, params: { q: '"Test Manifestation"' }
         expect(response).to be_successful


### PR DESCRIPTION
## Summary

- Sitewide search crashed when the query string contained Elasticsearch `query_string` reserved characters (e.g. `הו!` raised a parse error because `!` is a NOT operator)
- Added `quote_special_char_tokens` helper in `SearchController` that wraps any token containing a reserved character in double quotes, so ES treats it as a literal string
- The full set of reserved characters covered: `+ - = ! & | > < ( ) { } [ ] ^ ~ * ? : \ /`
- Already-quoted phrases (`"..."`) are passed through unchanged

## Test plan

- [ ] New tests in `spec/controllers/search_controller_spec.rb` cover: the reported `!` crash, all other special characters, and already-quoted phrases
- [ ] All 12 examples pass (`bundle exec rspec spec/controllers/search_controller_spec.rb`)
- [ ] Manual: search for `הו!` on the site — should return results (or zero results) without an error page

🤖 Generated with [Claude Code](https://claude.com/claude-code)