### PR TITLE
Double extensions handling in FilesController

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,7 +12,7 @@ Bybeconv::Application.routes.draw do
   post 'collections_migration/create_collection'
 
   # Special route for user-friendly file links to be used in Manifestation and StaticPage markdown
-  get 'files/:record_type/:record_id/*filename', to: 'files#download', as: 'file_download'
+  get 'files/:record_type/:record_id/*filename', to: 'files#download', as: 'file_download', format: false
 
   namespace :admin do
     resources :featured_contents do

--- a/spec/requests/files_spec.rb
+++ b/spec/requests/files_spec.rb
@@ -93,7 +93,7 @@ describe '/files' do
 
         it 'redirects to the file URL' do
           attachment = record.images.detect { |att| att.filename.to_s == filename }
-          call
+          get "/files/#{record_type}/#{record_id}/#{filename}"
           expect(response).to redirect_to(rails_blob_url(attachment.blob, disposition: 'inline'))
         end
       end


### PR DESCRIPTION
Updated FilesController routing to properly handle files with dots in a filename (like file.double.ext). Previously it failed with 404 on such filenames