### PR TITLE
added missing event names

### DIFF
--- a/app/models/ahoy/event.rb
+++ b/app/models/ahoy/event.rb
@@ -5,9 +5,27 @@ module Ahoy
   class Event < ApplicationRecord
     include Ahoy::QueryMethods
 
-    ALLOWED_NAMES = %w(view download page_view search clicked_tag donev_text_footban donev_banner donev_sidebox_homepage
-                       donev_menu donev_mobile_menu donev_top_bar donev_mobile_top_banner donev_mobile_top_banner_scrolled
-                       donev_footban donev_footban_mobile).freeze
+    ALLOWED_NAMES = %w(
+      view
+      download
+      page_view
+      search
+      clicked_tag
+      donev_text_footban
+      donev_banner
+      donev_sidebox_homepage
+      donev_menu
+      donev_mobile_menu
+      donev_top_bar
+      donev_mobile_top_banner
+      donev_mobile_top_banner_scrolled
+      donev_footban
+      donev_footban_mobile
+      donev_footer
+      donev_bannmsg
+      donev_text_footban_mobile
+      donev_sidebox
+    ).freeze
 
     self.table_name = 'ahoy_events'
 


### PR DESCRIPTION
There were several errors in Sentry, caused by missing event names in Ahoy::Event::ALLOWED_NAMES array