### PR TITLE
Fix ddslick spec: preserve analyzed flag when setting image metadata

### DIFF
--- a/spec/system/manifestation_edit_ddslick_spec.rb
+++ b/spec/system/manifestation_edit_ddslick_spec.rb
@@ -25,8 +25,12 @@ RSpec.describe 'Manifestation edit ddslick dropdown', :js, type: :system do
         filename: 'test_image_2.jpg',
         content_type: 'image/jpeg'
       )
-      # Set known dimensions so data-width/data-height are rendered and can be asserted
-      m.images.each { |img| img.blob.update!(metadata: { 'width' => 800, 'height' => 600 }) }
+      # Set known dimensions so data-width/data-height are rendered and can be asserted.
+      # 'analyzed' must be in the metadata JSON (not a separate column) to prevent the helper
+      # from calling blob.analyze, which would overwrite our dimensions with the fixture's real 1x1 size.
+      m.images.each do |img|
+        img.blob.update!(metadata: img.blob.metadata.merge('analyzed' => true, 'width' => 800, 'height' => 600))
+      end
     end
   end
 


### PR DESCRIPTION
## Summary

- `ActiveStorage::Blob#analyzed?` reads from the `metadata` JSON column, not a separate DB column
- The spec's `blob.update!(metadata: { 'width' => 800, 'height' => 600 })` replaced the entire metadata hash, stripping the `'analyzed'` key
- At render time, `image_dimensions_data` saw `blob.analyzed? == false` and called `blob.analyze`, which analyzed the actual 1×1 fixture image and overwrote the dimensions
- Result: inserted images had `style="width: 1px; height: 1px; ..."` instead of the expected `800px × 600px`

**Fix**: use `blob.metadata.merge(...)` to preserve existing metadata entries while adding `'analyzed' => true` alongside the known dimensions.

## Test plan

- [x] `bundle exec rspec spec/system/manifestation_edit_ddslick_spec.rb` — all 5 examples pass (was 2 failures)