### PR TITLE
Fix NoMethodError on /works with stale pagination params

### DIFF
--- a/app/controllers/concerns/filtering_and_pagination_concern.rb
+++ b/app/controllers/concerns/filtering_and_pagination_concern.rb
@@ -46,8 +46,8 @@ module FilteringAndPaginationConcern
     end
 
     sort_column = get_sort_column(@sort_by)
-    @search_after_for_next = search_after_for_item(records.last, sort_column, false) if have_more_items
-    @search_after_for_previous = search_after_for_item(records.first, sort_column, true) if @page > 1
+    @search_after_for_next = search_after_for_item(records.last, sort_column, false) if have_more_items && records.last
+    @search_after_for_previous = search_after_for_item(records.first, sort_column, true) if @page > 1 && records.first
 
     records
   end

--- a/spec/controllers/manifestations_controller_spec.rb
+++ b/spec/controllers/manifestations_controller_spec.rb
@@ -203,6 +203,14 @@ describe ManifestationController do
           expect(subject).to be_successful
         end
       end
+
+      context 'when page > 1 and filter produces empty results' do
+        let(:browse_params) { { page: 2, search_input: 'zzz_no_match_xxxxxxxxxxx', search_type: 'workname' } }
+
+        it 'returns successfully without raising NoMethodError' do
+          expect(subject).to be_successful
+        end
+      end
     end
 
     after(:all) do


### PR DESCRIPTION
## Summary

- Fixes a production `NoMethodError: undefined method 'sort_title' for nil` crash on `GET /works`
- Root cause: stale or invalid pagination params (e.g. `page=2`) with an empty result set cause `records.first` to return `nil`, which is then passed to `search_after_for_item` and crashes on `nil.send(:sort_column)`
- Fix: add nil guards on both `search_after_for_item` calls in `FilteringAndPaginationConcern#paginate` (lines 49–50)

## Test plan

- [ ] Manually verify `/works?page=2` with no matching filters returns gracefully
- [ ] Run `bundle exec rspec spec/` to ensure no regressions