### PR TITLE
Add indent button to markdown editors

### DIFF
--- a/app/views/ingestibles/_form.html.haml
+++ b/app/views/ingestibles/_form.html.haml
@@ -182,6 +182,8 @@
                     %b.btn-text-v02= t(:remove_angled_brackets)
                   %button.btn-small-outline-v02#minuses_to_makafim{ style: 'display:unset' }
                     %b.btn-text-v02= t(:minuses_to_makafim)
+                  %button.btn-small-outline-v02#add_indent{ style: 'display:unset' }
+                    %b.btn-text-v02= t(:indent)
                   = f.text_area :markdown, class: 'textarea100 markdown'
                 .col-sm-9
                   %h2= t(:display_text)

--- a/app/views/manifestation/edit.html.haml
+++ b/app/views/manifestation/edit.html.haml
@@ -39,6 +39,8 @@
           %b.static-btn= t(:remove_angled_brackets)
         %button.btn-small-outline-v02#minuses_to_makafim
           %b.static-btn= t(:minuses_to_makafim)
+        %button.btn-small-outline-v02#add_indent
+          %b.static-btn= t(:indent)
 
         - if @m.images.attached?
           %button.btn-small-outline-v02#add_image

--- a/app/views/shared/_markdown_utils.html.haml
+++ b/app/views/shared/_markdown_utils.html.haml
@@ -58,6 +58,19 @@
       $txt.caretTo(caretPos+txtToAdd.length);
       $txt[0].scrollTo(scrollLeft, scrollTop); // restore scroll position
     });
+    $('##{container_id} #add_indent').click(function(e) {
+      e.preventDefault();
+      var $txt = jQuery(element_id);
+      var scrollLeft = $txt[0].scrollLeft;
+      var scrollTop  = $txt[0].scrollTop;
+      var caretPos = $txt[0].selectionStart;
+      var textAreaTxt = $txt.val();
+      var txtToAdd = "&emsp;";
+      $txt.val(textAreaTxt.substring(0, caretPos) + txtToAdd + textAreaTxt.substring(caretPos));
+      $txt.focus();
+      $txt.caretTo(caretPos+txtToAdd.length);
+      $txt[0].scrollTo(scrollLeft, scrollTop);
+    });
     // highlight suspicious angled brackets in rendered HTML
     $("#preview p:contains('> ')").each(function(){
       $(this).html(highlight_in_red($(this).html()));

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -874,6 +874,7 @@ en:
   url_placeholder: URL
   add_recommendation: Add Recommendation
   add_stanza_break: Add Stanza Break
+  indent: Indent
   add_tag: Add Tag
   add_this_work_to_anthology: Add This Work
   add_url: Add the Link

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -81,6 +81,7 @@ he:
   must_set_author: חובה לשייך יוצר!
   docx_too_large: אין די זכרון להסב את הקובץ. יש לפצלו או להסב ידנית.
   add_stanza_break: הוספת מעבר בית
+  indent: חזחה
   minuses_to_makafim: תיקון למקפים עבריים גאים
   tidy_footnote_dirs: סידור כיוון הערות
   add_angled_brackets: הוספת סימון שירה לקטע


### PR DESCRIPTION
## Summary

- Adds an **Indent** (חזחה) button to the Manifestation#edit and ingestible full-markdown editors, alongside the existing insertion buttons
- When clicked, inserts `&emsp;` at the current cursor position
- I18n keys added for both Hebrew (`חזחה`) and English (`Indent`)

## Changes

- `app/views/manifestation/edit.html.haml` — new `#add_indent` button after `#minuses_to_makafim`
- `app/views/ingestibles/_form.html.haml` — new `#add_indent` button in the full markdown tab
- `app/views/shared/_markdown_utils.html.haml` — click handler inserting `&emsp;` at caret position (reuses existing scroll/caret preservation pattern)
- `config/locales/he.yml` / `config/locales/en.yml` — `indent` key

## Test plan

- [ ] Open Manifestation#edit, click "חזחה" — verify `&emsp;` is inserted at cursor
- [ ] Open Ingestible edit → Full Markdown tab, click "חזחה" — verify same behaviour
- [ ] Verify caret moves to after the inserted text and scroll position is preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)