### PR TITLE
Add mass update system for catalog editors

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -94,6 +94,7 @@ gem 'puma_worker_killer' # cycle workers when they bloat
 gem 'rack-attack' # control misbehaving clients
 gem 'rswag-api'
 gem 'rswag-ui'
+gem 'addressable' # used in application_helper
 
 gem 'dotenv', '~> 3.1.2'
 ## these were used for some legacy HtmlDir VIAF lookup stuff. They have a huge RAM footprint (~160MB per process), so commented out until needed again.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -834,6 +834,7 @@ DEPENDENCIES
   active_data
   active_record_query_trace
   activerecord-session_store
+  addressable
   ahoy_matey
   aws-sdk-s3
   bcrypt_pbkdf

--- a/app/controllers/admin/mass_updates_controller.rb
+++ b/app/controllers/admin/mass_updates_controller.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+module Admin
+  # Handles the mass update tool: selection of records and batch application of changes.
+  class MassUpdatesController < ApplicationController
+    before_action -> { require_editor('edit_catalog') }
+    layout 'backend'
+
+    def new
+      # renders new.html.haml
+    end
+
+    def create
+      records = params[:records].to_a.map(&:to_unsafe_h)
+      changes = params[:changes].to_a.map(&:to_unsafe_h)
+
+      if records.blank?
+        render json: { error: I18n.t('admin.mass_update.errors.no_records') }, status: :unprocessable_content
+        return
+      end
+
+      if changes.blank?
+        render json: { error: I18n.t('admin.mass_update.errors.no_changes') }, status: :unprocessable_content
+        return
+      end
+
+      results = MassUpdateService.new(records, changes).apply
+
+      render json: { results: format_results(results) }
+    end
+
+    # AJAX: returns flat list of all items (recursively) within a collection.
+    # Params: collection_id
+    # Returns: { items: [{ type:, id:, title:, depth: }, ...] }
+    def collection_contents
+      collection = Collection.find_by(id: params[:collection_id])
+      if collection.nil?
+        return render json: { error: I18n.t('admin.mass_update.errors.record_not_found') },
+                      status: :not_found
+      end
+
+      items = collect_items(collection, 0)
+      render json: { items: items }
+    end
+
+    # AJAX: returns manifestations whose Expression or Work an authority is involved in.
+    # Params: authority_id
+    # Returns: { manifestations: [{ id:, title: }, ...] }
+    def authority_manifestations
+      authority = Authority.find_by(id: params[:authority_id])
+      if authority.nil?
+        return render json: { error: I18n.t('admin.mass_update.errors.authority_not_found') },
+                      status: :not_found
+      end
+
+      manifestations = authority.manifestations.select(:id, :title).order(:title)
+      render json: { manifestations: manifestations.map { |m| { id: m.id, title: m.title } } }
+    end
+
+    private
+
+    def format_results(results)
+      results.map do |(type, id), change_results|
+        {
+          type: type,
+          id: id,
+          results: change_results.map { |r| r == :ok ? { ok: true } : { ok: false, error: r } }
+        }
+      end
+    end
+
+    # Recursively collects all items in a collection as a flat list.
+    def collect_items(collection, depth)
+      items = []
+      collection.collection_items.includes(:item).order(:seqno).each do |ci|
+        next if ci.item.blank?
+
+        case ci.item
+        when Manifestation
+          items << { type: 'Manifestation', id: ci.item.id, title: ci.item.title, depth: depth }
+        when Collection
+          items << { type: 'Collection', id: ci.item.id, title: ci.item.title, depth: depth }
+          items.concat(collect_items(ci.item, depth + 1))
+        end
+      end
+      items
+    end
+  end
+end

--- a/app/controllers/admin/mass_updates_controller.rb
+++ b/app/controllers/admin/mass_updates_controller.rb
@@ -94,7 +94,13 @@ module Admin
         {
           type: type,
           id: id,
-          results: change_results.map { |r| r == :ok ? { ok: true } : { ok: false, error: r } }
+          results: change_results.map do |r|
+            if r[:result] == :ok
+              { ok: true, change_index: r[:change_index] }
+            else
+              { ok: false, error: r[:result], change_index: r[:change_index] }
+            end
+          end
         }
       end
     end

--- a/app/controllers/admin/mass_updates_controller.rb
+++ b/app/controllers/admin/mass_updates_controller.rb
@@ -73,6 +73,20 @@ module Admin
       render json: { manifestations: manifestations.map { |m| { id: m.id, title: m.title } } }
     end
 
+    # AJAX: returns collections of type volume associated with an authority.
+    # Params: authority_id
+    # Returns: { volumes: [{ id:, title: }, ...] }
+    def authority_volumes
+      authority = Authority.find_by(id: params[:authority_id])
+      if authority.nil?
+        return render json: { error: I18n.t('admin.mass_update.errors.authority_not_found') },
+                      status: :not_found
+      end
+
+      volumes = authority.volumes.select(:id, :title).order(:title)
+      render json: { volumes: volumes.map { |v| { id: v.id, title: v.title } } }
+    end
+
     private
 
     def format_results(results)

--- a/app/controllers/admin/mass_updates_controller.rb
+++ b/app/controllers/admin/mass_updates_controller.rb
@@ -29,6 +29,22 @@ module Admin
       render json: { results: format_results(results) }
     end
 
+    # AJAX: returns id and title for a single Manifestation or Collection record.
+    # Params: type (Manifestation|Collection), id
+    # Returns: { id:, title:, type: } or 404
+    def record_info
+      record = case params[:type]
+               when 'Manifestation' then Manifestation.find_by(id: params[:id].to_i)
+               when 'Collection'    then Collection.find_by(id: params[:id].to_i)
+               end
+      if record.nil?
+        return render json: { error: I18n.t('admin.mass_update.errors.record_not_found') },
+                      status: :not_found
+      end
+
+      render json: { id: record.id, title: record.title, type: params[:type] }
+    end
+
     # AJAX: returns flat list of all items (recursively) within a collection.
     # Params: collection_id
     # Returns: { items: [{ type:, id:, title:, depth: }, ...] }

--- a/app/controllers/admin/mass_updates_controller.rb
+++ b/app/controllers/admin/mass_updates_controller.rb
@@ -3,7 +3,7 @@
 module Admin
   # Handles the mass update tool: selection of records and batch application of changes.
   class MassUpdatesController < ApplicationController
-    before_action -> { require_editor('edit_catalog') }
+    before_action -> { require_editor('batch_editing') }
     layout 'backend'
 
     def new

--- a/app/controllers/admin/saved_selections_controller.rb
+++ b/app/controllers/admin/saved_selections_controller.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+module Admin
+  # CRUD for SavedSelections used in the mass update tool.
+  class SavedSelectionsController < ApplicationController
+    before_action -> { require_editor('edit_catalog') }
+    before_action :set_selection, only: %i(show destroy)
+
+    def index
+      selections = SavedSelection.visible_to(current_user).order(name: :asc)
+      render json: selections.map { |s|
+        { id: s.id, name: s.name, shared: s.shared, mine: s.user_id == current_user.id,
+          item_count: s.saved_selection_items.size, delete_after: s.delete_after }
+      }
+    end
+
+    def show
+      items = @selection.saved_selection_items.map do |ssi|
+        record = ssi.item_type.constantize.find_by(id: ssi.item_id)
+        next if record.nil?
+
+        { type: ssi.item_type, id: ssi.item_id, title: record.title }
+      end.compact
+      render json: { id: @selection.id, name: @selection.name, items: items }
+    end
+
+    def create
+      selection = SavedSelection.new(
+        name: params[:name],
+        shared: params[:shared].in?(['true', '1', true]),
+        user: current_user
+      )
+
+      items_param = params[:items].to_a.map(&:to_unsafe_h)
+
+      ActiveRecord::Base.transaction do
+        selection.save!
+        items_param.each do |item|
+          selection.saved_selection_items.create!(item_type: item['type'], item_id: item['id'].to_i)
+        end
+      end
+
+      render json: { id: selection.id, name: selection.name, shared: selection.shared }, status: :created
+    rescue ActiveRecord::RecordInvalid => e
+      render json: { error: e.message }, status: :unprocessable_content
+    end
+
+    def destroy
+      unless @selection.user_id == current_user.id
+        render json: { error: I18n.t('admin.mass_update.errors.not_owner') }, status: :forbidden
+        return
+      end
+      @selection.destroy
+      head :no_content
+    end
+
+    private
+
+    def set_selection
+      @selection = SavedSelection.find_by(id: params[:id])
+      return if @selection.present?
+
+      render json: { error: I18n.t('admin.mass_update.errors.record_not_found') }, status: :not_found
+    end
+  end
+end

--- a/app/controllers/admin/saved_selections_controller.rb
+++ b/app/controllers/admin/saved_selections_controller.rb
@@ -3,7 +3,7 @@
 module Admin
   # CRUD for SavedSelections used in the mass update tool.
   class SavedSelectionsController < ApplicationController
-    before_action -> { require_editor('edit_catalog') }
+    before_action -> { require_editor('batch_editing') }
     before_action :set_selection, only: %i(show destroy)
 
     def index

--- a/app/controllers/admin/saved_selections_controller.rb
+++ b/app/controllers/admin/saved_selections_controller.rb
@@ -7,7 +7,7 @@ module Admin
     before_action :set_selection, only: %i(show destroy)
 
     def index
-      selections = SavedSelection.visible_to(current_user).order(name: :asc)
+      selections = SavedSelection.visible_to(current_user).includes(:saved_selection_items).order(name: :asc)
       render json: selections.map { |s|
         { id: s.id, name: s.name, shared: s.shared, mine: s.user_id == current_user.id,
           item_count: s.saved_selection_items.size, delete_after: s.delete_after }

--- a/app/models/saved_selection.rb
+++ b/app/models/saved_selection.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+# Stores a named, reusable set of records (Manifestations and/or Collections)
+# for use with the mass update tool. Selections expire after delete_after date.
+class SavedSelection < ApplicationRecord
+  belongs_to :user
+  has_many :saved_selection_items, dependent: :destroy
+
+  validates :name, presence: true
+  validates :delete_after, presence: true
+
+  before_validation :set_default_delete_after, on: :create
+
+  scope :active, -> { where(delete_after: Time.zone.today..) }
+  scope :visible_to, ->(user) { active.where(user: user).or(active.where(shared: true)) }
+
+  private
+
+  def set_default_delete_after
+    self.delete_after ||= 90.days.from_now.to_date
+  end
+end

--- a/app/models/saved_selection_item.rb
+++ b/app/models/saved_selection_item.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+# A single record (Manifestation or Collection) within a SavedSelection.
+class SavedSelectionItem < ApplicationRecord
+  belongs_to :saved_selection
+  belongs_to :item, polymorphic: true
+
+  ALLOWED_ITEM_TYPES = %w(Manifestation Collection).freeze
+
+  validates :item_type, inclusion: { in: ALLOWED_ITEM_TYPES }
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -18,7 +18,7 @@ class User < ApplicationRecord
   # editor bits
   EDITOR_BITS = %w(handle_proofs handle_recommendations curate_featured_content bib_workshop edit_catalog
                    legacy_metadata edit_people conversion_verification edit_sitenotice
-                   moderate_tags link_moderation).freeze
+                   moderate_tags link_moderation batch_editing).freeze
 
   def admin?
     admin

--- a/app/services/mass_update_service.rb
+++ b/app/services/mass_update_service.rb
@@ -19,7 +19,8 @@ class MassUpdateService
   EXPRESSION_FIELDS    = %w(title date period language first_publication_date
                             source_edition comment intellectual_property).freeze
   WORK_FIELDS          = %w(title genre primary orig_lang origlang_title date comment).freeze
-  COLLECTION_FIELDS    = %w(title sort_title collection_type comment
+  COLLECTION_FIELDS    = %w(title sort_title subtitle alternate_titles description
+                            publisher_line pub_year collection_type
                             suppress_download_and_print).freeze
 
   def initialize(records, changes)

--- a/app/services/mass_update_service.rb
+++ b/app/services/mass_update_service.rb
@@ -34,9 +34,16 @@ class MassUpdateService
       key = [rec['type'], rec['id'].to_i]
       record = load_record(rec['type'], rec['id'].to_i)
       results[key] = if record.nil?
-                       @changes.map { I18n.t('admin.mass_update.errors.record_not_found') }
+                       @changes.each_with_index.map do |_, i|
+                         { result: I18n.t('admin.mass_update.errors.record_not_found'), change_index: i }
+                       end
                      else
-                       @changes.map.with_index { |change, i| apply_change(record, change, i) }
+                       @changes.each_with_index.filter_map do |change, i|
+                         outcome = apply_change(record, change, i)
+                         next if outcome == :skip
+
+                         { result: outcome, change_index: i }
+                       end
                      end
     end
     results
@@ -76,7 +83,7 @@ class MassUpdateService
     value       = change['value'].presence
 
     target = resolve_field_target(record, record_type)
-    return :ok if target.nil? # change doesn't apply to this record type — skip silently
+    return :skip if target.nil? # change doesn't apply to this record type — omit from results
 
     unless allowed_field?(record_type, field)
       return I18n.t('admin.mass_update.errors.field_not_allowed', field: field)
@@ -134,7 +141,7 @@ class MassUpdateService
     return I18n.t('admin.mass_update.errors.authority_not_found') if authority.nil?
 
     entity = resolve_ia_entity(record, change['entity'])
-    return :ok if entity.nil? # change doesn't apply to this record type — skip silently
+    return :skip if entity.nil? # change doesn't apply to this record type — omit from results
 
     role = change['role']
 

--- a/app/services/mass_update_service.rb
+++ b/app/services/mass_update_service.rb
@@ -61,7 +61,10 @@ class MassUpdateService
       I18n.t('admin.mass_update.errors.unknown_change_kind', kind: change['kind'])
     end
   rescue StandardError => e
-    e.message
+    error_id = SecureRandom.hex(4)
+    Rails.logger.error("[MassUpdateService] Unexpected error (#{error_id}): #{e.message}\n" \
+                       "#{e.backtrace.first(10).join("\n")}")
+    I18n.t('admin.mass_update.errors.unknown_error', error_id: error_id)
   end
 
   # --- Field update ---

--- a/app/services/mass_update_service.rb
+++ b/app/services/mass_update_service.rb
@@ -76,10 +76,7 @@ class MassUpdateService
     value       = change['value'].presence
 
     target = resolve_field_target(record, record_type)
-    if target.nil?
-      return I18n.t('admin.mass_update.errors.field_not_applicable',
-                    record_type: record_type, field: field)
-    end
+    return :ok if target.nil? # change doesn't apply to this record type — skip silently
 
     unless allowed_field?(record_type, field)
       return I18n.t('admin.mass_update.errors.field_not_allowed', field: field)
@@ -137,10 +134,7 @@ class MassUpdateService
     return I18n.t('admin.mass_update.errors.authority_not_found') if authority.nil?
 
     entity = resolve_ia_entity(record, change['entity'])
-    if entity.nil?
-      return I18n.t('admin.mass_update.errors.ia_entity_not_applicable',
-                    entity: change['entity'])
-    end
+    return :ok if entity.nil? # change doesn't apply to this record type — skip silently
 
     role = change['role']
 

--- a/app/services/mass_update_service.rb
+++ b/app/services/mass_update_service.rb
@@ -1,0 +1,178 @@
+# frozen_string_literal: true
+
+# Applies a batch of changes to a list of Manifestation and/or Collection records.
+#
+# Usage:
+#   results = MassUpdateService.new(records, changes).apply
+#
+# records: array of { 'type' => 'Manifestation'|'Collection', 'id' => Integer }
+# changes: array of change hashes (see CHANGE_KINDS below)
+#
+# Returns:
+#   { [type, id] => [ :ok | error_string, ... ] }  (one entry per change per record)
+class MassUpdateService
+  CHANGE_KINDS = %w(field_update involved_authority_add involved_authority_remove
+                    external_link_add external_link_remove).freeze
+
+  MANIFESTATION_FIELDS = %w(title alternate_titles sort_title status comment
+                            exclude_from_index sefaria_linker).freeze
+  EXPRESSION_FIELDS    = %w(title date period language first_publication_date
+                            source_edition comment intellectual_property).freeze
+  WORK_FIELDS          = %w(title genre primary orig_lang origlang_title date comment).freeze
+  COLLECTION_FIELDS    = %w(title sort_title collection_type comment
+                            suppress_download_and_print).freeze
+
+  def initialize(records, changes)
+    @records = records
+    @changes = changes
+  end
+
+  def apply
+    results = {}
+    @records.each do |rec|
+      key = [rec['type'], rec['id'].to_i]
+      record = load_record(rec['type'], rec['id'].to_i)
+      results[key] = if record.nil?
+                       @changes.map { I18n.t('admin.mass_update.errors.record_not_found') }
+                     else
+                       @changes.map.with_index { |change, i| apply_change(record, change, i) }
+                     end
+    end
+    results
+  end
+
+  private
+
+  def load_record(type, id)
+    case type
+    when 'Manifestation' then Manifestation.find_by(id: id)
+    when 'Collection'    then Collection.find_by(id: id)
+    end
+  end
+
+  def apply_change(record, change, _index)
+    case change['kind']
+    when 'field_update'           then apply_field_update(record, change)
+    when 'involved_authority_add' then apply_involved_authority(record, change, :add)
+    when 'involved_authority_remove' then apply_involved_authority(record, change, :remove)
+    when 'external_link_add'      then apply_external_link(record, change, :add)
+    when 'external_link_remove'   then apply_external_link(record, change, :remove)
+    else
+      I18n.t('admin.mass_update.errors.unknown_change_kind', kind: change['kind'])
+    end
+  rescue StandardError => e
+    e.message
+  end
+
+  # --- Field update ---
+
+  def apply_field_update(record, change)
+    record_type = change['record_type']
+    field       = change['field']
+    value       = change['value'].presence
+
+    target = resolve_field_target(record, record_type)
+    if target.nil?
+      return I18n.t('admin.mass_update.errors.field_not_applicable',
+                    record_type: record_type, field: field)
+    end
+
+    unless allowed_field?(record_type, field)
+      return I18n.t('admin.mass_update.errors.field_not_allowed', field: field)
+    end
+
+    target.assign_attributes(field => value)
+    if target.save
+      :ok
+    else
+      target.errors.full_messages.join(', ')
+    end
+  end
+
+  # Returns the AR object that owns the given record_type fields for this record.
+  def resolve_field_target(record, record_type)
+    case record
+    when Manifestation
+      case record_type
+      when 'manifestation' then record
+      when 'expression'    then record.expression
+      when 'work'          then record.expression&.work
+      end
+    when Collection
+      record_type == 'collection' ? record : nil
+    end
+  end
+
+  def allowed_field?(record_type, field)
+    case record_type
+    when 'manifestation' then MANIFESTATION_FIELDS.include?(field)
+    when 'expression'    then EXPRESSION_FIELDS.include?(field)
+    when 'work'          then WORK_FIELDS.include?(field)
+    when 'collection'    then COLLECTION_FIELDS.include?(field)
+    else false
+    end
+  end
+
+  # --- InvolvedAuthority ---
+
+  def apply_involved_authority(record, change, action)
+    authority = Authority.find_by(id: change['authority_id'])
+    return I18n.t('admin.mass_update.errors.authority_not_found') if authority.nil?
+
+    entity = resolve_ia_entity(record, change['entity'])
+    if entity.nil?
+      return I18n.t('admin.mass_update.errors.ia_entity_not_applicable',
+                    entity: change['entity'])
+    end
+
+    role = change['role']
+
+    if action == :add
+      ia = InvolvedAuthority.find_or_initialize_by(item: entity, authority: authority, role: role)
+      ia.save ? :ok : ia.errors.full_messages.join(', ')
+    else
+      ia = InvolvedAuthority.find_by(item: entity, authority: authority, role: role)
+      if ia
+        ia.destroy
+        ia.destroyed? ? :ok : I18n.t('admin.mass_update.errors.destroy_failed')
+      else
+        I18n.t('admin.mass_update.errors.ia_not_found')
+      end
+    end
+  end
+
+  def resolve_ia_entity(record, entity_type)
+    case record
+    when Manifestation
+      case entity_type
+      when 'work'       then record.expression&.work
+      when 'expression' then record.expression
+      end
+    when Collection
+      entity_type == 'collection' ? record : nil
+    end
+  end
+
+  # --- ExternalLink ---
+
+  def apply_external_link(record, change, action)
+    if action == :add
+      link = ExternalLink.new(
+        linkable: record,
+        url: change['url'],
+        linktype: change['linktype'],
+        description: change['description'],
+        status: :approved
+      )
+      link.save ? :ok : link.errors.full_messages.join(', ')
+    else
+      link = ExternalLink.find_by(linkable: record, url: change['url'])
+      if link
+        link.destroy
+        link.destroyed? ? :ok : I18n.t('admin.mass_update.errors.destroy_failed')
+      else
+        I18n.t('admin.mass_update.errors.external_link_not_found', url: change['url'])
+      end
+    end
+  end
+end

--- a/app/services/mass_update_service.rb
+++ b/app/services/mass_update_service.rb
@@ -83,9 +83,22 @@ class MassUpdateService
 
     target.assign_attributes(field => value)
     if target.save
-      :ok
+      verify_field_persisted(target, field, value)
     else
       target.errors.full_messages.join(', ')
+    end
+  end
+
+  # Guards against silent normalization: if a before_validation callback
+  # reset the value to something other than what we intended, report it.
+  def verify_field_persisted(target, field, intended_value)
+    actual = target.public_send(field)
+    if intended_value.nil?
+      actual.nil? ? :ok : I18n.t('admin.mass_update.errors.value_not_persisted', field: field)
+    elsif actual.to_s == intended_value.to_s
+      :ok
+    else
+      I18n.t('admin.mass_update.errors.value_not_persisted', field: field)
     end
   end
 

--- a/app/views/admin/index.html.haml
+++ b/app/views/admin/index.html.haml
@@ -14,6 +14,7 @@
         %p= link_to t(:catalog_dashboard), manifestation_list_path
         %p= link_to t(:ingestibles_system), ingestibles_path
         %p= link_to t('collections_migration.index.title'), collections_migration_index_path
+        %p= link_to t('admin.mass_update.dashboard_link'), admin_mass_update_path
     - if current_user.admin?
       %b
         %p= link_to t('projects.index.title'), admin_projects_path

--- a/app/views/admin/mass_updates/new.html.haml
+++ b/app/views/admin/mass_updates/new.html.haml
@@ -1,0 +1,619 @@
+-# app/views/admin/mass_updates/new.html.haml
+.backend
+  %h1= t('admin.mass_update.new.title')
+
+  -# ─── SECTION 1: Record Selection ───────────────────────────────────────
+  .admin_dashboard_item
+    %h2= t('admin.mass_update.section_records')
+
+    -# Selection mode tabs
+    %ul.nav.nav-tabs#selection-mode-tabs{ role: 'tablist' }
+      %li.nav-item{ role: 'presentation' }
+        %a.nav-link.active{ href: '#tab-by-id', data: { toggle: 'tab' }, role: 'tab' }
+          = t('admin.mass_update.mode_by_id')
+      %li.nav-item{ role: 'presentation' }
+        %a.nav-link{ href: '#tab-by-title', data: { toggle: 'tab' }, role: 'tab' }
+          = t('admin.mass_update.mode_by_title')
+      %li.nav-item{ role: 'presentation' }
+        %a.nav-link{ href: '#tab-by-authority', data: { toggle: 'tab' }, role: 'tab' }
+          = t('admin.mass_update.mode_by_authority')
+
+    .tab-content.mt-2
+      -# ── Tab 1: By ID ──
+      .tab-pane.active#tab-by-id{ role: 'tabpanel' }
+        .admin_container
+          %b= t('admin.mass_update.record_type_label')
+          - rec_opts = [[t('admin.mass_update.record_type_manifestation'), 'Manifestation']]
+          - rec_opts << [t('admin.mass_update.record_type_collection'), 'Collection']
+          = select_tag :direct_record_type, options_for_select(rec_opts), id: 'direct-record-type'
+          &nbsp;
+          %b= t('admin.mass_update.id_label')
+          = text_field_tag :direct_id, nil, id: 'direct-id', size: 10, style: 'background-color: #ffffff;'
+          &nbsp;
+          %button.btn.btn-secondary.btn-sm#add-by-id-btn{ type: 'button' }= t('admin.mass_update.add_button')
+        .text-danger#add-by-id-error{ style: 'display:none' }
+
+      -# ── Tab 2: By Title Search ──
+      .tab-pane#tab-by-title{ role: 'tabpanel' }
+        .admin_container
+          %b= t('admin.mass_update.record_type_manifestation') + ': '
+          - m_ac_opts = { id: 'manifestation-title-search', style: 'background-color: #ffffff; min-width:350px;', id_element: '#manifestation-title-id' }
+          = autocomplete_field_tag :manifestation_title_search, '', autocomplete_manifestation_title_path, m_ac_opts
+          = hidden_field_tag :manifestation_title_id, '', id: 'manifestation-title-id'
+        .admin_container.mt-1
+          %b= t('admin.mass_update.record_type_collection') + ': '
+          - c_ac_opts = { id: 'collection-title-search', style: 'background-color: #ffffff; min-width:350px;', id_element: '#collection-title-id' }
+          = autocomplete_field_tag :collection_title_search, '', autocomplete_collection_title_path, c_ac_opts
+          = hidden_field_tag :collection_title_id, '', id: 'collection-title-id'
+
+      -# ── Tab 3: By Authority ──
+      .tab-pane#tab-by-authority{ role: 'tabpanel' }
+        .admin_container
+          %b= t('admin.mass_update.authority_name_label')
+          - a_ac_opts = { id: 'authority-name-search', style: 'background-color: #ffffff; min-width:350px;', id_element: '#authority-id-hidden' }
+          = autocomplete_field_tag :authority_name_search, '', autocomplete_authority_name_and_aliases_path, a_ac_opts
+          = hidden_field_tag :authority_id_hidden, '', id: 'authority-id-hidden'
+        #authority-lists{ style: 'display:none;' }
+          .admin_container.mt-1
+            %b= t('admin.mass_update.authority_volumes_label')
+            %select.form-control#authority-volumes-dropdown{ style: 'max-width:500px;' }
+              %option= ''
+            %button.btn.btn-secondary.btn-sm#add-authority-volume-btn{ type: 'button' }
+              = t('admin.mass_update.add_button')
+          .admin_container.mt-1
+            %b= t('admin.mass_update.authority_manifestations_label')
+            %select.form-control#authority-manifestations-dropdown{ style: 'max-width:500px;' }
+              %option= ''
+            %button.btn.btn-secondary.btn-sm#add-authority-manifestation-btn{ type: 'button' }
+              = t('admin.mass_update.add_button')
+
+    -# ── Collection Expansion Widget (hidden by default) ──
+    #collection-expand-widget{ style: 'display:none; border: 1px solid #660248; padding:10px; margin-top:8px; background-color:#f0f0ff;' }
+      %b= t('admin.mass_update.collection_expand_label')
+      %br
+      - expand_modes = [
+      -   [:collection_only,         t('admin.mass_update.collection_expand_collection_only')],
+      -   [:collection_and_contents, t('admin.mass_update.collection_expand_collection_and_contents')],
+      -   [:contents_only,           t('admin.mass_update.collection_expand_contents_only')],
+      -   [:manifestations_only,     t('admin.mass_update.collection_expand_manifestations_only')],
+      -   [:custom,                  t('admin.mass_update.collection_expand_custom')]
+      - ]
+      - expand_modes.each_with_index do |(val, label), i|
+        %label.d-block
+          %input{ type: 'radio', name: 'collection_expand_mode', value: val, checked: i.zero? }
+          = label
+      #custom-content-tree{ style: 'display:none; margin-top:8px;' }
+      %button.btn.btn-primary.btn-sm.mt-2#confirm-add-collection-btn{ type: 'button' }
+        = t('admin.mass_update.add_button')
+      %button.btn.btn-secondary.btn-sm.mt-2#cancel-add-collection-btn{ type: 'button' }
+        = t(:cancel)
+
+    -# ── Selected Records List ──
+    %h3.mt-3= t('admin.mass_update.records_list_title')
+    %ul.list-group#records-list{ style: 'min-height: 40px;' }
+      %li.list-group-item.text-muted#records-list-empty= t('admin.mass_update.no_records_in_list')
+
+    -# ── Saved Selections ──
+    .mt-3
+      %b= t('admin.mass_update.saved_selections_label')
+      %select.form-control#saved-selections-dropdown{ style: 'max-width:400px; display:inline-block;' }
+        %option{ value: '' }= t('admin.mass_update.saved_selections_label')
+      %button.btn.btn-secondary.btn-sm#load-selection-btn{ type: 'button' }
+        = t('admin.mass_update.load_selection_button')
+      &nbsp;|&nbsp;
+      - sel_name_opts = { id: 'new-selection-name', placeholder: t('admin.mass_update.save_selection_name_placeholder'), style: 'background-color:#ffffff; width:200px;' }
+      = text_field_tag :new_selection_name, nil, sel_name_opts
+      %button.btn.btn-secondary.btn-sm#save-private-btn{ type: 'button' }
+        = t('admin.mass_update.save_private_button')
+      %button.btn.btn-info.btn-sm#save-shared-btn{ type: 'button' }
+        = t('admin.mass_update.save_shared_button')
+    .mt-1#saved-selection-message{ style: 'display:none;' }
+
+  -# ─── SECTION 2: Changes to Apply ────────────────────────────────────────
+  .admin_dashboard_item.mt-4
+    %h2= t('admin.mass_update.section_changes')
+
+    -# Change kind selector
+    .admin_container
+      %b= t('admin.mass_update.change_type_label')
+      - ck_opts = [
+      -   [t('admin.mass_update.change_kind_field_update'),              'field_update'],
+      -   [t('admin.mass_update.change_kind_involved_authority_add'),    'involved_authority_add'],
+      -   [t('admin.mass_update.change_kind_involved_authority_remove'), 'involved_authority_remove'],
+      -   [t('admin.mass_update.change_kind_external_link_add'),         'external_link_add'],
+      -   [t('admin.mass_update.change_kind_external_link_remove'),      'external_link_remove']
+      - ]
+      = select_tag :change_kind, options_for_select(ck_opts), id: 'change-kind-select'
+
+    -# ── Sub-form: field_update ──
+    .change-subform.mt-2#subform-field-update
+      .admin_container
+        %b= t('admin.mass_update.record_type_label')
+        - frt_opts = [
+        -   [t('admin.mass_update.record_type_work'),         'work'],
+        -   [t('admin.mass_update.record_type_expression'),   'expression'],
+        -   [t('admin.mass_update.record_type_manifestation'),'manifestation'],
+        -   [t('admin.mass_update.record_type_collection'),   'collection']
+        - ]
+        = select_tag :field_record_type, options_for_select(frt_opts), id: 'field-record-type'
+        &nbsp;
+        %b= t('admin.mass_update.field_label')
+        %select.form-control#field-name-select{ style: 'display:inline-block; width:auto;' }
+      .admin_container.mt-1
+        %b= t('admin.mass_update.value_label')
+        = text_field_tag :field_value, nil, id: 'field-value', style: 'background-color:#ffffff; min-width:250px;'
+        %span#field-value-enum-container{ style: 'display:none;' }
+          %select.form-control#field-value-enum{ style: 'display:inline-block; width:auto;' }
+
+    -# ── Sub-form: involved_authority (add/remove) ──
+    .change-subform.mt-2#subform-involved-authority{ style: 'display:none;' }
+      .admin_container
+        %b= t('admin.mass_update.role_label')
+        - ia_role_opts = InvolvedAuthority.roles.keys.map { |r| [t(r), r] }
+        = select_tag :ia_role, options_for_select(ia_role_opts), id: 'ia-role-select'
+        &nbsp;
+        %b= t('admin.mass_update.entity_label')
+        - ia_ent_opts = [[t('admin.mass_update.entity_work'), 'work'], [t('admin.mass_update.entity_expression'), 'expression']]
+        = select_tag :ia_entity, options_for_select(ia_ent_opts), id: 'ia-entity-select'
+      .admin_container.mt-1
+        %b= t('admin.mass_update.authority_name_label')
+        - ia_ac_opts = { id: 'ia-authority-name', style: 'background-color:#ffffff; min-width:300px;', id_element: '#ia-authority-id' }
+        = autocomplete_field_tag :ia_authority_name, '', autocomplete_authority_name_and_aliases_path, ia_ac_opts
+        = hidden_field_tag :ia_authority_id, '', id: 'ia-authority-id'
+
+    -# ── Sub-form: external_link_add ──
+    .change-subform.mt-2#subform-external-link-add{ style: 'display:none;' }
+      .admin_container
+        %b= t('admin.mass_update.url_label')
+        = text_field_tag :ext_link_url, nil, id: 'ext-link-url', style: 'background-color:#ffffff; min-width:350px;'
+        &nbsp;
+        %b= t('admin.mass_update.link_type_label')
+        - lt_opts = ExternalLink.linktypes.keys.map { |lt| [t(lt), lt] }
+        = select_tag :ext_link_type, options_for_select(lt_opts), id: 'ext-link-type'
+      .admin_container.mt-1
+        %b= t('admin.mass_update.link_description_label')
+        = text_field_tag :ext_link_description, nil, id: 'ext-link-description', style: 'background-color:#ffffff; min-width:350px;'
+
+    -# ── Sub-form: external_link_remove ──
+    .change-subform.mt-2#subform-external-link-remove{ style: 'display:none;' }
+      .admin_container
+        %b= t('admin.mass_update.url_label')
+        = text_field_tag :ext_remove_url, nil, id: 'ext-remove-url', style: 'background-color:#ffffff; min-width:350px;'
+
+    %button.btn.btn-secondary.mt-2#add-change-btn{ type: 'button' }
+      = t('admin.mass_update.add_change_button')
+    .text-danger.mt-1#add-change-error{ style: 'display:none;' }
+
+    -# ── Changes List ──
+    %h3.mt-3= t('admin.mass_update.changes_list_title')
+    %ul.list-group#changes-list{ style: 'min-height: 40px;' }
+      %li.list-group-item.text-muted#changes-list-empty= t('admin.mass_update.no_changes_in_list')
+
+  -# ─── APPLY ───────────────────────────────────────────────────────────────
+  .mt-4
+    %button.btn.btn-danger#apply-btn{ type: 'button' }
+      = t('admin.mass_update.apply_button')
+    %span#applying-indicator{ style: 'display:none; margin-right:10px;' }
+      = t('admin.mass_update.applying')
+
+  .mt-4#results-section{ style: 'display:none;' }
+    %h2= t('admin.mass_update.results_title')
+    #results-body
+
+:javascript
+  var MassUpdate = (function() {
+    var selectedRecords = [];
+    var pendingChanges  = [];
+    var pendingCollection = null;
+
+    var i18n = {
+      removeButton:  #{t('admin.mass_update.remove_button').to_json},
+      noRecords:     #{t('admin.mass_update.no_records_in_list').to_json},
+      noChanges:     #{t('admin.mass_update.no_changes_in_list').to_json},
+      confirmApply:  #{t('admin.mass_update.confirm_apply', count_records: '__REC__', count_changes: '__CHG__').to_json},
+      resultOk:      #{t('admin.mass_update.result_ok').to_json},
+      resultError:   #{t('admin.mass_update.result_error', message: '__MSG__').to_json},
+      saveSuccess:   #{t('admin.saved_selections.save_success').to_json},
+      noSelections:  #{t('admin.saved_selections.no_selections').to_json},
+      typeManifest:  #{t('admin.mass_update.record_type_manifestation').to_json},
+      typeCollection:#{t('admin.mass_update.record_type_collection').to_json}
+    };
+
+    var fieldDefs = {
+      work:          #{MassUpdateService::WORK_FIELDS.to_json},
+      expression:    #{MassUpdateService::EXPRESSION_FIELDS.to_json},
+      manifestation: #{MassUpdateService::MANIFESTATION_FIELDS.to_json},
+      collection:    #{MassUpdateService::COLLECTION_FIELDS.to_json}
+    };
+
+    var enumOptions = {
+      genre:                 #{Work::GENRES.map { |g| [t(g), g] }.to_json},
+      status:                #{Manifestation.statuses.keys.map { |k| [t(k), k] }.to_json},
+      period:                #{Expression.periods.keys.map { |p| [t(p), p] }.to_json},
+      language:              #{get_langs.map { |lang| [textify_lang(lang), lang] }.to_json},
+      intellectual_property: #{Expression.intellectual_properties.keys.map { |ip| [textify_intellectual_property(ip), ip] }.to_json},
+      collection_type:       #{(Collection.collection_types.keys - Collection::SYSTEM_TYPES).map { |ct| [ct, ct] }.to_json}
+    };
+
+    var booleanFields = ['primary', 'exclude_from_index', 'sefaria_linker', 'suppress_download_and_print'];
+
+    function getCsrf() {
+      return $('meta[name="csrf-token"]').attr('content');
+    }
+
+    // ── Records list ──
+    function renderRecords() {
+      var $list = $('#records-list').empty();
+      if (selectedRecords.length === 0) {
+        $list.append('<li class="list-group-item text-muted">' + i18n.noRecords + '</li>');
+        return;
+      }
+      selectedRecords.forEach(function(rec, idx) {
+        var typeLabel = rec.type === 'Manifestation' ? i18n.typeManifest : i18n.typeCollection;
+        var $item = $('<li class="list-group-item d-flex justify-content-between align-items-center">');
+        $item.append('<span>' + typeLabel + ' #' + rec.id + ': ' + $('<span>').text(rec.title).html() + '</span>');
+        var $btn = $('<button class="btn btn-danger btn-sm">').text(i18n.removeButton);
+        (function(i) { $btn.on('click', function() { selectedRecords.splice(i, 1); renderRecords(); }); }(idx));
+        $item.append($btn);
+        $list.append($item);
+      });
+    }
+
+    function addRecord(type, id, title) {
+      if (!selectedRecords.some(function(r) { return r.type === type && r.id == id; })) {
+        selectedRecords.push({ type: type, id: parseInt(id, 10), title: title });
+        renderRecords();
+      }
+    }
+
+    // ── Collection expand widget ──
+    function showCollectionExpandWidget(id, title) {
+      pendingCollection = { id: id, title: title };
+      $('input[name="collection_expand_mode"]').first().prop('checked', true);
+      $('#custom-content-tree').hide().empty();
+      $('#collection-expand-widget').show();
+    }
+
+    $('#confirm-add-collection-btn').on('click', function() {
+      if (!pendingCollection) return;
+      var mode = $('input[name="collection_expand_mode"]:checked').val();
+      var cid = pendingCollection.id, ctitle = pendingCollection.title;
+      $('#collection-expand-widget').hide();
+      if (mode === 'collection_only') {
+        addRecord('Collection', cid, ctitle);
+        pendingCollection = null;
+      } else if (mode === 'custom') {
+        $('#custom-content-tree input[type=checkbox]:checked').each(function() {
+          addRecord($(this).data('type'), $(this).data('id'), $(this).data('title'));
+        });
+        pendingCollection = null;
+      } else {
+        var contentsUrl = '#{admin_mass_update_collection_contents_path}';
+        $.getJSON(contentsUrl, { collection_id: cid }, function(data) {
+          var all = data.items || [];
+          var filtered = mode === 'collection_and_contents'
+            ? [{ type: 'Collection', id: cid, title: ctitle }].concat(all)
+            : mode === 'contents_only' ? all
+            : mode === 'manifestations_only'
+              ? all.filter(function(i) { return i.type === 'Manifestation'; })
+            : [];
+          filtered.forEach(function(item) { addRecord(item.type, item.id, item.title); });
+        });
+        pendingCollection = null;
+      }
+    });
+
+    $('#cancel-add-collection-btn').on('click', function() {
+      pendingCollection = null;
+      $('#collection-expand-widget').hide();
+    });
+
+    $(document).on('change', 'input[name="collection_expand_mode"]', function() {
+      if ($(this).val() !== 'custom' || !pendingCollection) {
+        $('#custom-content-tree').hide();
+        return;
+      }
+      var contentsUrl = '#{admin_mass_update_collection_contents_path}';
+      $('#custom-content-tree').show().html('<em>טוען...</em>');
+      $.getJSON(contentsUrl, { collection_id: pendingCollection.id }, function(data) {
+        var $tree = $('#custom-content-tree').empty();
+        (data.items || []).forEach(function(item) {
+          var $label = $('<label class="d-block">').css('padding-right', (item.depth * 20) + 'px');
+          var $cb = $('<input type="checkbox" checked>');
+          $cb.data('type', item.type).data('id', item.id).data('title', item.title);
+          $label.append($cb).append(' ' + item.type + ' #' + item.id + ': ' + $('<span>').text(item.title).html());
+          $tree.append($label);
+        });
+      });
+    });
+
+    // ── Tab 1: By ID ──
+    $('#add-by-id-btn').on('click', function() {
+      var type = $('#direct-record-type').val();
+      var id   = $('#direct-id').val().trim();
+      if (!id) return;
+      fetchRecordTitle(type, id, function(title) {
+        if (type === 'Collection') {
+          showCollectionExpandWidget(id, title);
+        } else {
+          addRecord(type, id, title);
+        }
+        $('#direct-id').val('');
+        $('#add-by-id-error').hide();
+      }, function() {
+        $('#add-by-id-error').text('').show();
+      });
+    });
+
+    function fetchRecordTitle(type, id, onSuccess) {
+      var path = type === 'Manifestation'
+        ? '/manifestation/' + id + '.json'
+        : '/collections/' + id + '.json';
+      $.getJSON(path, function(data) {
+        onSuccess(data.title || ('#' + id));
+      }).fail(function() { onSuccess('#' + id); });
+    }
+
+    // ── Tab 2: Autocomplete ──
+    $(document).on('autocompleteselect', '#manifestation-title-search', function(event, ui) {
+      var id = ui.item.id || $('#manifestation-title-id').val();
+      addRecord('Manifestation', id, ui.item.label || $(this).val());
+      $(this).val(''); $('#manifestation-title-id').val(''); event.preventDefault();
+    });
+
+    $(document).on('autocompleteselect', '#collection-title-search', function(event, ui) {
+      var id = ui.item.id || $('#collection-title-id').val();
+      showCollectionExpandWidget(id, ui.item.label || $(this).val());
+      $(this).val(''); $('#collection-title-id').val(''); event.preventDefault();
+    });
+
+    // ── Tab 3: Authority ──
+    $(document).on('autocompleteselect', '#authority-name-search', function(event, ui) {
+      $('#authority-id-hidden').val(ui.item.id);
+      loadAuthorityDropdowns(ui.item.id);
+      event.preventDefault();
+    });
+
+    function loadAuthorityDropdowns(authorityId) {
+      $('#authority-lists').show();
+      var $volDrop = $('#authority-volumes-dropdown').html('<option value=""></option>');
+      var $manDrop = $('#authority-manifestations-dropdown').html('<option value=""></option>');
+      $.getJSON('/authors/' + authorityId + '/volumes', function(data) {
+        var vols = (data.volumes || []).concat(data.publications || []);
+        vols.forEach(function(v) {
+          $volDrop.append($('<option>').val(v.id).text(v.title));
+        });
+      });
+      var manifestUrl = '#{admin_mass_update_authority_manifestations_path}';
+      $.getJSON(manifestUrl, { authority_id: authorityId }, function(data) {
+        (data.manifestations || []).forEach(function(m) {
+          $manDrop.append($('<option>').val(m.id).data('title', m.title).text(m.title));
+        });
+      });
+    }
+
+    $('#add-authority-volume-btn').on('click', function() {
+      var $sel = $('#authority-volumes-dropdown');
+      var id = $sel.val(), title = $sel.find('option:selected').text();
+      if (id) showCollectionExpandWidget(id, title);
+    });
+
+    $('#add-authority-manifestation-btn').on('click', function() {
+      var $sel = $('#authority-manifestations-dropdown'), id = $sel.val();
+      var title = $sel.find('option:selected').data('title') || $sel.find('option:selected').text();
+      if (id) addRecord('Manifestation', id, title);
+    });
+
+    // ── Field dropdown ──
+    function updateFieldDropdown() {
+      var rt = $('#field-record-type').val();
+      var $sel = $('#field-name-select').empty();
+      (fieldDefs[rt] || []).forEach(function(f) { $sel.append($('<option>').val(f).text(f)); });
+      updateValueWidget();
+    }
+
+    function updateValueWidget() {
+      var field = $('#field-name-select').val();
+      if (!field) return;
+      if (enumOptions[field]) {
+        $('#field-value').hide();
+        var $enumSel = $('#field-value-enum').empty().append('<option value=""></option>');
+        enumOptions[field].forEach(function(pair) {
+          $enumSel.append($('<option>').val(pair[1]).text(pair[0]));
+        });
+        $('#field-value-enum-container').show();
+      } else if (booleanFields.indexOf(field) !== -1) {
+        $('#field-value').hide();
+        var $b = $('#field-value-enum').empty();
+        $b.append('<option value="">--</option>');
+        $b.append('<option value="true">כן / Yes</option>');
+        $b.append('<option value="false">לא / No</option>');
+        $('#field-value-enum-container').show();
+      } else {
+        $('#field-value-enum-container').hide();
+        $('#field-value').show();
+      }
+    }
+
+    $('#field-record-type').on('change', updateFieldDropdown);
+    $('#field-name-select').on('change', updateValueWidget);
+    updateFieldDropdown();
+
+    // ── Change sub-forms ──
+    function updateSubforms() {
+      var kind = $('#change-kind-select').val();
+      $('.change-subform').hide();
+      if (kind === 'field_update')              $('#subform-field-update').show();
+      else if (kind.indexOf('involved_') === 0) $('#subform-involved-authority').show();
+      else if (kind === 'external_link_add')    $('#subform-external-link-add').show();
+      else if (kind === 'external_link_remove') $('#subform-external-link-remove').show();
+    }
+    $('#change-kind-select').on('change', updateSubforms);
+    updateSubforms();
+
+    // ── Changes list ──
+    function renderChanges() {
+      var $list = $('#changes-list').empty();
+      if (pendingChanges.length === 0) {
+        $list.append('<li class="list-group-item text-muted">' + i18n.noChanges + '</li>');
+        return;
+      }
+      pendingChanges.forEach(function(ch, idx) {
+        var $item = $('<li class="list-group-item d-flex justify-content-between align-items-center">');
+        $item.append('<span>' + $('<span>').text(describeChange(ch)).html() + '</span>');
+        var $btn = $('<button class="btn btn-danger btn-sm">').text(i18n.removeButton);
+        (function(i) { $btn.on('click', function() { pendingChanges.splice(i, 1); renderChanges(); }); }(idx));
+        $item.append($btn);
+        $list.append($item);
+      });
+    }
+
+    function describeChange(ch) {
+      if (ch.kind === 'field_update') {
+        return ch.record_type + '.' + ch.field + ' = ' + (ch.value || '(blank)');
+      }
+      if (ch.kind === 'involved_authority_add') {
+        return '[+] ' + ch.role + ': ' + ch.authority_name + ' (' + ch.entity + ')';
+      }
+      if (ch.kind === 'involved_authority_remove') {
+        return '[-] ' + ch.role + ': ' + ch.authority_name + ' (' + ch.entity + ')';
+      }
+      if (ch.kind === 'external_link_add') return '[+ link] ' + ch.url + ' (' + ch.linktype + ')';
+      if (ch.kind === 'external_link_remove') return '[- link] ' + ch.url;
+      return ch.kind;
+    }
+
+    $('#add-change-btn').on('click', function() {
+      var kind = $('#change-kind-select').val(), change = { kind: kind }, error = null;
+      if (kind === 'field_update') {
+        change.record_type = $('#field-record-type').val();
+        change.field = $('#field-name-select').val();
+        var enumVisible = $('#field-value-enum-container').is(':visible');
+        change.value = enumVisible ? $('#field-value-enum').val() : $('#field-value').val();
+        if (!change.field) error = 'בחר שדה';
+      } else if (kind.indexOf('involved_') === 0) {
+        change.role = $('#ia-role-select').val();
+        change.authority_id = $('#ia-authority-id').val();
+        change.authority_name = $('#ia-authority-name').val();
+        change.entity = $('#ia-entity-select').val();
+        if (!change.authority_id) error = 'בחר יוצר/ת';
+      } else if (kind === 'external_link_add') {
+        change.url = $('#ext-link-url').val().trim();
+        change.linktype = $('#ext-link-type').val();
+        change.description = $('#ext-link-description').val();
+        if (!change.url) error = 'נא להזין כתובת URL';
+      } else if (kind === 'external_link_remove') {
+        change.url = $('#ext-remove-url').val().trim();
+        if (!change.url) error = 'נא להזין כתובת URL';
+      }
+      if (error) { $('#add-change-error').text(error).show(); return; }
+      $('#add-change-error').hide();
+      pendingChanges.push(change);
+      renderChanges();
+    });
+
+    // ── Apply ──
+    $('#apply-btn').on('click', function() {
+      if (!selectedRecords.length || !pendingChanges.length) return;
+      var msg = i18n.confirmApply
+        .replace('__REC__', selectedRecords.length)
+        .replace('__CHG__', pendingChanges.length);
+      if (!confirm(msg)) return;
+      $('#applying-indicator').show();
+      $('#apply-btn').prop('disabled', true);
+      $.ajax({
+        url: '#{admin_mass_update_path}',
+        method: 'POST',
+        contentType: 'application/json',
+        headers: { 'X-CSRF-Token': getCsrf() },
+        data: JSON.stringify({ records: selectedRecords, changes: pendingChanges }),
+        success: function(data) {
+          $('#applying-indicator').hide();
+          $('#apply-btn').prop('disabled', false);
+          renderResults(data.results);
+        },
+        error: function(xhr) {
+          $('#applying-indicator').hide();
+          $('#apply-btn').prop('disabled', false);
+          var errMsg = xhr.responseJSON ? xhr.responseJSON.error : 'שגיאה לא ידועה';
+          $('#results-body').html('<div class="alert alert-danger">' + $('<span>').text(errMsg).html() + '</div>');
+          $('#results-section').show();
+        }
+      });
+    });
+
+    function renderResults(results) {
+      var $body = $('#results-body').empty();
+      results.forEach(function(res) {
+        var typeLabel = res.type === 'Manifestation' ? i18n.typeManifest : i18n.typeCollection;
+        $body.append($('<h4>').text(typeLabel + ' #' + res.id));
+        var $ul = $('<ul class="list-group mb-2">');
+        res.results.forEach(function(r, i) {
+          var desc = describeChange(pendingChanges[i] || {});
+          var okMsg = desc + ': ' + i18n.resultOk;
+          var errMsg = desc + ': ' + i18n.resultError.replace('__MSG__', r.error || '?');
+          var $li = r.ok
+            ? $('<li class="list-group-item list-group-item-success">').text(okMsg)
+            : $('<li class="list-group-item list-group-item-danger">').text(errMsg);
+          $ul.append($li);
+        });
+        $body.append($ul);
+      });
+      $('#results-section').show();
+    }
+
+    // ── Saved Selections ──
+    function loadSavedSelectionsList() {
+      $.getJSON('#{admin_saved_selections_path}', function(data) {
+        var $drop = $('#saved-selections-dropdown').empty().append('<option value=""></option>');
+        if (!data.length) {
+          $drop.append($('<option>').val('').text(i18n.noSelections));
+          return;
+        }
+        data.forEach(function(s) {
+          var label = s.name + ' (' + s.item_count + ')' + (s.shared ? ' \u2605' : '');
+          $drop.append($('<option>').val(s.id).text(label));
+        });
+      });
+    }
+    loadSavedSelectionsList();
+
+    $('#load-selection-btn').on('click', function() {
+      var id = $('#saved-selections-dropdown').val();
+      if (!id) return;
+      $.getJSON('#{admin_saved_selections_path}/' + id, function(data) {
+        (data.items || []).forEach(function(item) { addRecord(item.type, item.id, item.title); });
+      });
+    });
+
+    function saveSelection(shared) {
+      var name = $('#new-selection-name').val().trim();
+      if (!name) { alert('נא לתת שם לבחירה'); return; }
+      if (!selectedRecords.length) { alert(i18n.noRecords); return; }
+      $.ajax({
+        url: '#{admin_saved_selections_path}',
+        method: 'POST',
+        contentType: 'application/json',
+        headers: { 'X-CSRF-Token': getCsrf() },
+        data: JSON.stringify({ name: name, shared: shared, items: selectedRecords }),
+        success: function() {
+          var $msg = $('#saved-selection-message');
+          $msg.text(i18n.saveSuccess).removeClass('text-danger').addClass('text-success').show();
+          setTimeout(function() { $msg.hide(); }, 3000);
+          $('#new-selection-name').val('');
+          loadSavedSelectionsList();
+        },
+        error: function(xhr) {
+          var err = xhr.responseJSON ? xhr.responseJSON.error : 'שגיאה';
+          $('#saved-selection-message').text(err).removeClass('text-success').addClass('text-danger').show();
+        }
+      });
+    }
+
+    $('#save-private-btn').on('click', function() { saveSelection(false); });
+    $('#save-shared-btn').on('click', function() { saveSelection(true); });
+
+    renderRecords();
+    renderChanges();
+
+  }());

--- a/app/views/admin/mass_updates/new.html.haml
+++ b/app/views/admin/mass_updates/new.html.haml
@@ -214,10 +214,10 @@
     };
 
     var fieldDefs = {
-      work:          #{MassUpdateService::WORK_FIELDS.to_json},
-      expression:    #{MassUpdateService::EXPRESSION_FIELDS.to_json},
-      manifestation: #{MassUpdateService::MANIFESTATION_FIELDS.to_json},
-      collection:    #{MassUpdateService::COLLECTION_FIELDS.to_json}
+      work:          #{MassUpdateService::WORK_FIELDS.map { |f| [t("admin.mass_update.fields.work.#{f}"), f] }.to_json},
+      expression:    #{MassUpdateService::EXPRESSION_FIELDS.map { |f| [t("admin.mass_update.fields.expression.#{f}"), f] }.to_json},
+      manifestation: #{MassUpdateService::MANIFESTATION_FIELDS.map { |f| [t("admin.mass_update.fields.manifestation.#{f}"), f] }.to_json},
+      collection:    #{MassUpdateService::COLLECTION_FIELDS.map { |f| [t("admin.mass_update.fields.collection.#{f}"), f] }.to_json}
     };
 
     var enumOptions = {
@@ -402,7 +402,7 @@
     function updateFieldDropdown() {
       var rt = $('#field-record-type').val();
       var $sel = $('#field-name-select').empty();
-      (fieldDefs[rt] || []).forEach(function(f) { $sel.append($('<option>').val(f).text(f)); });
+      (fieldDefs[rt] || []).forEach(function(pair) { $sel.append($('<option>').val(pair[1]).text(pair[0])); });
       updateValueWidget();
     }
 
@@ -464,7 +464,7 @@
 
     function describeChange(ch) {
       if (ch.kind === 'field_update') {
-        return ch.record_type + '.' + ch.field + ' = ' + (ch.value || '(blank)');
+        return ch.record_type + '.' + (ch.field_label || ch.field) + ' = ' + (ch.value || '(blank)');
       }
       if (ch.kind === 'involved_authority_add') {
         return '[+] ' + ch.role + ': ' + ch.authority_name + ' (' + ch.entity + ')';
@@ -482,6 +482,7 @@
       if (kind === 'field_update') {
         change.record_type = $('#field-record-type').val();
         change.field = $('#field-name-select').val();
+        change.field_label = $('#field-name-select option:selected').text();
         var enumVisible = $('#field-value-enum-container').is(':visible');
         change.value = enumVisible ? $('#field-value-enum').val() : $('#field-value').val();
         if (!change.field) error = 'בחר שדה';

--- a/app/views/admin/mass_updates/new.html.haml
+++ b/app/views/admin/mass_updates/new.html.haml
@@ -87,8 +87,11 @@
         = t(:cancel)
 
     -# ── Selected Records List ──
-    %h3.mt-3= t('admin.mass_update.records_list_title')
-    %ul.list-group#records-list{ style: 'min-height: 40px;' }
+    .mt-3.d-flex.align-items-center
+      %h3.mb-0= t('admin.mass_update.records_list_title')
+      %button.btn.btn-outline-danger.btn-sm.ml-3#clear-records-btn{ type: 'button', style: 'display:none;' }
+        = t('admin.mass_update.clear_all_button')
+    %ul.list-group.mt-2#records-list{ style: 'min-height: 40px;' }
       %li.list-group-item.text-muted#records-list-empty= t('admin.mass_update.no_records_in_list')
 
     -# ── Saved Selections ──
@@ -215,8 +218,12 @@
       errorNoAuthority:  #{t('admin.mass_update.errors.no_authority_selected').to_json},
       errorNoUrl:        #{t('admin.mass_update.errors.no_url_entered').to_json},
       errorUnknown:      #{t('admin.mass_update.errors.unknown_error').to_json},
-      errorNoName:       #{t('admin.mass_update.errors.no_selection_name').to_json},
-      loading:           #{t('admin.mass_update.loading').to_json}
+      errorNoName:        #{t('admin.mass_update.errors.no_selection_name').to_json},
+      loading:            #{t('admin.mass_update.loading').to_json},
+      clearAll:           #{t('admin.mass_update.clear_all_button').to_json},
+      resultsSummary:     #{t('admin.mass_update.results_summary', total: '__TOTAL__').to_json},
+      resultsSummaryOk:   #{t('admin.mass_update.results_summary_succeeded', count: '__OK__').to_json},
+      resultsSummaryFail: #{t('admin.mass_update.results_summary_failed', count: '__FAIL__').to_json}
     };
 
     var fieldDefs = {
@@ -245,6 +252,7 @@
     // ── Records list ──
     function renderRecords() {
       var $list = $('#records-list').empty();
+      $('#clear-records-btn').toggle(selectedRecords.length > 0);
       if (selectedRecords.length === 0) {
         $list.append('<li class="list-group-item text-muted">' + i18n.noRecords + '</li>');
         return;
@@ -266,6 +274,11 @@
         renderRecords();
       }
     }
+
+    $('#clear-records-btn').on('click', function() {
+      selectedRecords = [];
+      renderRecords();
+    });
 
     // ── Collection expand widget ──
     function showCollectionExpandWidget(id, title) {
@@ -561,6 +574,16 @@
 
     function renderResults(results) {
       var $body = $('#results-body').empty();
+      var total = 0, succeeded = 0, failed = 0;
+      results.forEach(function(res) {
+        res.results.forEach(function(r) { total++; if (r.ok) succeeded++; else failed++; });
+      });
+      var $summary = $('<div class="mb-3 p-2" style="border:1px solid #ccc; background:#f9f9f9; border-radius:4px;">');
+      $summary.append($('<span>').text(i18n.resultsSummary.replace('__TOTAL__', total) + ' '));
+      $summary.append($('<strong class="text-success">').text(i18n.resultsSummaryOk.replace('__OK__', succeeded)));
+      $summary.append($('<span>').text(', '));
+      $summary.append($('<strong class="text-danger">').text(i18n.resultsSummaryFail.replace('__FAIL__', failed)));
+      $body.append($summary);
       results.forEach(function(res) {
         var typeLabel = res.type === 'Manifestation' ? i18n.typeManifest : i18n.typeCollection;
         var heading = $('<h4>');

--- a/app/views/admin/mass_updates/new.html.haml
+++ b/app/views/admin/mass_updates/new.html.haml
@@ -71,13 +71,11 @@
     #collection-expand-widget{ style: 'display:none; border: 1px solid #660248; padding:10px; margin-top:8px; background-color:#f0f0ff;' }
       %b= t('admin.mass_update.collection_expand_label')
       %br
-      - expand_modes = [
-      -   [:collection_only,         t('admin.mass_update.collection_expand_collection_only')],
-      -   [:collection_and_contents, t('admin.mass_update.collection_expand_collection_and_contents')],
-      -   [:contents_only,           t('admin.mass_update.collection_expand_contents_only')],
-      -   [:manifestations_only,     t('admin.mass_update.collection_expand_manifestations_only')],
-      -   [:custom,                  t('admin.mass_update.collection_expand_custom')]
-      - ]
+      - expand_modes = [[:collection_only, t('admin.mass_update.collection_expand_collection_only')]]
+      - expand_modes << [:collection_and_contents, t('admin.mass_update.collection_expand_collection_and_contents')]
+      - expand_modes << [:contents_only, t('admin.mass_update.collection_expand_contents_only')]
+      - expand_modes << [:manifestations_only, t('admin.mass_update.collection_expand_manifestations_only')]
+      - expand_modes << [:custom, t('admin.mass_update.collection_expand_custom')]
       - expand_modes.each_with_index do |(val, label), i|
         %label.d-block
           %input{ type: 'radio', name: 'collection_expand_mode', value: val, checked: i.zero? }
@@ -116,25 +114,21 @@
     -# Change kind selector
     .admin_container
       %b= t('admin.mass_update.change_type_label')
-      - ck_opts = [
-      -   [t('admin.mass_update.change_kind_field_update'),              'field_update'],
-      -   [t('admin.mass_update.change_kind_involved_authority_add'),    'involved_authority_add'],
-      -   [t('admin.mass_update.change_kind_involved_authority_remove'), 'involved_authority_remove'],
-      -   [t('admin.mass_update.change_kind_external_link_add'),         'external_link_add'],
-      -   [t('admin.mass_update.change_kind_external_link_remove'),      'external_link_remove']
-      - ]
+      - ck_opts = [[t('admin.mass_update.change_kind_field_update'), 'field_update']]
+      - ck_opts << [t('admin.mass_update.change_kind_involved_authority_add'), 'involved_authority_add']
+      - ck_opts << [t('admin.mass_update.change_kind_involved_authority_remove'), 'involved_authority_remove']
+      - ck_opts << [t('admin.mass_update.change_kind_external_link_add'), 'external_link_add']
+      - ck_opts << [t('admin.mass_update.change_kind_external_link_remove'), 'external_link_remove']
       = select_tag :change_kind, options_for_select(ck_opts), id: 'change-kind-select'
 
     -# ── Sub-form: field_update ──
     .change-subform.mt-2#subform-field-update
       .admin_container
         %b= t('admin.mass_update.record_type_label')
-        - frt_opts = [
-        -   [t('admin.mass_update.record_type_work'),         'work'],
-        -   [t('admin.mass_update.record_type_expression'),   'expression'],
-        -   [t('admin.mass_update.record_type_manifestation'),'manifestation'],
-        -   [t('admin.mass_update.record_type_collection'),   'collection']
-        - ]
+        - frt_opts = [[t('admin.mass_update.record_type_work'), 'work']]
+        - frt_opts << [t('admin.mass_update.record_type_expression'), 'expression']
+        - frt_opts << [t('admin.mass_update.record_type_manifestation'), 'manifestation']
+        - frt_opts << [t('admin.mass_update.record_type_collection'), 'collection']
         = select_tag :field_record_type, options_for_select(frt_opts), id: 'field-record-type'
         &nbsp;
         %b= t('admin.mass_update.field_label')

--- a/app/views/admin/mass_updates/new.html.haml
+++ b/app/views/admin/mass_updates/new.html.haml
@@ -341,16 +341,22 @@
         }
         $('#direct-id').val('');
         $('#add-by-id-error').hide();
-      }, function() {
-        $('#add-by-id-error').text('').show();
+      }, function(errorMessage) {
+        $('#add-by-id-error').text(errorMessage || i18n.error).show();
       });
     });
 
-    function fetchRecordTitle(type, id, onSuccess) {
+    function fetchRecordTitle(type, id, onSuccess, onFailure) {
       var url = '#{admin_mass_update_record_info_path}';
       $.getJSON(url, { type: type, id: id }, function(data) {
         onSuccess(data.title || ('#' + id));
-      }).fail(function() { onSuccess('#' + id); });
+      }).fail(function(jqXHR) {
+        var errorMessage = i18n.error;
+        if (jqXHR && jqXHR.responseJSON) {
+          errorMessage = jqXHR.responseJSON.error || jqXHR.responseJSON.message || errorMessage;
+        }
+        if (onFailure) onFailure(errorMessage);
+      });
     }
 
     // ── Tab 2: Autocomplete ──

--- a/app/views/admin/mass_updates/new.html.haml
+++ b/app/views/admin/mass_updates/new.html.haml
@@ -396,9 +396,8 @@
       $('#authority-lists').show();
       var $volDrop = $('#authority-volumes-dropdown').html('<option value=""></option>');
       var $manDrop = $('#authority-manifestations-dropdown').html('<option value=""></option>');
-      $.getJSON('/authors/' + authorityId + '/volumes', function(data) {
-        var vols = (data.volumes || []).concat(data.publications || []);
-        vols.forEach(function(v) {
+      $.getJSON('#{admin_mass_update_authority_volumes_path}', { authority_id: authorityId }, function(data) {
+        (data.volumes || []).forEach(function(v) {
           $volDrop.append($('<option>').val(v.id).text(v.title));
         });
       });

--- a/app/views/admin/mass_updates/new.html.haml
+++ b/app/views/admin/mass_updates/new.html.haml
@@ -190,6 +190,8 @@
   .mt-4
     %button.btn.btn-danger#apply-btn{ type: 'button' }
       = t('admin.mass_update.apply_button')
+    %button.btn.btn-secondary.mr-2#new-batch-btn{ type: 'button', style: 'display:none;' }
+      = t('admin.mass_update.new_batch_button')
     %span#applying-indicator{ style: 'display:none; margin-right:10px;' }
       = t('admin.mass_update.applying')
 
@@ -550,6 +552,7 @@
           $('#applying-indicator').hide();
           $('#apply-btn').prop('disabled', false);
           renderResults(data.results);
+          $('#new-batch-btn').show();
         },
         error: function(xhr) {
           $('#applying-indicator').hide();
@@ -559,6 +562,18 @@
           $('#results-section').show();
         }
       });
+    });
+
+    $('#new-batch-btn').on('click', function() {
+      selectedRecords  = [];
+      pendingChanges   = [];
+      pendingCollection = null;
+      renderRecords();
+      renderChanges();
+      $('#collection-expand-widget').hide();
+      $('#results-section').hide();
+      $('#results-body').empty();
+      $('#new-batch-btn').hide();
     });
 
     var recordUrlPatterns = {

--- a/app/views/admin/mass_updates/new.html.haml
+++ b/app/views/admin/mass_updates/new.html.haml
@@ -605,8 +605,8 @@
         heading.append(recordLink(res.type, res.id, typeLabel + ' #' + res.id));
         $body.append(heading);
         var $ul = $('<ul class="list-group mb-2">');
-        res.results.forEach(function(r, i) {
-          var desc = describeChange(pendingChanges[i] || {});
+        res.results.forEach(function(r) {
+          var desc = describeChange(pendingChanges[r.change_index] || {});
           var okMsg = desc + ': ' + i18n.resultOk;
           var errMsg = desc + ': ' + i18n.resultError.replace('__MSG__', r.error || '?');
           var $li = r.ok

--- a/app/views/admin/mass_updates/new.html.haml
+++ b/app/views/admin/mass_updates/new.html.haml
@@ -207,10 +207,16 @@
       confirmApply:  #{t('admin.mass_update.confirm_apply', count_records: '__REC__', count_changes: '__CHG__').to_json},
       resultOk:      #{t('admin.mass_update.result_ok').to_json},
       resultError:   #{t('admin.mass_update.result_error', message: '__MSG__').to_json},
-      saveSuccess:   #{t('admin.saved_selections.save_success').to_json},
-      noSelections:  #{t('admin.saved_selections.no_selections').to_json},
-      typeManifest:  #{t('admin.mass_update.record_type_manifestation').to_json},
-      typeCollection:#{t('admin.mass_update.record_type_collection').to_json}
+      saveSuccess:       #{t('admin.saved_selections.save_success').to_json},
+      noSelections:      #{t('admin.saved_selections.no_selections').to_json},
+      typeManifest:      #{t('admin.mass_update.record_type_manifestation').to_json},
+      typeCollection:    #{t('admin.mass_update.record_type_collection').to_json},
+      errorNoField:      #{t('admin.mass_update.errors.no_field_selected').to_json},
+      errorNoAuthority:  #{t('admin.mass_update.errors.no_authority_selected').to_json},
+      errorNoUrl:        #{t('admin.mass_update.errors.no_url_entered').to_json},
+      errorUnknown:      #{t('admin.mass_update.errors.unknown_error').to_json},
+      errorNoName:       #{t('admin.mass_update.errors.no_selection_name').to_json},
+      loading:           #{t('admin.mass_update.loading').to_json}
     };
 
     var fieldDefs = {
@@ -309,7 +315,7 @@
         return;
       }
       var contentsUrl = '#{admin_mass_update_collection_contents_path}';
-      $('#custom-content-tree').show().html('<em>טוען...</em>');
+      $('#custom-content-tree').show().html('<em>' + i18n.loading + '</em>');
       $.getJSON(contentsUrl, { collection_id: pendingCollection.id }, function(data) {
         var $tree = $('#custom-content-tree').empty();
         (data.items || []).forEach(function(item) {
@@ -341,31 +347,29 @@
     });
 
     function fetchRecordTitle(type, id, onSuccess) {
-      var path = type === 'Manifestation'
-        ? '/manifestation/' + id + '.json'
-        : '/collections/' + id + '.json';
-      $.getJSON(path, function(data) {
+      var url = '#{admin_mass_update_record_info_path}';
+      $.getJSON(url, { type: type, id: id }, function(data) {
         onSuccess(data.title || ('#' + id));
       }).fail(function() { onSuccess('#' + id); });
     }
 
     // ── Tab 2: Autocomplete ──
-    $(document).on('autocompleteselect', '#manifestation-title-search', function(event, ui) {
-      var id = ui.item.id || $('#manifestation-title-id').val();
-      addRecord('Manifestation', id, ui.item.label || $(this).val());
+    $(document).on('railsAutocomplete.select', '#manifestation-title-search', function(event, data) {
+      var id = data.item.id || $('#manifestation-title-id').val();
+      addRecord('Manifestation', id, data.item.label || $(this).val());
       $(this).val(''); $('#manifestation-title-id').val(''); event.preventDefault();
     });
 
-    $(document).on('autocompleteselect', '#collection-title-search', function(event, ui) {
-      var id = ui.item.id || $('#collection-title-id').val();
-      showCollectionExpandWidget(id, ui.item.label || $(this).val());
+    $(document).on('railsAutocomplete.select', '#collection-title-search', function(event, data) {
+      var id = data.item.id || $('#collection-title-id').val();
+      showCollectionExpandWidget(id, data.item.label || $(this).val());
       $(this).val(''); $('#collection-title-id').val(''); event.preventDefault();
     });
 
     // ── Tab 3: Authority ──
-    $(document).on('autocompleteselect', '#authority-name-search', function(event, ui) {
-      $('#authority-id-hidden').val(ui.item.id);
-      loadAuthorityDropdowns(ui.item.id);
+    $(document).on('railsAutocomplete.select', '#authority-name-search', function(event, data) {
+      $('#authority-id-hidden').val(data.item.id);
+      loadAuthorityDropdowns(data.item.id);
       event.preventDefault();
     });
 
@@ -486,21 +490,21 @@
         change.field_label = $('#field-name-select option:selected').text();
         var enumVisible = $('#field-value-enum-container').is(':visible');
         change.value = enumVisible ? $('#field-value-enum').val() : $('#field-value').val();
-        if (!change.field) error = 'בחר שדה';
+        if (!change.field) error = i18n.errorNoField;
       } else if (kind.indexOf('involved_') === 0) {
         change.role = $('#ia-role-select').val();
         change.authority_id = $('#ia-authority-id').val();
         change.authority_name = $('#ia-authority-name').val();
         change.entity = $('#ia-entity-select').val();
-        if (!change.authority_id) error = 'בחר יוצר/ת';
+        if (!change.authority_id) error = i18n.errorNoAuthority;
       } else if (kind === 'external_link_add') {
         change.url = $('#ext-link-url').val().trim();
         change.linktype = $('#ext-link-type').val();
         change.description = $('#ext-link-description').val();
-        if (!change.url) error = 'נא להזין כתובת URL';
+        if (!change.url) error = i18n.errorNoUrl;
       } else if (kind === 'external_link_remove') {
         change.url = $('#ext-remove-url').val().trim();
-        if (!change.url) error = 'נא להזין כתובת URL';
+        if (!change.url) error = i18n.errorNoUrl;
       }
       if (error) { $('#add-change-error').text(error).show(); return; }
       $('#add-change-error').hide();
@@ -531,7 +535,7 @@
         error: function(xhr) {
           $('#applying-indicator').hide();
           $('#apply-btn').prop('disabled', false);
-          var errMsg = xhr.responseJSON ? xhr.responseJSON.error : 'שגיאה לא ידועה';
+          var errMsg = xhr.responseJSON ? xhr.responseJSON.error : i18n.errorUnknown;
           $('#results-body').html('<div class="alert alert-danger">' + $('<span>').text(errMsg).html() + '</div>');
           $('#results-section').show();
         }
@@ -539,8 +543,8 @@
     });
 
     var recordUrlPatterns = {
-      Manifestation: '#{manifestation_path("RECID")}',
-      Collection: '#{collection_path("RECID")}'
+      Manifestation: '#{manifestation_path('RECID')}',
+      Collection: '#{collection_path('RECID')}'
     };
 
     function recordLink(type, id, label) {
@@ -597,7 +601,7 @@
 
     function saveSelection(shared) {
       var name = $('#new-selection-name').val().trim();
-      if (!name) { alert('נא לתת שם לבחירה'); return; }
+      if (!name) { alert(i18n.errorNoName); return; }
       if (!selectedRecords.length) { alert(i18n.noRecords); return; }
       $.ajax({
         url: '#{admin_saved_selections_path}',
@@ -613,7 +617,7 @@
           loadSavedSelectionsList();
         },
         error: function(xhr) {
-          var err = xhr.responseJSON ? xhr.responseJSON.error : 'שגיאה';
+          var err = xhr.responseJSON ? xhr.responseJSON.error : i18n.errorUnknown;
           $('#saved-selection-message').text(err).removeClass('text-success').addClass('text-danger').show();
         }
       });

--- a/app/views/admin/mass_updates/new.html.haml
+++ b/app/views/admin/mass_updates/new.html.haml
@@ -335,7 +335,8 @@
           var $label = $('<label class="d-block">').css('padding-right', (item.depth * 20) + 'px');
           var $cb = $('<input type="checkbox" checked>');
           $cb.data('type', item.type).data('id', item.id).data('title', item.title);
-          $label.append($cb).append(' ' + item.type + ' #' + item.id + ': ' + $('<span>').text(item.title).html());
+          var typeLabel = item.type === 'Manifestation' ? i18n.typeManifest : i18n.typeCollection;
+          $label.append($cb).append(' ' + typeLabel + ' #' + item.id + ': ' + $('<span>').text(item.title).html());
           $tree.append($label);
         });
       });

--- a/app/views/admin/mass_updates/new.html.haml
+++ b/app/views/admin/mass_updates/new.html.haml
@@ -150,7 +150,7 @@
         = select_tag :ia_role, options_for_select(ia_role_opts), id: 'ia-role-select'
         &nbsp;
         %b= t('admin.mass_update.entity_label')
-        - ia_ent_opts = [[t('admin.mass_update.entity_work'), 'work'], [t('admin.mass_update.entity_expression'), 'expression']]
+        - ia_ent_opts = [[t('admin.mass_update.entity_work'), 'work'], [t('admin.mass_update.entity_expression'), 'expression'], [t('admin.mass_update.entity_collection'), 'collection']]
         = select_tag :ia_entity, options_for_select(ia_ent_opts), id: 'ia-entity-select'
       .admin_container.mt-1
         %b= t('admin.mass_update.authority_name_label')
@@ -490,13 +490,13 @@
 
     function describeChange(ch) {
       if (ch.kind === 'field_update') {
-        return ch.record_type + '.' + (ch.field_label || ch.field) + ' = ' + (ch.value || '(blank)');
+        return (ch.record_type_label || ch.record_type) + '.' + (ch.field_label || ch.field) + ' = ' + (ch.value || '(blank)');
       }
       if (ch.kind === 'involved_authority_add') {
-        return '[+] ' + ch.role + ': ' + ch.authority_name + ' (' + ch.entity + ')';
+        return '[+] ' + (ch.role_label || ch.role) + ': ' + ch.authority_name + ' (' + (ch.entity_label || ch.entity) + ')';
       }
       if (ch.kind === 'involved_authority_remove') {
-        return '[-] ' + ch.role + ': ' + ch.authority_name + ' (' + ch.entity + ')';
+        return '[-] ' + (ch.role_label || ch.role) + ': ' + ch.authority_name + ' (' + (ch.entity_label || ch.entity) + ')';
       }
       if (ch.kind === 'external_link_add') return '[+ link] ' + ch.url + ' (' + ch.linktype + ')';
       if (ch.kind === 'external_link_remove') return '[- link] ' + ch.url;
@@ -507,6 +507,7 @@
       var kind = $('#change-kind-select').val(), change = { kind: kind }, error = null;
       if (kind === 'field_update') {
         change.record_type = $('#field-record-type').val();
+        change.record_type_label = $('#field-record-type option:selected').text();
         change.field = $('#field-name-select').val();
         change.field_label = $('#field-name-select option:selected').text();
         var enumVisible = $('#field-value-enum-container').is(':visible');
@@ -514,9 +515,11 @@
         if (!change.field) error = i18n.errorNoField;
       } else if (kind.indexOf('involved_') === 0) {
         change.role = $('#ia-role-select').val();
+        change.role_label = $('#ia-role-select option:selected').text();
         change.authority_id = $('#ia-authority-id').val();
         change.authority_name = $('#ia-authority-name').val();
         change.entity = $('#ia-entity-select').val();
+        change.entity_label = $('#ia-entity-select option:selected').text();
         if (!change.authority_id) error = i18n.errorNoAuthority;
       } else if (kind === 'external_link_add') {
         change.url = $('#ext-link-url').val().trim();

--- a/app/views/admin/mass_updates/new.html.haml
+++ b/app/views/admin/mass_updates/new.html.haml
@@ -23,7 +23,7 @@
       .tab-pane.active#tab-by-id{ role: 'tabpanel' }
         .admin_container
           %b= t('admin.mass_update.record_type_label')
-          - rec_opts = [[t('admin.mass_update.record_type_manifestation'), 'Manifestation']]
+          - rec_opts = [[t('text'), 'Manifestation']]
           - rec_opts << [t('admin.mass_update.record_type_collection'), 'Collection']
           = select_tag :direct_record_type, options_for_select(rec_opts), id: 'direct-record-type'
           &nbsp;

--- a/app/views/admin/mass_updates/new.html.haml
+++ b/app/views/admin/mass_updates/new.html.haml
@@ -221,10 +221,11 @@
     };
 
     var enumOptions = {
-      genre:                 #{Work::GENRES.map { |g| [t(g), g] }.to_json},
+      genre:                 #{Work::GENRES.map { |g| [t("genre_values.#{g}"), g] }.to_json},
       status:                #{Manifestation.statuses.keys.map { |k| [t(k), k] }.to_json},
       period:                #{Expression.periods.keys.map { |p| [t(p), p] }.to_json},
       language:              #{get_langs.map { |lang| [textify_lang(lang), lang] }.to_json},
+      orig_lang:             #{get_langs.map { |lang| [textify_lang(lang), lang] }.to_json},
       intellectual_property: #{Expression.intellectual_properties.keys.map { |ip| [textify_intellectual_property(ip), ip] }.to_json},
       collection_type:       #{(Collection.collection_types.keys - Collection::SYSTEM_TYPES).map { |ct| [ct, ct] }.to_json}
     };
@@ -537,11 +538,24 @@
       });
     });
 
+    var recordUrlPatterns = {
+      Manifestation: '#{manifestation_path("RECID")}',
+      Collection: '#{collection_path("RECID")}'
+    };
+
+    function recordLink(type, id, label) {
+      var pattern = recordUrlPatterns[type];
+      if (!pattern) return $('<span>').text(label);
+      return $('<a>').attr('href', pattern.replace('RECID', id)).attr('target', '_blank').text(label);
+    }
+
     function renderResults(results) {
       var $body = $('#results-body').empty();
       results.forEach(function(res) {
         var typeLabel = res.type === 'Manifestation' ? i18n.typeManifest : i18n.typeCollection;
-        $body.append($('<h4>').text(typeLabel + ' #' + res.id));
+        var heading = $('<h4>');
+        heading.append(recordLink(res.type, res.id, typeLabel + ' #' + res.id));
+        $body.append(heading);
         var $ul = $('<ul class="list-group mb-2">');
         res.results.forEach(function(r, i) {
           var desc = describeChange(pendingChanges[i] || {});

--- a/config/initializers/scheduler.rb
+++ b/config/initializers/scheduler.rb
@@ -31,3 +31,9 @@ scheduler.every '7d' do
   puts "sending weekly notification digests"
   NotificationDigestJob.perform_async('weekly')
 end
+
+scheduler.every '7d' do
+  Rails.logger.info 'purging expired saved selections'
+  count = SavedSelection.where(delete_after: ...Time.zone.today).delete_all
+  Rails.logger.info "purged #{count} expired saved selections"
+end

--- a/config/initializers/scheduler.rb
+++ b/config/initializers/scheduler.rb
@@ -34,6 +34,9 @@ end
 
 scheduler.every '7d' do
   Rails.logger.info 'purging expired saved selections'
-  count = SavedSelection.where(delete_after: ...Time.zone.today).delete_all
+  count = 0
+  SavedSelection.where(delete_after: ...Time.zone.today).find_each do |saved_selection|
+    count += 1 if saved_selection.destroy
+  end
   Rails.logger.info "purged #{count} expired saved selections"
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -355,6 +355,7 @@ en:
       changes_list_title: Changes Added
       no_changes_in_list: No changes defined yet
       apply_button: Apply All Changes
+      new_batch_button: Start new mass update
       confirm_apply: "Are you sure you want to update %{count_records} records with %{count_changes} changes?"
       applying: Applying changes...
       results_title: Update Results

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -302,6 +302,112 @@ en:
     index:
       takes_long_time: Takes long time
       batch_operations: Batch Operations
+    mass_update:
+      dashboard_link: Mass Update
+      new:
+        title: Mass Update Records
+      section_records: Records to Update
+      section_changes: Changes to Apply
+      mode_by_id: By ID
+      mode_by_title: By Title Search
+      mode_by_authority: By Authority Name
+      record_type_manifestation: Manifestation
+      record_type_collection: Collection
+      id_label: "ID:"
+      add_button: Add to List
+      remove_button: Remove
+      authority_name_label: "Authority name:"
+      authority_volumes_label: "Collections/Volumes this authority is involved in:"
+      authority_manifestations_label: "Manifestations whose Expression or Work this authority is involved in:"
+      collection_expand_label: "How to add this collection?"
+      collection_expand_collection_only: Collection record only
+      collection_expand_collection_and_contents: Collection + all contents (recursive)
+      collection_expand_contents_only: Contents only (without collection record)
+      collection_expand_manifestations_only: Manifestations only (skip sub-collection entities)
+      collection_expand_custom: Custom selection
+      saved_selections_label: "Saved selections:"
+      load_selection_button: Load
+      save_private_button: Save for me only
+      save_shared_button: Save and share with others
+      save_selection_name_placeholder: Selection name...
+      no_records_in_list: No records selected yet
+      records_list_title: Selected Records
+      change_type_label: "Change type:"
+      change_kind_field_update: Field Update
+      change_kind_involved_authority_add: Add Involved Authority
+      change_kind_involved_authority_remove: Remove Involved Authority
+      change_kind_external_link_add: Add External Link
+      change_kind_external_link_remove: Remove External Link
+      record_type_label: "Record type:"
+      record_type_work: Work
+      record_type_expression: Expression
+      field_label: "Field:"
+      value_label: "Value (leave blank to clear):"
+      role_label: "Role:"
+      entity_label: "Entity to update:"
+      entity_work: Work
+      entity_expression: Expression
+      url_label: "URL:"
+      link_type_label: "Link type:"
+      link_description_label: "Description:"
+      add_change_button: Add Change
+      changes_list_title: Changes Added
+      no_changes_in_list: No changes defined yet
+      apply_button: Apply All Changes
+      confirm_apply: "Are you sure you want to update %{count_records} records with %{count_changes} changes?"
+      applying: Applying changes...
+      results_title: Update Results
+      result_ok: OK
+      result_error: "Error: %{message}"
+      fields:
+        work:
+          title: Title (Work)
+          genre: Genre
+          primary: Primary
+          orig_lang: Original Language
+          origlang_title: Original Language Title
+          date: Creation Date
+          comment: Comments
+        expression:
+          title: Title (Expression)
+          date: Publication Date
+          period: Period
+          language: Language
+          first_publication_date: First Publication Date
+          source_edition: Source Edition
+          comment: Comments
+          intellectual_property: Intellectual Property
+        manifestation:
+          title: Title (Manifestation)
+          alternate_titles: Alternate Titles
+          sort_title: Sort Title
+          status: Status
+          comment: Comments
+          exclude_from_index: Exclude from Index
+          sefaria_linker: Sefaria Linker
+        collection:
+          title: Title
+          sort_title: Sort Title
+          collection_type: Collection Type
+          comment: Comments
+          suppress_download_and_print: Suppress Download and Print
+      errors:
+        record_not_found: Record not found
+        authority_not_found: Authority not found
+        field_not_applicable: "Field '%{field}' does not apply to record type '%{record_type}'"
+        field_not_allowed: "Field '%{field}' is not allowed for mass update"
+        ia_entity_not_applicable: "Entity '%{entity}' is not applicable to this record"
+        ia_not_found: Involved authority record not found
+        external_link_not_found: "External link not found: %{url}"
+        destroy_failed: Deletion failed
+        unknown_change_kind: "Unknown change kind: %{kind}"
+        no_records: No records selected for update
+        no_changes: No changes defined to apply
+        not_owner: Only the owner of a saved selection can delete it
+    saved_selections:
+      save_success: Selection saved successfully
+      delete_confirm: Are you sure you want to delete this selection?
+      no_selections: No saved selections available
     incongruous_copyright:
       title: Probably incongruous copyright report
       columns:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -392,8 +392,12 @@ en:
         collection:
           title: Title
           sort_title: Sort Title
+          subtitle: Subtitle
+          alternate_titles: Alternate Titles
+          description: Description
+          publisher_line: Edition Details
+          pub_year: Year Published
           collection_type: Collection Type
-          comment: Comments
           suppress_download_and_print: Suppress Download and Print
       errors:
         record_not_found: Record not found

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -348,6 +348,7 @@ en:
       entity_label: "Entity to update:"
       entity_work: Work
       entity_expression: Expression
+      entity_collection: Collection
       url_label: "URL:"
       link_type_label: "Link type:"
       link_description_label: "Description:"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2476,6 +2476,7 @@ en:
   like: Like
   link_description: Link Description
   link_moderation: Link Moderation
+  batch_editing: Batch Editing
   link_type: Link Type
   linked_author: Linked Author
   linked_taggings: Linked Taggings

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -400,6 +400,7 @@ en:
         ia_not_found: Involved authority record not found
         external_link_not_found: "External link not found: %{url}"
         destroy_failed: Deletion failed
+        value_not_persisted: "The value entered for field '%{field}' was not saved (it may be invalid)"
         unknown_change_kind: "Unknown change kind: %{kind}"
         no_records: No records selected for update
         no_changes: No changes defined to apply

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -332,6 +332,7 @@ en:
       save_selection_name_placeholder: Selection name...
       no_records_in_list: No records selected yet
       records_list_title: Selected Records
+      clear_all_button: Clear all
       change_type_label: "Change type:"
       change_kind_field_update: Field Update
       change_kind_involved_authority_add: Add Involved Authority
@@ -357,6 +358,9 @@ en:
       confirm_apply: "Are you sure you want to update %{count_records} records with %{count_changes} changes?"
       applying: Applying changes...
       results_title: Update Results
+      results_summary: "Total %{total} changes:"
+      results_summary_succeeded: "%{count} succeeded"
+      results_summary_failed: "%{count} failed"
       result_ok: OK
       result_error: "Error: %{message}"
       fields:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -404,7 +404,13 @@ en:
         unknown_change_kind: "Unknown change kind: %{kind}"
         no_records: No records selected for update
         no_changes: No changes defined to apply
+        no_field_selected: Please select a field
+        no_authority_selected: Please select an authority
+        no_url_entered: Please enter a URL
+        unknown_error: Unknown error
+        no_selection_name: Please enter a name for this selection
         not_owner: Only the owner of a saved selection can delete it
+      loading: Loading...
     saved_selections:
       save_success: Selection saved successfully
       delete_confirm: Are you sure you want to delete this selection?

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -407,7 +407,7 @@ en:
         no_field_selected: Please select a field
         no_authority_selected: Please select an authority
         no_url_entered: Please enter a URL
-        unknown_error: Unknown error
+        unknown_error: "Unexpected error (ID: %{error_id})"
         no_selection_name: Please enter a name for this selection
         not_owner: Only the owner of a saved selection can delete it
       loading: Loading...

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -1840,6 +1840,7 @@ he:
       changes_list_title: שינויים שנוספו
       no_changes_in_list: לא הוגדרו שינויים
       apply_button: החל את כל השינויים
+      new_batch_button: התחל עדכון אצווה חדש
       confirm_apply: "האם אתה בטוח שברצונך לעדכן %{count_records} רשומות עם %{count_changes} שינויים?"
       applying: מחיל שינויים...
       results_title: תוצאות העדכון

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -1795,7 +1795,7 @@ he:
       mode_by_id: לפי מזהה
       mode_by_title: לפי כותרת
       mode_by_authority: לפי שם יוצר/ת
-      record_type_manifestation: יצירה
+      record_type_manifestation: מימוש
       record_type_collection: אוסף
       id_label: "מזהה:"
       add_button: הוסף לרשימה
@@ -1854,11 +1854,11 @@ he:
           comment: הערות
         expression:
           title: "כותרת (ביטוי)"
-          date: תאריך פרסום
+          date: תאריך הוצאה
           period: תקופה
           language: שפה
           first_publication_date: תאריך פרסום ראשון
-          source_edition: מהדורת מקור
+          source_edition: פרטי הוצאה
           comment: הערות
           intellectual_property: זכויות יוצרים
         manifestation:

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -1877,8 +1877,12 @@ he:
         collection:
           title: כותרת
           sort_title: כותרת למיון
+          subtitle: כותרת משנה
+          alternate_titles: כותרות נוספות
+          description: תיאור
+          publisher_line: פרטי מהדורה
+          pub_year: שנת הוצאה
           collection_type: סוג האוסף
-          comment: הערות
           suppress_download_and_print: מניעת הורדה והדפסה
       errors:
         record_not_found: הרשומה לא נמצאה

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -1888,7 +1888,13 @@ he:
         unknown_change_kind: "סוג שינוי לא מוכר: %{kind}"
         no_records: לא נבחרו רשומות לעדכון
         no_changes: לא הוגדרו שינויים להחיל
+        no_field_selected: בחר שדה
+        no_authority_selected: "בחר יוצר/ת"
+        no_url_entered: נא להזין כתובת URL
+        unknown_error: שגיאה לא ידועה
+        no_selection_name: נא לתת שם לבחירה
         not_owner: רק בעל/ת הבחירה יכול/ה למחוק אותה
+      loading: "טוען..."
     saved_selections:
       save_success: הבחירה נשמרה בהצלחה
       delete_confirm: האם אתה בטוח שברצונך למחוק בחירה זו?

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -1833,6 +1833,7 @@ he:
       entity_label: "ישות לעדכן:"
       entity_work: יצירה
       entity_expression: ביטוי
+      entity_collection: אוסף
       url_label: "כתובת URL:"
       link_type_label: "סוג קישור:"
       link_description_label: "תיאור:"

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -1816,6 +1816,7 @@ he:
       save_selection_name_placeholder: שם הבחירה...
       no_records_in_list: לא נבחרו רשומות
       records_list_title: רשומות שנבחרו
+      clear_all_button: נקה הכל
       change_type_label: "סוג השינוי:"
       change_kind_field_update: עדכון שדה
       change_kind_involved_authority_add: הוספת יוצר/ת מעורב/ת
@@ -1841,6 +1842,9 @@ he:
       confirm_apply: "האם אתה בטוח שברצונך לעדכן %{count_records} רשומות עם %{count_changes} שינויים?"
       applying: מחיל שינויים...
       results_title: תוצאות העדכון
+      results_summary: "סה\"כ %{total} שינויים:"
+      results_summary_succeeded: "%{count} הצליחו"
+      results_summary_failed: "%{count} נכשלו"
       result_ok: הצליח
       result_error: "שגיאה: %{message}"
       fields:

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -1879,7 +1879,7 @@ he:
           sort_title: כותרת למיון
           collection_type: סוג האוסף
           comment: הערות
-          suppress_download_and_print: בלום הורדה והדפסה
+          suppress_download_and_print: מניעת הורדה והדפסה
       errors:
         record_not_found: הרשומה לא נמצאה
         authority_not_found: היוצר/ת לא נמצא/אה

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -1891,7 +1891,7 @@ he:
         no_field_selected: בחר שדה
         no_authority_selected: "בחר יוצר/ת"
         no_url_entered: נא להזין כתובת URL
-        unknown_error: שגיאה לא ידועה
+        unknown_error: "שגיאה לא צפויה (מזהה: %{error_id})"
         no_selection_name: נא לתת שם לבחירה
         not_owner: רק בעל/ת הבחירה יכול/ה למחוק אותה
       loading: "טוען..."

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -1786,6 +1786,112 @@ he:
       title: פעולות באצווה
       enter_manifestation_ids: "נא להזין מספרי זיהוי של *יצירות* (מופרדים ברווח או במעבר שורה)"
       fetch: טען יצירות
+    mass_update:
+      dashboard_link: עדכון מסה
+      new:
+        title: עדכון מסה של רשומות
+      section_records: רשומות שתתעדכנּה
+      section_changes: שינויים להחיל
+      mode_by_id: לפי מזהה
+      mode_by_title: לפי כותרת
+      mode_by_authority: לפי שם יוצר/ת
+      record_type_manifestation: יצירה
+      record_type_collection: אוסף
+      id_label: "מזהה:"
+      add_button: הוסף לרשימה
+      remove_button: הסר
+      authority_name_label: "שם יוצר/ת:"
+      authority_volumes_label: "כרכים שהיוצר/ת מעורב/ת בהם:"
+      authority_manifestations_label: "יצירות שהיוצר/ת מעורב/ת בהן:"
+      collection_expand_label: "כיצד להוסיף את האוסף?"
+      collection_expand_collection_only: האוסף בלבד
+      collection_expand_collection_and_contents: האוסף וכל תוכנו (רקורסיבי)
+      collection_expand_contents_only: תוכן האוסף בלבד (ללא האוסף עצמו)
+      collection_expand_manifestations_only: יצירות בלבד (ללא ישויות של תת-אוסף)
+      collection_expand_custom: בחירה מותאמת אישית
+      saved_selections_label: "בחירות שמורות:"
+      load_selection_button: טען
+      save_private_button: שמור לי בלבד
+      save_shared_button: שמור לשיתוף
+      save_selection_name_placeholder: שם הבחירה...
+      no_records_in_list: לא נבחרו רשומות
+      records_list_title: רשומות שנבחרו
+      change_type_label: "סוג השינוי:"
+      change_kind_field_update: עדכון שדה
+      change_kind_involved_authority_add: הוספת יוצר/ת מעורב/ת
+      change_kind_involved_authority_remove: הסרת יוצר/ת מעורב/ת
+      change_kind_external_link_add: הוספת קישור חיצוני
+      change_kind_external_link_remove: הסרת קישור חיצוני
+      record_type_label: "סוג הרשומה:"
+      record_type_work: יצירה (Work)
+      record_type_expression: גרסה (Expression)
+      field_label: "שדה:"
+      value_label: "ערך (ריק = ביטול):"
+      role_label: "תפקיד:"
+      entity_label: "ישות לעדכן:"
+      entity_work: יצירה (Work)
+      entity_expression: גרסה (Expression)
+      url_label: "כתובת URL:"
+      link_type_label: "סוג קישור:"
+      link_description_label: "תיאור:"
+      add_change_button: הוסף שינוי
+      changes_list_title: שינויים שנוספו
+      no_changes_in_list: לא הוגדרו שינויים
+      apply_button: החל את כל השינויים
+      confirm_apply: "האם אתה בטוח שברצונך לעדכן %{count_records} רשומות עם %{count_changes} שינויים?"
+      applying: מחיל שינויים...
+      results_title: תוצאות העדכון
+      result_ok: הצליח
+      result_error: "שגיאה: %{message}"
+      fields:
+        work:
+          title: "כותרת (Work)"
+          genre: ז'אנר
+          primary: ראשי
+          orig_lang: שפת מקור
+          origlang_title: כותרת בשפת מקור
+          date: תאריך יצירה
+          comment: הערות
+        expression:
+          title: "כותרת (Expression)"
+          date: תאריך פרסום
+          period: תקופה
+          language: שפה
+          first_publication_date: תאריך פרסום ראשון
+          source_edition: מהדורת מקור
+          comment: הערות
+          intellectual_property: זכויות יוצרים
+        manifestation:
+          title: "כותרת (Manifestation)"
+          alternate_titles: כותרות חלופיות
+          sort_title: כותרת למיון
+          status: סטטוס
+          comment: הערות
+          exclude_from_index: הוצא מהאינדקס
+          sefaria_linker: קישור ספריא
+        collection:
+          title: כותרת
+          sort_title: כותרת למיון
+          collection_type: סוג האוסף
+          comment: הערות
+          suppress_download_and_print: בלום הורדה והדפסה
+      errors:
+        record_not_found: הרשומה לא נמצאה
+        authority_not_found: היוצר/ת לא נמצא/אה
+        field_not_applicable: "השדה '%{field}' אינו חל על סוג רשומה '%{record_type}'"
+        field_not_allowed: "השדה '%{field}' אינו מותר לעדכון מסה"
+        ia_entity_not_applicable: "ישות '%{entity}' אינה ישימה לרשומה זו"
+        ia_not_found: קשר יוצר/ת-ישות לא נמצא
+        external_link_not_found: "קישור חיצוני לא נמצא: %{url}"
+        destroy_failed: המחיקה נכשלה
+        unknown_change_kind: "סוג שינוי לא מוכר: %{kind}"
+        no_records: לא נבחרו רשומות לעדכון
+        no_changes: לא הוגדרו שינויים להחיל
+        not_owner: רק בעל/ת הבחירה יכול/ה למחוק אותה
+    saved_selections:
+      save_success: הבחירה נשמרה בהצלחה
+      delete_confirm: האם אתה בטוח שברצונך למחוק בחירה זו?
+      no_selections: אין בחירות שמורות זמינות
     incongruous_copyright:
       title: דו\"ח יצירות במצב זכויות יוצרים שגוי (כנראה)
       columns:

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -868,6 +868,7 @@ he:
   tag: תגית
   moderate_tags: ניטור תיוגים מהציבור
   link_moderation: ניטור קישוריות מהציבור
+  batch_editing: עריכה באצווה
   next_milestone: היעד הבא
   my_activity: הפעילות שלי
   similar_to_x: "דומה לפריט: %{x}"

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -1822,7 +1822,7 @@ he:
       change_kind_involved_authority_remove: הסרת יוצר/ת מעורב/ת
       change_kind_external_link_add: הוספת קישור חיצוני
       change_kind_external_link_remove: הסרת קישור חיצוני
-      record_type_label: "סוג הרשומה:"
+      record_type_label: "סוג הפרטים:"
       record_type_work: יצירה
       record_type_expression: ביטוי
       field_label: "שדה:"

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -1787,9 +1787,9 @@ he:
       enter_manifestation_ids: "נא להזין מספרי זיהוי של *יצירות* (מופרדים ברווח או במעבר שורה)"
       fetch: טען יצירות
     mass_update:
-      dashboard_link: עדכון מסה
+      dashboard_link: עדכון באצווה
       new:
-        title: עדכון מסה של רשומות
+        title: עדכון באצווה של רשומות
       section_records: רשומות שתתעדכנּה
       section_changes: שינויים להחיל
       mode_by_id: לפי מזהה
@@ -1823,14 +1823,14 @@ he:
       change_kind_external_link_add: הוספת קישור חיצוני
       change_kind_external_link_remove: הסרת קישור חיצוני
       record_type_label: "סוג הרשומה:"
-      record_type_work: יצירה (Work)
-      record_type_expression: גרסה (Expression)
+      record_type_work: יצירה
+      record_type_expression: ביטוי
       field_label: "שדה:"
       value_label: "ערך (ריק = ביטול):"
       role_label: "תפקיד:"
       entity_label: "ישות לעדכן:"
-      entity_work: יצירה (Work)
-      entity_expression: גרסה (Expression)
+      entity_work: יצירה
+      entity_expression: ביטוי
       url_label: "כתובת URL:"
       link_type_label: "סוג קישור:"
       link_description_label: "תיאור:"
@@ -1845,7 +1845,7 @@ he:
       result_error: "שגיאה: %{message}"
       fields:
         work:
-          title: "כותרת (Work)"
+          title: "כותרת (יצירה)"
           genre: ז'אנר
           primary: ראשי
           orig_lang: שפת מקור
@@ -1853,7 +1853,7 @@ he:
           date: תאריך יצירה
           comment: הערות
         expression:
-          title: "כותרת (Expression)"
+          title: "כותרת (ביטוי)"
           date: תאריך פרסום
           period: תקופה
           language: שפה
@@ -1862,7 +1862,7 @@ he:
           comment: הערות
           intellectual_property: זכויות יוצרים
         manifestation:
-          title: "כותרת (Manifestation)"
+          title: "כותרת (מימוש)"
           alternate_titles: כותרות חלופיות
           sort_title: כותרת למיון
           status: סטטוס
@@ -1879,7 +1879,7 @@ he:
         record_not_found: הרשומה לא נמצאה
         authority_not_found: היוצר/ת לא נמצא/אה
         field_not_applicable: "השדה '%{field}' אינו חל על סוג רשומה '%{record_type}'"
-        field_not_allowed: "השדה '%{field}' אינו מותר לעדכון מסה"
+        field_not_allowed: "השדה '%{field}' אינו מותר לעדכון באצווה"
         ia_entity_not_applicable: "ישות '%{entity}' אינה ישימה לרשומה זו"
         ia_not_found: קשר יוצר/ת-ישות לא נמצא
         external_link_not_found: "קישור חיצוני לא נמצא: %{url}"

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -1846,7 +1846,7 @@ he:
       fields:
         work:
           title: "כותרת (יצירה)"
-          genre: ז'אנר
+          genre: סוגה
           primary: ראשי
           orig_lang: שפת מקור
           origlang_title: כותרת בשפת מקור
@@ -1884,6 +1884,7 @@ he:
         ia_not_found: קשר יוצר/ת-ישות לא נמצא
         external_link_not_found: "קישור חיצוני לא נמצא: %{url}"
         destroy_failed: המחיקה נכשלה
+        value_not_persisted: "הערך שהוזן לשדה '%{field}' לא נשמר (ייתכן שאינו תקין)"
         unknown_change_kind: "סוג שינוי לא מוכר: %{kind}"
         no_records: לא נבחרו רשומות לעדכון
         no_changes: לא הוגדרו שינויים להחיל

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,7 +22,9 @@ Bybeconv::Application.routes.draw do
          as: 'mass_update_collection_contents'
     get  'mass_update/authority_manifestations' => 'mass_updates#authority_manifestations',
          as: 'mass_update_authority_manifestations'
-    resources :saved_selections, only: %i[index show create destroy]
+    get  'mass_update/record_info' => 'mass_updates#record_info',
+         as: 'mass_update_record_info'
+    resources :saved_selections, only: %i(index show create destroy)
 
     resources :featured_contents do
       resources :features, controller: 'featured_content_features', only: %i(create)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,6 +22,8 @@ Bybeconv::Application.routes.draw do
          as: 'mass_update_collection_contents'
     get  'mass_update/authority_manifestations' => 'mass_updates#authority_manifestations',
          as: 'mass_update_authority_manifestations'
+    get  'mass_update/authority_volumes' => 'mass_updates#authority_volumes',
+         as: 'mass_update_authority_volumes'
     get  'mass_update/record_info' => 'mass_updates#record_info',
          as: 'mass_update_record_info'
     resources :saved_selections, only: %i(index show create destroy)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,6 +15,15 @@ Bybeconv::Application.routes.draw do
   get 'files/:record_type/:record_id/*filename', to: 'files#download', as: 'file_download', format: false
 
   namespace :admin do
+    # Mass update tool
+    get  'mass_update' => 'mass_updates#new', as: 'mass_update'
+    post 'mass_update' => 'mass_updates#create'
+    get  'mass_update/collection_contents' => 'mass_updates#collection_contents',
+         as: 'mass_update_collection_contents'
+    get  'mass_update/authority_manifestations' => 'mass_updates#authority_manifestations',
+         as: 'mass_update_authority_manifestations'
+    resources :saved_selections, only: %i[index show create destroy]
+
     resources :featured_contents do
       resources :features, controller: 'featured_content_features', only: %i(create)
     end

--- a/db/migrate/20260411020030_create_saved_selections.rb
+++ b/db/migrate/20260411020030_create_saved_selections.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+# Migration to create saved_selections table for mass update system
+class CreateSavedSelections < ActiveRecord::Migration[8.1]
+  def change
+    create_table :saved_selections do |t|
+      t.string :name, null: false
+      t.integer :user_id, null: false
+      t.boolean :shared, null: false, default: false
+      t.date :delete_after, null: false
+
+      t.timestamps
+    end
+
+    add_index :saved_selections, :user_id
+    add_index :saved_selections, :delete_after
+  end
+end

--- a/db/migrate/20260411020041_create_saved_selection_items.rb
+++ b/db/migrate/20260411020041_create_saved_selection_items.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+# Migration to create saved_selection_items table for mass update system
+class CreateSavedSelectionItems < ActiveRecord::Migration[8.1]
+  def change
+    create_table :saved_selection_items do |t|
+      t.integer :saved_selection_id, null: false
+      t.string :item_type, null: false
+      t.integer :item_id, null: false
+
+      t.timestamps
+    end
+
+    add_index :saved_selection_items, :saved_selection_id
+    add_index :saved_selection_items, %i(item_type item_id)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_10_000000) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_11_020041) do
   create_table "aboutnesses", id: :integer, charset: "utf8mb4", collation: "utf8mb4_bin", force: :cascade do |t|
     t.integer "aboutable_id"
     t.string "aboutable_type"
@@ -799,6 +799,27 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_10_000000) do
     t.index ["manifestation_id", "status"], name: "index_recommendations_on_manifestation_id_and_status"
     t.index ["manifestation_id"], name: "index_recommendations_on_manifestation_id"
     t.index ["user_id"], name: "index_recommendations_on_user_id"
+  end
+
+  create_table "saved_selection_items", charset: "utf8mb4", collation: "utf8mb4_bin", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.integer "item_id", null: false
+    t.string "item_type", null: false
+    t.integer "saved_selection_id", null: false
+    t.datetime "updated_at", null: false
+    t.index ["item_type", "item_id"], name: "index_saved_selection_items_on_item_type_and_item_id"
+    t.index ["saved_selection_id"], name: "index_saved_selection_items_on_saved_selection_id"
+  end
+
+  create_table "saved_selections", charset: "utf8mb4", collation: "utf8mb4_bin", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.date "delete_after", null: false
+    t.string "name", null: false
+    t.boolean "shared", default: false, null: false
+    t.datetime "updated_at", null: false
+    t.integer "user_id", null: false
+    t.index ["delete_after"], name: "index_saved_selections_on_delete_after"
+    t.index ["user_id"], name: "index_saved_selections_on_user_id"
   end
 
   create_table "sessions", id: :integer, charset: "utf8mb4", collation: "utf8mb4_bin", force: :cascade do |t|

--- a/spec/models/saved_selection_item_spec.rb
+++ b/spec/models/saved_selection_item_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe SavedSelectionItem do
+  let(:owner) { create(:user, editor: true) }
+  let(:selection) do
+    SavedSelection.create!(name: 'Test', user: owner, delete_after: 90.days.from_now.to_date)
+  end
+  let(:manifestation) { create(:manifestation) }
+  let(:collection)    { create(:collection, collection_type: :volume) }
+
+  describe 'item_type validation' do
+    it 'is valid with item_type Manifestation' do
+      item = described_class.new(saved_selection: selection, item_type: 'Manifestation',
+                                 item_id: manifestation.id)
+      expect(item).to be_valid
+    end
+
+    it 'is valid with item_type Collection' do
+      item = described_class.new(saved_selection: selection, item_type: 'Collection',
+                                 item_id: collection.id)
+      expect(item).to be_valid
+    end
+
+    it 'is invalid with an arbitrary item_type' do
+      item = described_class.new(saved_selection: selection, item_type: 'Work', item_id: 1)
+      expect(item).not_to be_valid
+      expect(item.errors[:item_type]).to be_present
+    end
+
+    it 'is invalid with a blank item_type' do
+      item = described_class.new(saved_selection: selection, item_type: '', item_id: 1)
+      expect(item).not_to be_valid
+    end
+  end
+end

--- a/spec/models/saved_selection_spec.rb
+++ b/spec/models/saved_selection_spec.rb
@@ -1,0 +1,104 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe SavedSelection do
+  let(:owner) { create(:user, editor: true) }
+  let(:other_user) { create(:user, editor: true) }
+
+  def make_selection(user:, shared: false, delete_after: nil)
+    attrs = { name: 'Test', user: user, shared: shared }
+    attrs[:delete_after] = delete_after || 90.days.from_now.to_date
+    SavedSelection.create!(**attrs)
+  end
+
+  describe 'validations' do
+    it 'is valid with a name and user' do
+      sel = described_class.new(name: 'My Selection', user: owner, delete_after: 90.days.from_now.to_date)
+      expect(sel).to be_valid
+    end
+
+    it 'is invalid without a name' do
+      sel = described_class.new(user: owner, delete_after: 90.days.from_now.to_date)
+      expect(sel).not_to be_valid
+      expect(sel.errors[:name]).to be_present
+    end
+  end
+
+  describe '#delete_after default' do
+    it 'defaults to 90 days from today when not set' do
+      sel = described_class.create!(name: 'Auto Expire', user: owner)
+      expect(sel.delete_after).to eq(90.days.from_now.to_date)
+    end
+
+    it 'does not override an explicitly set delete_after' do
+      custom_date = 30.days.from_now.to_date
+      sel = described_class.create!(name: 'Custom Expire', user: owner, delete_after: custom_date)
+      expect(sel.delete_after).to eq(custom_date)
+    end
+  end
+
+  describe '.active scope' do
+    it 'includes selections with delete_after >= today' do
+      active = make_selection(user: owner, delete_after: Time.zone.today)
+      expect(described_class.active).to include(active)
+    end
+
+    it 'excludes selections with delete_after < today' do
+      expired = make_selection(user: owner, delete_after: Time.zone.yesterday)
+      expect(described_class.active).not_to include(expired)
+    end
+  end
+
+  describe '.visible_to scope' do
+    context 'with a private (unshared) selection owned by owner' do
+      let!(:private_sel) { make_selection(user: owner, shared: false) }
+
+      it 'is visible to the owner' do
+        expect(described_class.visible_to(owner)).to include(private_sel)
+      end
+
+      it 'is NOT visible to another user' do
+        expect(described_class.visible_to(other_user)).not_to include(private_sel)
+      end
+    end
+
+    context 'with a shared selection owned by owner' do
+      let!(:shared_sel) { make_selection(user: owner, shared: true) }
+
+      it 'is visible to the owner' do
+        expect(described_class.visible_to(owner)).to include(shared_sel)
+      end
+
+      it 'is visible to another user' do
+        expect(described_class.visible_to(other_user)).to include(shared_sel)
+      end
+    end
+
+    context 'with an expired selection' do
+      let!(:expired_private) { make_selection(user: owner, shared: false, delete_after: Time.zone.yesterday) }
+      let!(:expired_shared)  { make_selection(user: owner, shared: true,  delete_after: Time.zone.yesterday) }
+
+      it 'excludes expired private selection from owner' do
+        expect(described_class.visible_to(owner)).not_to include(expired_private)
+      end
+
+      it 'excludes expired shared selection from any user' do
+        expect(described_class.visible_to(other_user)).not_to include(expired_shared)
+      end
+    end
+
+    context 'with a mix of active and active-shared selections' do
+      let!(:own_private)   { make_selection(user: owner,      shared: false) }
+      let!(:own_shared)    { make_selection(user: owner,      shared: true) }
+      let!(:other_private) { make_selection(user: other_user, shared: false) }
+      let!(:other_shared)  { make_selection(user: other_user, shared: true) }
+
+      it 'returns own private, own shared, and other shared — but NOT other private' do
+        visible = described_class.visible_to(owner)
+        expect(visible).to include(own_private, own_shared, other_shared)
+        expect(visible).not_to include(other_private)
+      end
+    end
+  end
+end

--- a/spec/requests/admin/mass_updates_spec.rb
+++ b/spec/requests/admin/mass_updates_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe 'Admin::MassUpdates', type: :request do
-  before { login_as_catalog_editor }
+  before { login_as_batch_editor }
 
   let(:manifestation) { create(:manifestation, title: 'Test Manifestation') }
   let(:collection)    { create(:collection, title: 'Test Collection', collection_type: :volume) }
@@ -153,6 +153,23 @@ RSpec.describe 'Admin::MassUpdates', type: :request do
     it 'returns 404 for unknown id' do
       get admin_mass_update_record_info_path, params: { type: 'Manifestation', id: 0 }
       expect(response).to have_http_status(:not_found)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Authorization: batch_editing bit required
+  # ---------------------------------------------------------------------------
+  describe 'authorization' do
+    it 'redirects an editor without batch_editing bit' do
+      user = create(:user, editor: true)
+      # has edit_catalog but NOT batch_editing
+      ListItem.create!(listkey: 'edit_catalog', item: user)
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
+      # override the global stub so the real require_editor runs
+      allow_any_instance_of(ApplicationController).to receive(:require_editor).and_call_original
+
+      get admin_mass_update_path
+      expect(response).to redirect_to('/')
     end
   end
 end

--- a/spec/requests/admin/mass_updates_spec.rb
+++ b/spec/requests/admin/mass_updates_spec.rb
@@ -129,4 +129,30 @@ RSpec.describe 'Admin::MassUpdates', type: :request do
       expect(response).to have_http_status(:not_found)
     end
   end
+
+  # ---------------------------------------------------------------------------
+  # GET /admin/mass_update/record_info
+  # ---------------------------------------------------------------------------
+  describe 'GET /admin/mass_update/record_info' do
+    it 'returns id and title for a Manifestation' do
+      get admin_mass_update_record_info_path, params: { type: 'Manifestation', id: manifestation.id }
+      expect(response).to have_http_status(:ok)
+      body = response.parsed_body
+      expect(body['id']).to eq(manifestation.id)
+      expect(body['title']).to eq(manifestation.title)
+      expect(body['type']).to eq('Manifestation')
+    end
+
+    it 'returns id and title for a Collection' do
+      col = create(:collection, title: 'My Collection', collection_type: :volume)
+      get admin_mass_update_record_info_path, params: { type: 'Collection', id: col.id }
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body['title']).to eq('My Collection')
+    end
+
+    it 'returns 404 for unknown id' do
+      get admin_mass_update_record_info_path, params: { type: 'Manifestation', id: 0 }
+      expect(response).to have_http_status(:not_found)
+    end
+  end
 end

--- a/spec/requests/admin/mass_updates_spec.rb
+++ b/spec/requests/admin/mass_updates_spec.rb
@@ -102,6 +102,28 @@ RSpec.describe 'Admin::MassUpdates', type: :request do
   # ---------------------------------------------------------------------------
   # GET /admin/mass_update/authority_manifestations
   # ---------------------------------------------------------------------------
+  # GET /admin/mass_update/authority_volumes
+  # ---------------------------------------------------------------------------
+  describe 'GET /admin/mass_update/authority_volumes' do
+    let(:authority) { create(:authority) }
+
+    it 'returns volumes (collections) associated with the authority' do
+      vol = create(:collection, title: 'Vol 1', collection_type: :volume)
+      InvolvedAuthority.create!(item: vol, authority: authority, role: :author)
+
+      get admin_mass_update_authority_volumes_path, params: { authority_id: authority.id }
+      expect(response).to have_http_status(:ok)
+      returned_ids = response.parsed_body['volumes'].map { |v| v['id'] } # rubocop:disable Rails/Pluck
+      expect(returned_ids).to include(vol.id)
+    end
+
+    it 'returns 404 for an unknown authority_id' do
+      get admin_mass_update_authority_volumes_path, params: { authority_id: 0 }
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
   describe 'GET /admin/mass_update/authority_manifestations' do
     let(:authority) { create(:authority) }
 

--- a/spec/requests/admin/mass_updates_spec.rb
+++ b/spec/requests/admin/mass_updates_spec.rb
@@ -1,0 +1,132 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Admin::MassUpdates', type: :request do
+  before { login_as_catalog_editor }
+
+  let(:manifestation) { create(:manifestation, title: 'Test Manifestation') }
+  let(:collection)    { create(:collection, title: 'Test Collection', collection_type: :volume) }
+
+  # ---------------------------------------------------------------------------
+  # POST /admin/mass_update  (create)
+  # ---------------------------------------------------------------------------
+  describe 'POST /admin/mass_update' do
+    it 'returns 422 with error key when records list is empty' do
+      post admin_mass_update_path,
+           params: { records: [], changes: [{ kind: 'field_update' }] },
+           as: :json
+      expect(response).to have_http_status(:unprocessable_content)
+      body = response.parsed_body
+      expect(body['error']).to eq(I18n.t('admin.mass_update.errors.no_records'))
+    end
+
+    it 'returns 422 with error key when changes list is empty' do
+      post admin_mass_update_path,
+           params: { records: [{ type: 'Manifestation', id: manifestation.id }], changes: [] },
+           as: :json
+      expect(response).to have_http_status(:unprocessable_content)
+      body = response.parsed_body
+      expect(body['error']).to eq(I18n.t('admin.mass_update.errors.no_changes'))
+    end
+
+    it 'returns results JSON for a valid request' do
+      post admin_mass_update_path,
+           params: {
+             records: [{ type: 'Manifestation', id: manifestation.id }],
+             changes: [{ kind: 'field_update', record_type: 'manifestation',
+                         field: 'title', value: 'Updated Via API' }]
+           },
+           as: :json
+      expect(response).to have_http_status(:ok)
+      body = response.parsed_body
+      expect(body['results']).to be_an(Array)
+      expect(body['results'].first['results'].first['ok']).to be true
+      expect(manifestation.reload.title).to eq('Updated Via API')
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # GET /admin/mass_update/collection_contents
+  # ---------------------------------------------------------------------------
+  describe 'GET /admin/mass_update/collection_contents' do
+    let!(:sub_manifestation) { create(:manifestation, title: 'Sub Work') }
+    let!(:_item) do
+      create(:collection_item, collection: collection, item: sub_manifestation,
+                               seqno: 1, item_type: 'Manifestation')
+    end
+
+    it 'returns a flat item list with correct type and depth' do
+      get admin_mass_update_collection_contents_path, params: { collection_id: collection.id }
+      expect(response).to have_http_status(:ok)
+      items = response.parsed_body['items']
+      expect(items).to be_an(Array)
+      expect(items.length).to eq(1)
+      expect(items.first['type']).to eq('Manifestation')
+      expect(items.first['id']).to eq(sub_manifestation.id)
+      expect(items.first['depth']).to eq(0)
+    end
+
+    it 'returns nested items with incremented depth for sub-collections' do
+      sub_collection = create(:collection, title: 'Sub Collection', collection_type: :volume)
+      sub_sub_manifestation = create(:manifestation, title: 'Deep Work')
+      create(:collection_item, collection: collection, item: sub_collection,
+                               seqno: 2, item_type: 'Collection')
+      create(:collection_item, collection: sub_collection, item: sub_sub_manifestation,
+                               seqno: 1, item_type: 'Manifestation')
+
+      get admin_mass_update_collection_contents_path, params: { collection_id: collection.id }
+      items = response.parsed_body['items']
+      # Should have: sub_manifestation (depth 0), sub_collection (depth 0), sub_sub_manifestation (depth 1)
+      depths = items.to_h { |i| [i['title'], i['depth']] }
+      expect(depths['Sub Work']).to eq(0)
+      expect(depths['Sub Collection']).to eq(0)
+      expect(depths['Deep Work']).to eq(1)
+    end
+
+    it 'returns items ordered by seqno' do
+      second = create(:manifestation, title: 'Second Work')
+      create(:collection_item, collection: collection, item: second, seqno: 2, item_type: 'Manifestation')
+
+      get admin_mass_update_collection_contents_path, params: { collection_id: collection.id }
+      items = response.parsed_body['items']
+      expect(items.map { |i| i['title'] }).to eq(['Sub Work', 'Second Work']) # rubocop:disable Rails/Pluck
+    end
+
+    it 'returns 404 for an unknown collection_id' do
+      get admin_mass_update_collection_contents_path, params: { collection_id: 0 }
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # GET /admin/mass_update/authority_manifestations
+  # ---------------------------------------------------------------------------
+  describe 'GET /admin/mass_update/authority_manifestations' do
+    let(:authority) { create(:authority) }
+
+    it 'returns manifestations whose Work involves the authority' do
+      work = manifestation.expression.work
+      InvolvedAuthority.create!(item: work, authority: authority, role: :editor)
+
+      get admin_mass_update_authority_manifestations_path, params: { authority_id: authority.id }
+      expect(response).to have_http_status(:ok)
+      returned_ids = response.parsed_body['manifestations'].map { |m| m['id'] } # rubocop:disable Rails/Pluck
+      expect(returned_ids).to include(manifestation.id)
+    end
+
+    it 'returns manifestations whose Expression involves the authority' do
+      expression = manifestation.expression
+      InvolvedAuthority.create!(item: expression, authority: authority, role: :translator)
+
+      get admin_mass_update_authority_manifestations_path, params: { authority_id: authority.id }
+      returned_ids = response.parsed_body['manifestations'].map { |m| m['id'] } # rubocop:disable Rails/Pluck
+      expect(returned_ids).to include(manifestation.id)
+    end
+
+    it 'returns 404 for an unknown authority_id' do
+      get admin_mass_update_authority_manifestations_path, params: { authority_id: 0 }
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+end

--- a/spec/requests/admin/saved_selections_spec.rb
+++ b/spec/requests/admin/saved_selections_spec.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Admin::SavedSelections', type: :request do
+  let(:owner)      { login_as_catalog_editor }
+  let(:other_user) { create(:user, editor: true) }
+
+  def make_selection(user:, shared: false)
+    SavedSelection.create!(name: 'Test Selection', user: user,
+                           delete_after: 90.days.from_now.to_date, shared: shared)
+  end
+
+  before { owner } # ensure login_as_catalog_editor runs and stubs current_user
+
+  # ---------------------------------------------------------------------------
+  # DELETE /admin/saved_selections/:id
+  # ---------------------------------------------------------------------------
+  describe 'DELETE /admin/saved_selections/:id' do
+    context 'when the current user owns the selection' do
+      it 'deletes the selection and returns 204' do
+        sel = make_selection(user: owner)
+        delete admin_saved_selection_path(sel)
+        expect(response).to have_http_status(:no_content)
+        expect(SavedSelection.exists?(sel.id)).to be false
+      end
+    end
+
+    context 'when the current user does NOT own the selection' do
+      it 'returns 403 and does not delete the selection' do
+        sel = make_selection(user: other_user)
+        delete admin_saved_selection_path(sel)
+        expect(response).to have_http_status(:forbidden)
+        expect(SavedSelection.exists?(sel.id)).to be true
+      end
+    end
+
+    context 'when the selection does not exist' do
+      it 'returns 404' do
+        delete admin_saved_selection_path(0)
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # POST /admin/saved_selections (create)
+  # ---------------------------------------------------------------------------
+  describe 'POST /admin/saved_selections' do
+    let(:manifestation) { create(:manifestation) }
+
+    it 'creates a private selection and returns 201' do
+      post admin_saved_selections_path,
+           params: {
+             name: 'My Private',
+             shared: false,
+             items: [{ type: 'Manifestation', id: manifestation.id }]
+           },
+           as: :json
+      expect(response).to have_http_status(:created)
+      sel = SavedSelection.find_by(name: 'My Private')
+      expect(sel).to be_present
+      expect(sel.shared).to be false
+      expect(sel.saved_selection_items.count).to eq(1)
+    end
+
+    it 'creates a shared selection' do
+      post admin_saved_selections_path,
+           params: { name: 'Shared One', shared: true, items: [] },
+           as: :json
+      expect(response).to have_http_status(:created)
+      expect(SavedSelection.find_by(name: 'Shared One').shared).to be true
+    end
+
+    it 'returns 422 when name is blank' do
+      post admin_saved_selections_path,
+           params: { name: '', shared: false, items: [] },
+           as: :json
+      expect(response).to have_http_status(:unprocessable_content)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # GET /admin/saved_selections (index)
+  # ---------------------------------------------------------------------------
+  describe 'GET /admin/saved_selections' do
+    it 'returns only selections visible to the current user' do
+      own           = make_selection(user: owner, shared: false)
+      shared        = make_selection(user: other_user, shared: true)
+      private_other = make_selection(user: other_user, shared: false)
+
+      get admin_saved_selections_path
+      ids = response.parsed_body.map { |s| s['id'] } # rubocop:disable Rails/Pluck
+      expect(ids).to include(own.id, shared.id)
+      expect(ids).not_to include(private_other.id)
+    end
+  end
+end

--- a/spec/requests/admin/saved_selections_spec.rb
+++ b/spec/requests/admin/saved_selections_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe 'Admin::SavedSelections', type: :request do
-  let(:owner)      { login_as_catalog_editor }
+  let(:owner)      { login_as_batch_editor }
   let(:other_user) { create(:user, editor: true) }
 
   def make_selection(user:, shared: false)

--- a/spec/services/mass_update_service_spec.rb
+++ b/spec/services/mass_update_service_spec.rb
@@ -13,8 +13,9 @@ RSpec.describe MassUpdateService do
     described_class.new(records, changes).apply
   end
 
+  # Returns the array of result values (unwrapped from { result:, change_index: }) for a given record.
   def result_for(results, record)
-    results[[record['type'], record['id']]]
+    results[[record['type'], record['id']]].map { |r| r[:result] }
   end
 
   describe '#apply' do
@@ -22,7 +23,7 @@ RSpec.describe MassUpdateService do
       it 'returns error for all changes' do
         changes = [{ 'kind' => 'field_update', 'record_type' => 'manifestation', 'field' => 'title', 'value' => 'X' }]
         results = apply([{ 'type' => 'Manifestation', 'id' => 0 }], changes)
-        expect(results[['Manifestation', 0]].first).to eq(I18n.t('admin.mass_update.errors.record_not_found'))
+        expect(results[['Manifestation', 0]].first[:result]).to eq(I18n.t('admin.mass_update.errors.record_not_found'))
       end
     end
 
@@ -73,10 +74,10 @@ RSpec.describe MassUpdateService do
         expect(collection.reload.title).to eq('New Name')
       end
 
-      it 'silently skips a work field applied to collection (not applicable)' do
+      it 'omits result entirely for a work field applied to collection (not applicable)' do
         changes = [{ 'kind' => 'field_update', 'record_type' => 'work', 'field' => 'genre', 'value' => 'poetry' }]
         results = apply([c_record], changes)
-        expect(result_for(results, c_record).first).to eq(:ok)
+        expect(result_for(results, c_record)).to be_empty
       end
 
       it 'returns error for disallowed field' do
@@ -352,29 +353,29 @@ RSpec.describe MassUpdateService do
     end
 
     context 'with mixed Manifestation and Collection records in the same batch' do
-      it 'applies a collection-level change to collection and silently skips it for manifestation' do
+      it 'applies a collection-level change to collection and omits it for manifestation' do
         changes = [{ 'kind' => 'field_update', 'record_type' => 'collection',
                      'field' => 'title', 'value' => 'Bulk Title' }]
         results = apply([m_record, c_record], changes)
         expect(collection.reload.title).to eq('Bulk Title')
-        expect(result_for(results, m_record).first).to eq(:ok) # not applicable — silently skipped
+        expect(result_for(results, m_record)).to be_empty
       end
 
-      it 'applies a manifestation-level change to manifestation and silently skips it for collection' do
+      it 'applies a manifestation-level change to manifestation and omits it for collection' do
         changes = [{ 'kind' => 'field_update', 'record_type' => 'manifestation',
                      'field' => 'title', 'value' => 'Batch Title' }]
         results = apply([m_record, c_record], changes)
         expect(manifestation.reload.title).to eq('Batch Title')
-        expect(result_for(results, c_record).first).to eq(:ok) # not applicable — silently skipped
+        expect(result_for(results, c_record)).to be_empty
       end
 
-      it 'applies a work-level change to manifestation and silently skips it for collection' do
+      it 'applies a work-level change to manifestation and omits it for collection' do
         work = manifestation.expression.work
         changes = [{ 'kind' => 'field_update', 'record_type' => 'work',
                      'field' => 'genre', 'value' => 'drama' }]
         results = apply([m_record, c_record], changes)
         expect(work.reload.genre).to eq('drama')
-        expect(result_for(results, c_record).first).to eq(:ok) # not applicable — silently skipped
+        expect(result_for(results, c_record)).to be_empty
       end
 
       it 'applies multiple changes and collects independent results per record' do
@@ -423,18 +424,18 @@ RSpec.describe MassUpdateService do
         }.by(1)
       end
 
-      it 'silently skips work entity on Collection record (not applicable)' do
+      it 'omits result for work entity on Collection record (not applicable)' do
         changes = [{ 'kind' => 'involved_authority_add', 'role' => 'editor',
                      'authority_id' => authority.id, 'entity' => 'work' }]
         results = apply([c_record], changes)
-        expect(result_for(results, c_record).first).to eq(:ok)
+        expect(result_for(results, c_record)).to be_empty
       end
 
-      it 'silently skips expression entity on Collection record (not applicable)' do
+      it 'omits result for expression entity on Collection record (not applicable)' do
         changes = [{ 'kind' => 'involved_authority_add', 'role' => 'editor',
                      'authority_id' => authority.id, 'entity' => 'expression' }]
         results = apply([c_record], changes)
-        expect(result_for(results, c_record).first).to eq(:ok)
+        expect(result_for(results, c_record)).to be_empty
       end
     end
 

--- a/spec/services/mass_update_service_spec.rb
+++ b/spec/services/mass_update_service_spec.rb
@@ -217,6 +217,23 @@ RSpec.describe MassUpdateService do
       end
     end
 
+    context 'when an unexpected exception is raised inside apply_change' do
+      it 'logs the error and returns a generic i18n message with an error ID' do
+        allow(manifestation).to receive(:assign_attributes).and_raise(RuntimeError, 'DB exploded')
+        allow(Manifestation).to receive(:find_by).with(id: manifestation.id).and_return(manifestation)
+        allow(Rails.logger).to receive(:error)
+
+        changes = [{ 'kind' => 'field_update', 'record_type' => 'manifestation',
+                     'field' => 'title', 'value' => 'X' }]
+        results = apply([m_record], changes)
+        error_msg = result_for(results, m_record).first
+        expect(Rails.logger).to have_received(:error).with(a_string_matching(/MassUpdateService.*DB exploded/))
+        expect(error_msg).to be_a(String)
+        expect(error_msg).to match(/[0-9a-f]{8}/)
+        expect(error_msg).not_to include('DB exploded')
+      end
+    end
+
     context 'with boolean field changes' do
       it 'sets exclude_from_index to true' do
         manifestation.update!(exclude_from_index: false)

--- a/spec/services/mass_update_service_spec.rb
+++ b/spec/services/mass_update_service_spec.rb
@@ -1,0 +1,197 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe MassUpdateService do
+  let(:manifestation) { create(:manifestation, title: 'Original Title') }
+  let(:collection) { create(:collection, title: 'Original Collection', collection_type: :volume) }
+
+  let(:m_record) { { 'type' => 'Manifestation', 'id' => manifestation.id } }
+  let(:c_record) { { 'type' => 'Collection', 'id' => collection.id } }
+
+  def apply(records, changes)
+    described_class.new(records, changes).apply
+  end
+
+  def result_for(results, record)
+    results[[record['type'], record['id']]]
+  end
+
+  describe '#apply' do
+    context 'when record does not exist' do
+      it 'returns error for all changes' do
+        changes = [{ 'kind' => 'field_update', 'record_type' => 'manifestation', 'field' => 'title', 'value' => 'X' }]
+        results = apply([{ 'type' => 'Manifestation', 'id' => 0 }], changes)
+        expect(results[['Manifestation', 0]].first).to eq(I18n.t('admin.mass_update.errors.record_not_found'))
+      end
+    end
+
+    context 'with field_update changes' do
+      it 'updates a manifestation title' do
+        changes = [{ 'kind' => 'field_update', 'record_type' => 'manifestation', 'field' => 'title',
+                     'value' => 'New Title' }]
+        results = apply([m_record], changes)
+        expect(result_for(results, m_record)).to eq([:ok])
+        expect(manifestation.reload.title).to eq('New Title')
+      end
+
+      it 'updates a manifestation status' do
+        changes = [{ 'kind' => 'field_update', 'record_type' => 'manifestation', 'field' => 'status',
+                     'value' => 'unpublished' }]
+        results = apply([m_record], changes)
+        expect(result_for(results, m_record)).to eq([:ok])
+        expect(manifestation.reload.status).to eq('unpublished')
+      end
+
+      it 'clears a field when value is blank' do
+        manifestation.update!(comment: 'old comment')
+        changes = [{ 'kind' => 'field_update', 'record_type' => 'manifestation', 'field' => 'comment', 'value' => '' }]
+        apply([m_record], changes)
+        expect(manifestation.reload.comment).to be_nil
+      end
+
+      it 'updates an expression field (period)' do
+        expression = manifestation.expression
+        changes = [{ 'kind' => 'field_update', 'record_type' => 'expression', 'field' => 'period',
+                     'value' => 'modern' }]
+        apply([m_record], changes)
+        expect(expression.reload.period).to eq('modern')
+      end
+
+      it 'updates a work field (genre)' do
+        work = manifestation.expression.work
+        changes = [{ 'kind' => 'field_update', 'record_type' => 'work', 'field' => 'genre', 'value' => 'poetry' }]
+        apply([m_record], changes)
+        expect(work.reload.genre).to eq('poetry')
+      end
+
+      it 'updates a collection field' do
+        changes = [{ 'kind' => 'field_update', 'record_type' => 'collection', 'field' => 'title',
+                     'value' => 'New Name' }]
+        results = apply([c_record], changes)
+        expect(result_for(results, c_record)).to eq([:ok])
+        expect(collection.reload.title).to eq('New Name')
+      end
+
+      it 'returns error when work field applied to collection' do
+        changes = [{ 'kind' => 'field_update', 'record_type' => 'work', 'field' => 'genre', 'value' => 'poetry' }]
+        results = apply([c_record], changes)
+        expect(result_for(results, c_record).first).not_to eq(:ok)
+      end
+
+      it 'returns error for disallowed field' do
+        changes = [{ 'kind' => 'field_update', 'record_type' => 'manifestation', 'field' => 'markdown',
+                     'value' => 'x' }]
+        results = apply([m_record], changes)
+        expect(result_for(results, m_record).first).not_to eq(:ok)
+      end
+    end
+
+    context 'with involved_authority changes' do
+      let(:authority) { create(:authority) }
+
+      it 'adds an involved authority to the work' do
+        changes = [{ 'kind' => 'involved_authority_add', 'role' => 'editor', 'authority_id' => authority.id,
+                     'entity' => 'work' }]
+        work = manifestation.expression.work
+        expect { apply([m_record], changes) }.to change {
+          InvolvedAuthority.where(item: work, authority: authority).count
+        }.by(1)
+      end
+
+      it 'is idempotent for add (find_or_create)' do
+        work = manifestation.expression.work
+        InvolvedAuthority.create!(item: work, authority: authority, role: :editor)
+        changes = [{ 'kind' => 'involved_authority_add', 'role' => 'editor', 'authority_id' => authority.id,
+                     'entity' => 'work' }]
+        expect { apply([m_record], changes) }.not_to(change(InvolvedAuthority, :count))
+      end
+
+      it 'adds an involved authority to the expression' do
+        expression = manifestation.expression
+        changes = [{ 'kind' => 'involved_authority_add', 'role' => 'translator', 'authority_id' => authority.id,
+                     'entity' => 'expression' }]
+        expect { apply([m_record], changes) }.to change {
+          InvolvedAuthority.where(item: expression, authority: authority).count
+        }.by(1)
+      end
+
+      it 'removes an existing involved authority' do
+        work = manifestation.expression.work
+        ia = InvolvedAuthority.create!(item: work, authority: authority, role: :editor)
+        changes = [{ 'kind' => 'involved_authority_remove', 'role' => 'editor', 'authority_id' => authority.id,
+                     'entity' => 'work' }]
+        expect { apply([m_record], changes) }.to change { InvolvedAuthority.exists?(ia.id) }.from(true).to(false)
+      end
+
+      it 'returns error when removing non-existent involvement' do
+        changes = [{ 'kind' => 'involved_authority_remove', 'role' => 'editor', 'authority_id' => authority.id,
+                     'entity' => 'work' }]
+        results = apply([m_record], changes)
+        expect(result_for(results, m_record).first).not_to eq(:ok)
+      end
+
+      it 'returns error for missing authority_id' do
+        changes = [{ 'kind' => 'involved_authority_add', 'role' => 'editor', 'authority_id' => 0, 'entity' => 'work' }]
+        results = apply([m_record], changes)
+        expect(result_for(results, m_record).first).not_to eq(:ok)
+      end
+    end
+
+    context 'with external_link changes' do
+      it 'adds an external link' do
+        changes = [{ 'kind' => 'external_link_add', 'url' => 'https://example.com', 'linktype' => 'wikipedia',
+                     'description' => 'Test' }]
+        expect { apply([m_record], changes) }.to change(ExternalLink, :count).by(1)
+        link = ExternalLink.last
+        expect(link.url).to eq('https://example.com')
+        expect(link.linkable).to eq(manifestation)
+        expect(link).to be_status_approved
+      end
+
+      it 'removes an external link by URL' do
+        link = ExternalLink.create!(linkable: manifestation, url: 'https://example.com', linktype: :wikipedia)
+        changes = [{ 'kind' => 'external_link_remove', 'url' => 'https://example.com' }]
+        expect { apply([m_record], changes) }.to change { ExternalLink.exists?(link.id) }.from(true).to(false)
+      end
+
+      it 'returns error when removing non-existent link' do
+        changes = [{ 'kind' => 'external_link_remove', 'url' => 'https://no-such-url.com' }]
+        results = apply([m_record], changes)
+        expect(result_for(results, m_record).first).not_to eq(:ok)
+      end
+    end
+
+    context 'with multiple records and changes' do
+      let(:manifestation2) { create(:manifestation, title: 'Second Manifestation') }
+      let(:m_record2) { { 'type' => 'Manifestation', 'id' => manifestation2.id } }
+
+      it 'applies all changes to all records independently' do
+        changes = [
+          { 'kind' => 'field_update', 'record_type' => 'manifestation', 'field' => 'title', 'value' => 'Updated' },
+          { 'kind' => 'field_update', 'record_type' => 'manifestation', 'field' => 'comment', 'value' => 'Note' }
+        ]
+        apply([m_record, m_record2], changes)
+        expect(manifestation.reload.title).to eq('Updated')
+        expect(manifestation2.reload.title).to eq('Updated')
+        expect(manifestation.reload.comment).to eq('Note')
+      end
+
+      it 'collects errors without aborting other records' do
+        bad_record = { 'type' => 'Manifestation', 'id' => 0 }
+        changes = [{ 'kind' => 'field_update', 'record_type' => 'manifestation', 'field' => 'title', 'value' => 'OK' }]
+        apply([m_record, bad_record, m_record2], changes)
+        expect(manifestation.reload.title).to eq('OK')
+        expect(manifestation2.reload.title).to eq('OK')
+      end
+    end
+
+    context 'with unknown change kind' do
+      it 'returns an error string' do
+        changes = [{ 'kind' => 'does_not_exist' }]
+        results = apply([m_record], changes)
+        expect(result_for(results, m_record).first).to include('does_not_exist')
+      end
+    end
+  end
+end

--- a/spec/services/mass_update_service_spec.rb
+++ b/spec/services/mass_update_service_spec.rb
@@ -73,10 +73,10 @@ RSpec.describe MassUpdateService do
         expect(collection.reload.title).to eq('New Name')
       end
 
-      it 'returns error when work field applied to collection' do
+      it 'silently skips a work field applied to collection (not applicable)' do
         changes = [{ 'kind' => 'field_update', 'record_type' => 'work', 'field' => 'genre', 'value' => 'poetry' }]
         results = apply([c_record], changes)
-        expect(result_for(results, c_record).first).not_to eq(:ok)
+        expect(result_for(results, c_record).first).to eq(:ok)
       end
 
       it 'returns error for disallowed field' do
@@ -193,6 +193,7 @@ RSpec.describe MassUpdateService do
         work = manifestation.expression.work
         expression = manifestation.expression
         allow(expression).to receive(:work).and_return(work)
+        allow(manifestation).to receive(:expression).and_return(expression)
         allow(work).to receive(:save) do
           work.write_attribute(:orig_lang, nil) # simulate silent normalization
           true
@@ -200,10 +201,7 @@ RSpec.describe MassUpdateService do
 
         changes = [{ 'kind' => 'field_update', 'record_type' => 'work',
                      'field' => 'orig_lang', 'value' => 'invalid_lang' }]
-        # Feed the same manifestation but stub its expression to get our rigged work
-        allow(Manifestation).to receive(:find_by).with(id: manifestation.id).and_return(
-          instance_double(Manifestation, expression: expression)
-        )
+        allow(Manifestation).to receive(:find_by).with(id: manifestation.id).and_return(manifestation)
         results = apply([m_record], changes)
         expect(result_for(results, m_record).first).not_to eq(:ok)
       end
@@ -354,31 +352,29 @@ RSpec.describe MassUpdateService do
     end
 
     context 'with mixed Manifestation and Collection records in the same batch' do
-      it 'applies a collection-level change to collection and ignores it for manifestation' do
+      it 'applies a collection-level change to collection and silently skips it for manifestation' do
         changes = [{ 'kind' => 'field_update', 'record_type' => 'collection',
                      'field' => 'title', 'value' => 'Bulk Title' }]
         results = apply([m_record, c_record], changes)
-        # Collection gets the update
         expect(collection.reload.title).to eq('Bulk Title')
-        # Manifestation gets an error (collection field not applicable)
-        expect(result_for(results, m_record).first).not_to eq(:ok)
+        expect(result_for(results, m_record).first).to eq(:ok) # not applicable — silently skipped
       end
 
-      it 'applies a manifestation-level change to manifestation and returns error for collection' do
+      it 'applies a manifestation-level change to manifestation and silently skips it for collection' do
         changes = [{ 'kind' => 'field_update', 'record_type' => 'manifestation',
                      'field' => 'title', 'value' => 'Batch Title' }]
         results = apply([m_record, c_record], changes)
         expect(manifestation.reload.title).to eq('Batch Title')
-        expect(result_for(results, c_record).first).not_to eq(:ok)
+        expect(result_for(results, c_record).first).to eq(:ok) # not applicable — silently skipped
       end
 
-      it 'applies a work-level change to manifestation but returns error for collection' do
+      it 'applies a work-level change to manifestation and silently skips it for collection' do
         work = manifestation.expression.work
         changes = [{ 'kind' => 'field_update', 'record_type' => 'work',
                      'field' => 'genre', 'value' => 'drama' }]
         results = apply([m_record, c_record], changes)
         expect(work.reload.genre).to eq('drama')
-        expect(result_for(results, c_record).first).not_to eq(:ok)
+        expect(result_for(results, c_record).first).to eq(:ok) # not applicable — silently skipped
       end
 
       it 'applies multiple changes and collects independent results per record' do
@@ -427,18 +423,18 @@ RSpec.describe MassUpdateService do
         }.by(1)
       end
 
-      it 'returns error when entity is not applicable for Collection record' do
+      it 'silently skips work entity on Collection record (not applicable)' do
         changes = [{ 'kind' => 'involved_authority_add', 'role' => 'editor',
                      'authority_id' => authority.id, 'entity' => 'work' }]
         results = apply([c_record], changes)
-        expect(result_for(results, c_record).first).not_to eq(:ok)
+        expect(result_for(results, c_record).first).to eq(:ok)
       end
 
-      it 'returns error for expression entity on Collection record' do
+      it 'silently skips expression entity on Collection record (not applicable)' do
         changes = [{ 'kind' => 'involved_authority_add', 'role' => 'editor',
                      'authority_id' => authority.id, 'entity' => 'expression' }]
         results = apply([c_record], changes)
-        expect(result_for(results, c_record).first).not_to eq(:ok)
+        expect(result_for(results, c_record).first).to eq(:ok)
       end
     end
 

--- a/spec/services/mass_update_service_spec.rb
+++ b/spec/services/mass_update_service_spec.rb
@@ -193,5 +193,260 @@ RSpec.describe MassUpdateService do
         expect(result_for(results, m_record).first).to include('does_not_exist')
       end
     end
+
+    context 'with boolean field changes' do
+      it 'sets exclude_from_index to true' do
+        manifestation.update!(exclude_from_index: false)
+        changes = [{ 'kind' => 'field_update', 'record_type' => 'manifestation',
+                     'field' => 'exclude_from_index', 'value' => 'true' }]
+        apply([m_record], changes)
+        expect(manifestation.reload.exclude_from_index).to be true
+      end
+
+      it 'sets exclude_from_index to false' do
+        manifestation.update!(exclude_from_index: true)
+        changes = [{ 'kind' => 'field_update', 'record_type' => 'manifestation',
+                     'field' => 'exclude_from_index', 'value' => 'false' }]
+        apply([m_record], changes)
+        expect(manifestation.reload.exclude_from_index).to be false
+      end
+
+      it 'sets sefaria_linker (nullable boolean) to true' do
+        changes = [{ 'kind' => 'field_update', 'record_type' => 'manifestation',
+                     'field' => 'sefaria_linker', 'value' => 'true' }]
+        apply([m_record], changes)
+        expect(manifestation.reload.sefaria_linker).to be true
+      end
+
+      it 'clears sefaria_linker (nullable boolean) when value is blank' do
+        manifestation.update!(sefaria_linker: true)
+        changes = [{ 'kind' => 'field_update', 'record_type' => 'manifestation',
+                     'field' => 'sefaria_linker', 'value' => '' }]
+        apply([m_record], changes)
+        expect(manifestation.reload.sefaria_linker).to be_nil
+      end
+
+      it 'sets primary (work boolean) to false' do
+        work = manifestation.expression.work
+        work.update!(primary: true)
+        changes = [{ 'kind' => 'field_update', 'record_type' => 'work',
+                     'field' => 'primary', 'value' => 'false' }]
+        apply([m_record], changes)
+        expect(work.reload.primary).to be false
+      end
+
+      it 'sets suppress_download_and_print (collection boolean) to true' do
+        collection.update!(suppress_download_and_print: false)
+        changes = [{ 'kind' => 'field_update', 'record_type' => 'collection',
+                     'field' => 'suppress_download_and_print', 'value' => 'true' }]
+        apply([c_record], changes)
+        expect(collection.reload.suppress_download_and_print).to be true
+      end
+    end
+
+    context 'with enum field changes' do
+      it 'sets manifestation status to published' do
+        manifestation.update!(status: :unpublished)
+        changes = [{ 'kind' => 'field_update', 'record_type' => 'manifestation',
+                     'field' => 'status', 'value' => 'published' }]
+        apply([m_record], changes)
+        expect(manifestation.reload.status).to eq('published')
+      end
+
+      it 'sets manifestation status to deprecated' do
+        changes = [{ 'kind' => 'field_update', 'record_type' => 'manifestation',
+                     'field' => 'status', 'value' => 'deprecated' }]
+        apply([m_record], changes)
+        expect(manifestation.reload.status).to eq('deprecated')
+      end
+
+      it 'sets manifestation status to nonpd' do
+        changes = [{ 'kind' => 'field_update', 'record_type' => 'manifestation',
+                     'field' => 'status', 'value' => 'nonpd' }]
+        apply([m_record], changes)
+        expect(manifestation.reload.status).to eq('nonpd')
+      end
+
+      it 'sets expression intellectual_property to by_permission' do
+        expression = manifestation.expression
+        changes = [{ 'kind' => 'field_update', 'record_type' => 'expression',
+                     'field' => 'intellectual_property', 'value' => 'by_permission' }]
+        apply([m_record], changes)
+        expect(expression.reload.intellectual_property).to eq('by_permission')
+      end
+
+      it 'sets expression intellectual_property to copyrighted' do
+        expression = manifestation.expression
+        changes = [{ 'kind' => 'field_update', 'record_type' => 'expression',
+                     'field' => 'intellectual_property', 'value' => 'copyrighted' }]
+        apply([m_record], changes)
+        expect(expression.reload.intellectual_property).to eq('copyrighted')
+      end
+
+      it 'returns an error for an invalid enum value' do
+        changes = [{ 'kind' => 'field_update', 'record_type' => 'manifestation',
+                     'field' => 'status', 'value' => 'not_a_real_status' }]
+        results = apply([m_record], changes)
+        expect(result_for(results, m_record).first).not_to eq(:ok)
+      end
+
+      it 'sets collection collection_type to periodical' do
+        changes = [{ 'kind' => 'field_update', 'record_type' => 'collection',
+                     'field' => 'collection_type', 'value' => 'periodical' }]
+        apply([c_record], changes)
+        expect(collection.reload.collection_type).to eq('periodical')
+      end
+
+      it 'sets work genre to prose' do
+        work = manifestation.expression.work
+        changes = [{ 'kind' => 'field_update', 'record_type' => 'work',
+                     'field' => 'genre', 'value' => 'prose' }]
+        apply([m_record], changes)
+        expect(work.reload.genre).to eq('prose')
+      end
+
+      it 'returns an error for blank enum with presence validation' do
+        changes = [{ 'kind' => 'field_update', 'record_type' => 'expression',
+                     'field' => 'intellectual_property', 'value' => '' }]
+        results = apply([m_record], changes)
+        expect(result_for(results, m_record).first).not_to eq(:ok)
+      end
+    end
+
+    context 'with mixed Manifestation and Collection records in the same batch' do
+      it 'applies a collection-level change to collection and ignores it for manifestation' do
+        changes = [{ 'kind' => 'field_update', 'record_type' => 'collection',
+                     'field' => 'title', 'value' => 'Bulk Title' }]
+        results = apply([m_record, c_record], changes)
+        # Collection gets the update
+        expect(collection.reload.title).to eq('Bulk Title')
+        # Manifestation gets an error (collection field not applicable)
+        expect(result_for(results, m_record).first).not_to eq(:ok)
+      end
+
+      it 'applies a manifestation-level change to manifestation and returns error for collection' do
+        changes = [{ 'kind' => 'field_update', 'record_type' => 'manifestation',
+                     'field' => 'title', 'value' => 'Batch Title' }]
+        results = apply([m_record, c_record], changes)
+        expect(manifestation.reload.title).to eq('Batch Title')
+        expect(result_for(results, c_record).first).not_to eq(:ok)
+      end
+
+      it 'applies a work-level change to manifestation but returns error for collection' do
+        work = manifestation.expression.work
+        changes = [{ 'kind' => 'field_update', 'record_type' => 'work',
+                     'field' => 'genre', 'value' => 'drama' }]
+        results = apply([m_record, c_record], changes)
+        expect(work.reload.genre).to eq('drama')
+        expect(result_for(results, c_record).first).not_to eq(:ok)
+      end
+
+      it 'applies multiple changes and collects independent results per record' do
+        changes = [
+          { 'kind' => 'field_update', 'record_type' => 'manifestation', 'field' => 'title', 'value' => 'M Title' },
+          { 'kind' => 'field_update', 'record_type' => 'collection', 'field' => 'title', 'value' => 'C Title' }
+        ]
+        apply([m_record, c_record], changes)
+        expect(manifestation.reload.title).to eq('M Title')
+        expect(collection.reload.title).to eq('C Title')
+      end
+    end
+
+    context 'with InvolvedAuthority role validation' do
+      let(:authority) { create(:authority) }
+
+      it 'returns error when adding translator role to work entity (translator is expression-only)' do
+        changes = [{ 'kind' => 'involved_authority_add', 'role' => 'translator',
+                     'authority_id' => authority.id, 'entity' => 'work' }]
+        results = apply([m_record], changes)
+        expect(result_for(results, m_record).first).not_to eq(:ok)
+      end
+
+      it 'returns error when adding author role to expression entity (author is work-only)' do
+        changes = [{ 'kind' => 'involved_authority_add', 'role' => 'author',
+                     'authority_id' => authority.id, 'entity' => 'expression' }]
+        results = apply([m_record], changes)
+        expect(result_for(results, m_record).first).not_to eq(:ok)
+      end
+
+      it 'allows editor role on work entity' do
+        work = manifestation.expression.work
+        changes = [{ 'kind' => 'involved_authority_add', 'role' => 'editor',
+                     'authority_id' => authority.id, 'entity' => 'work' }]
+        expect { apply([m_record], changes) }.to change {
+          InvolvedAuthority.where(item: work, authority: authority, role: :editor).count
+        }.by(1)
+      end
+
+      it 'allows translator role on expression entity' do
+        expression = manifestation.expression
+        changes = [{ 'kind' => 'involved_authority_add', 'role' => 'translator',
+                     'authority_id' => authority.id, 'entity' => 'expression' }]
+        expect { apply([m_record], changes) }.to change {
+          InvolvedAuthority.where(item: expression, authority: authority, role: :translator).count
+        }.by(1)
+      end
+
+      it 'returns error when entity is not applicable for Collection record' do
+        changes = [{ 'kind' => 'involved_authority_add', 'role' => 'editor',
+                     'authority_id' => authority.id, 'entity' => 'work' }]
+        results = apply([c_record], changes)
+        expect(result_for(results, c_record).first).not_to eq(:ok)
+      end
+
+      it 'returns error for expression entity on Collection record' do
+        changes = [{ 'kind' => 'involved_authority_add', 'role' => 'editor',
+                     'authority_id' => authority.id, 'entity' => 'expression' }]
+        results = apply([c_record], changes)
+        expect(result_for(results, c_record).first).not_to eq(:ok)
+      end
+    end
+
+    context 'with ExternalLink edge cases' do
+      it 'returns error for a URL with an invalid scheme (ftp://)' do
+        changes = [{ 'kind' => 'external_link_add', 'url' => 'ftp://example.com',
+                     'linktype' => 'wikipedia', 'description' => '' }]
+        results = apply([m_record], changes)
+        expect(result_for(results, m_record).first).not_to eq(:ok)
+      end
+
+      it 'is idempotent when the same URL is added twice to the same record' do
+        changes = [{ 'kind' => 'external_link_add', 'url' => 'https://example.com',
+                     'linktype' => 'wikipedia', 'description' => '' }]
+        apply([m_record], changes)
+        # Second add should fail due to uniqueness (same linkable + url)
+        results = apply([m_record], changes)
+        # Either returns :ok (truly idempotent) or returns a validation error string —
+        # either way, it must NOT raise an exception, just return a result
+        expect(result_for(results, m_record).first).to be_a(Symbol).or be_a(String)
+      end
+
+      it 'adds an external link to a Collection record' do
+        changes = [{ 'kind' => 'external_link_add', 'url' => 'https://collection.example.com',
+                     'linktype' => 'other', 'description' => 'Test' }]
+        results = apply([c_record], changes)
+        expect(result_for(results, c_record).first).to eq(:ok)
+        expect(ExternalLink.find_by(linkable: collection, url: 'https://collection.example.com')).to be_present
+      end
+
+      it 'removes an external link from a Collection record' do
+        link = ExternalLink.create!(linkable: collection, url: 'https://collection.example.com', linktype: :other)
+        changes = [{ 'kind' => 'external_link_remove', 'url' => 'https://collection.example.com' }]
+        results = apply([c_record], changes)
+        expect(result_for(results, c_record).first).to eq(:ok)
+        expect(ExternalLink.exists?(link.id)).to be false
+      end
+
+      it 'does not remove a URL that belongs to a different record' do
+        # Link exists on manifestation, we try to remove from collection — should fail for collection
+        ExternalLink.create!(linkable: manifestation, url: 'https://shared-url.example.com', linktype: :other)
+        changes = [{ 'kind' => 'external_link_remove', 'url' => 'https://shared-url.example.com' }]
+        results = apply([c_record], changes)
+        # Collection should get an error (not found on collection)
+        expect(result_for(results, c_record).first).not_to eq(:ok)
+        # The manifestation's link is untouched
+        expect(ExternalLink.find_by(linkable: manifestation, url: 'https://shared-url.example.com')).to be_present
+      end
+    end
   end
 end

--- a/spec/services/mass_update_service_spec.rb
+++ b/spec/services/mass_update_service_spec.rb
@@ -387,6 +387,24 @@ RSpec.describe MassUpdateService do
         expect(manifestation.reload.title).to eq('M Title')
         expect(collection.reload.title).to eq('C Title')
       end
+
+      it 'returns correct change_index per record so results can be labelled by original change position' do
+        # changes[0] = work-level (Manifestation only), changes[1] = collection-level (Collection only)
+        changes = [
+          { 'kind' => 'field_update', 'record_type' => 'work', 'field' => 'genre', 'value' => 'drama' },
+          { 'kind' => 'field_update', 'record_type' => 'collection', 'field' => 'title', 'value' => 'C Title' }
+        ]
+        results = apply([m_record, c_record], changes)
+
+        m_results = results[['Manifestation', manifestation.id]]
+        c_results = results[['Collection', collection.id]]
+
+        expect(m_results.pluck(:change_index)).to eq([0])
+        expect(m_results.pluck(:result)).to eq([:ok])
+
+        expect(c_results.pluck(:change_index)).to eq([1])
+        expect(c_results.pluck(:result)).to eq([:ok])
+      end
     end
 
     context 'with InvolvedAuthority role validation' do
@@ -436,6 +454,30 @@ RSpec.describe MassUpdateService do
                      'authority_id' => authority.id, 'entity' => 'expression' }]
         results = apply([c_record], changes)
         expect(result_for(results, c_record)).to be_empty
+      end
+
+      it 'adds an involved authority directly to a Collection entity' do
+        changes = [{ 'kind' => 'involved_authority_add', 'role' => 'editor',
+                     'authority_id' => authority.id, 'entity' => 'collection' }]
+        expect { apply([c_record], changes) }.to change {
+          InvolvedAuthority.where(item: collection, authority: authority, role: :editor).count
+        }.by(1)
+      end
+
+      it 'removes an involved authority from a Collection entity' do
+        InvolvedAuthority.create!(item: collection, authority: authority, role: :editor)
+        changes = [{ 'kind' => 'involved_authority_remove', 'role' => 'editor',
+                     'authority_id' => authority.id, 'entity' => 'collection' }]
+        expect { apply([c_record], changes) }.to change {
+          InvolvedAuthority.where(item: collection, authority: authority, role: :editor).count
+        }.by(-1)
+      end
+
+      it 'omits result for collection entity on Manifestation record (not applicable)' do
+        changes = [{ 'kind' => 'involved_authority_add', 'role' => 'editor',
+                     'authority_id' => authority.id, 'entity' => 'collection' }]
+        results = apply([m_record], changes)
+        expect(result_for(results, m_record)).to be_empty
       end
     end
 

--- a/spec/services/mass_update_service_spec.rb
+++ b/spec/services/mass_update_service_spec.rb
@@ -186,6 +186,29 @@ RSpec.describe MassUpdateService do
       end
     end
 
+    context 'when value is silently not persisted after save' do
+      it 'returns an error if the saved value does not match the intended value' do
+        # Simulate a before_validation callback that resets a field to nil,
+        # so save returns true but the intended value was not persisted.
+        work = manifestation.expression.work
+        expression = manifestation.expression
+        allow(expression).to receive(:work).and_return(work)
+        allow(work).to receive(:save) do
+          work.write_attribute(:orig_lang, nil) # simulate silent normalization
+          true
+        end
+
+        changes = [{ 'kind' => 'field_update', 'record_type' => 'work',
+                     'field' => 'orig_lang', 'value' => 'invalid_lang' }]
+        # Feed the same manifestation but stub its expression to get our rigged work
+        allow(Manifestation).to receive(:find_by).with(id: manifestation.id).and_return(
+          instance_double(Manifestation, expression: expression)
+        )
+        results = apply([m_record], changes)
+        expect(result_for(results, m_record).first).not_to eq(:ok)
+      end
+    end
+
     context 'with unknown change kind' do
       it 'returns an error string' do
         changes = [{ 'kind' => 'does_not_exist' }]

--- a/spec/support/test_helpers.rb
+++ b/spec/support/test_helpers.rb
@@ -20,6 +20,23 @@ module TestHelpers
     user
   end
 
+  # Creates an editor user with batch_editing privileges for testing
+  def create_batch_editor
+    @batch_editor ||= begin
+      user = create(:user, editor: true)
+      ListItem.create!(listkey: 'batch_editing', item: user)
+      user
+    end
+  end
+
+  # Login helper for mass-update / saved-selections specs
+  def login_as_batch_editor
+    user = create_batch_editor
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
+    allow_any_instance_of(ApplicationController).to receive(:require_editor).and_return(true)
+    user
+  end
+
   # Creates an editor user with moderate_tags privileges for testing
   def create_moderator
     @moderator ||= begin

--- a/spec/system/admin/mass_update_spec.rb
+++ b/spec/system/admin/mass_update_spec.rb
@@ -1,0 +1,156 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Mass Update Tool', :js, type: :system do
+  before do
+    skip 'WebDriver not available or misconfigured' unless webdriver_available?
+    login_as_catalog_editor
+  end
+
+  let!(:manifestation) { create(:manifestation, title: 'Test Manifestation') }
+  let!(:collection)    { create(:collection, title: 'Test Collection', collection_type: :volume) }
+
+  # Adds a record to the selection list via the "By ID" tab, then waits for it to appear.
+  def add_record_by_id(type_label, id)
+    select type_label, from: 'direct_record_type'
+    fill_in 'direct_id', with: id.to_s
+    click_button I18n.t('admin.mass_update.add_button'), match: :first
+    # Wait for the record to appear in the list (Capybara auto-waits)
+    find('#records-list', text: "##{id}", wait: 5)
+  end
+
+  # Adds a field_update change to the changes list.
+  def add_field_update_change(record_type_label, field_name, value)
+    select I18n.t('admin.mass_update.change_kind_field_update'), from: 'change_kind'
+    select record_type_label, from: 'field_record_type'
+    select field_name, from: 'field-name-select'
+    fill_in 'field_value', with: value
+    click_button I18n.t('admin.mass_update.add_change_button')
+    find('#changes-list', text: "#{record_type_label.downcase}.#{field_name}", wait: 5)
+  end
+
+  describe 'page load' do
+    it 'renders the page title and both sections' do
+      visit admin_mass_update_path
+      expect(page).to have_content(I18n.t('admin.mass_update.new.title'), wait: 5)
+      expect(page).to have_content(I18n.t('admin.mass_update.section_records'))
+      expect(page).to have_content(I18n.t('admin.mass_update.section_changes'))
+    end
+  end
+
+  describe 'adding a record by ID' do
+    before { visit admin_mass_update_path }
+
+    it 'adds a Manifestation to the list' do
+      add_record_by_id(I18n.t('admin.mass_update.record_type_manifestation'), manifestation.id)
+      expect(page).to have_content("Manifestation ##{manifestation.id}")
+      expect(page).not_to have_content(I18n.t('admin.mass_update.no_records_in_list'))
+    end
+  end
+
+  describe 'adding a field_update change' do
+    before do
+      visit admin_mass_update_path
+      add_record_by_id(I18n.t('admin.mass_update.record_type_manifestation'), manifestation.id)
+    end
+
+    it 'adds a change to the changes list' do
+      add_field_update_change(I18n.t('admin.mass_update.record_type_manifestation'), 'title', 'Updated Title')
+      expect(page).to have_content('manifestation.title = Updated Title')
+    end
+  end
+
+  describe 'applying changes' do
+    before do
+      visit admin_mass_update_path
+      add_record_by_id(I18n.t('admin.mass_update.record_type_manifestation'), manifestation.id)
+      add_field_update_change(I18n.t('admin.mass_update.record_type_manifestation'), 'title', 'Mass Updated Title')
+    end
+
+    it 'applies the changes and shows results' do
+      page.accept_confirm do
+        click_button I18n.t('admin.mass_update.apply_button')
+      end
+      expect(page).to have_content(I18n.t('admin.mass_update.results_title'), wait: 10)
+      expect(page).to have_content(I18n.t('admin.mass_update.result_ok'), wait: 5)
+      expect(manifestation.reload.title).to eq('Mass Updated Title')
+    end
+  end
+
+  describe 'saving and loading selections' do
+    before do
+      visit admin_mass_update_path
+      add_record_by_id(I18n.t('admin.mass_update.record_type_manifestation'), manifestation.id)
+    end
+
+    it 'saves a private selection' do
+      fill_in 'new_selection_name', with: 'My Private Selection'
+      click_button I18n.t('admin.mass_update.save_private_button')
+      expect(page).to have_content(I18n.t('admin.saved_selections.save_success'), wait: 5)
+      expect(SavedSelection.where(name: 'My Private Selection', shared: false)).to exist
+    end
+
+    it 'saves a shared selection' do
+      fill_in 'new_selection_name', with: 'Shared Selection'
+      click_button I18n.t('admin.mass_update.save_shared_button')
+      expect(page).to have_content(I18n.t('admin.saved_selections.save_success'), wait: 5)
+      expect(SavedSelection.where(name: 'Shared Selection', shared: true)).to exist
+    end
+
+    context 'when a selection exists in the DB' do
+      let!(:saved_selection) do
+        sel = SavedSelection.create!(name: 'Existing Selection', user: create_catalog_editor, shared: false)
+        sel.saved_selection_items.create!(item_type: 'Manifestation', item_id: manifestation.id)
+        sel
+      end
+
+      it 'shows the selection in the dropdown and loads it' do
+        visit admin_mass_update_path
+        # The dropdown is populated via AJAX on page load
+        expect(page).to have_select('saved-selections-dropdown',
+                                    with_options: ['Existing Selection (1)'], wait: 5)
+        select 'Existing Selection (1)', from: 'saved-selections-dropdown'
+        click_button I18n.t('admin.mass_update.load_selection_button')
+        expect(page).to have_content("Manifestation ##{manifestation.id}", wait: 5)
+      end
+    end
+  end
+
+  describe 'collection expansion options' do
+    let!(:sub_manifestation) { create(:manifestation, title: 'Sub Manifestation') }
+    let!(:_collection_item) do
+      create(:collection_item, collection: collection, item: sub_manifestation,
+                               seqno: 1, item_type: 'Manifestation')
+    end
+
+    before { visit admin_mass_update_path }
+
+    it 'shows expansion options when adding a collection by ID' do
+      add_record_by_id(I18n.t('admin.mass_update.record_type_collection'), collection.id)
+      expect(page).to have_content(I18n.t('admin.mass_update.collection_expand_label'), wait: 5)
+    end
+
+    it 'adds only the collection when collection_only is selected' do
+      add_record_by_id(I18n.t('admin.mass_update.record_type_collection'), collection.id)
+      choose I18n.t('admin.mass_update.collection_expand_collection_only')
+      click_button I18n.t('admin.mass_update.add_button'), id: 'confirm-add-collection-btn'
+      expect(page).to have_content("Collection ##{collection.id}", wait: 5)
+      expect(page).not_to have_content("Manifestation ##{sub_manifestation.id}")
+    end
+  end
+
+  describe 'removing a record from the list' do
+    before do
+      visit admin_mass_update_path
+      add_record_by_id(I18n.t('admin.mass_update.record_type_manifestation'), manifestation.id)
+    end
+
+    it 'removes a record when clicking the remove button' do
+      within('#records-list') do
+        click_button I18n.t('admin.mass_update.remove_button')
+      end
+      expect(page).to have_content(I18n.t('admin.mass_update.no_records_in_list'), wait: 5)
+    end
+  end
+end

--- a/spec/system/admin/mass_update_spec.rb
+++ b/spec/system/admin/mass_update_spec.rb
@@ -21,13 +21,15 @@ RSpec.describe 'Mass Update Tool', :js, type: :system do
   end
 
   # Adds a field_update change to the changes list.
-  def add_field_update_change(record_type_label, field_name, value)
+  # field_name is the internal key (e.g. 'title'); field_label is the localized label shown in the dropdown.
+  def add_field_update_change(record_type_label, field_name, value, record_type_key: nil)
     select I18n.t('admin.mass_update.change_kind_field_update'), from: 'change_kind'
     select record_type_label, from: 'field_record_type'
-    select field_name, from: 'field-name-select'
+    field_label = record_type_key ? I18n.t("admin.mass_update.fields.#{record_type_key}.#{field_name}") : field_name
+    select field_label, from: 'field-name-select'
     fill_in 'field_value', with: value
     click_button I18n.t('admin.mass_update.add_change_button')
-    find('#changes-list', text: "#{record_type_label.downcase}.#{field_name}", wait: 5)
+    find('#changes-list', text: field_label, wait: 5)
   end
 
   describe 'page load' do
@@ -56,8 +58,9 @@ RSpec.describe 'Mass Update Tool', :js, type: :system do
     end
 
     it 'adds a change to the changes list' do
-      add_field_update_change(I18n.t('admin.mass_update.record_type_manifestation'), 'title', 'Updated Title')
-      expect(page).to have_content('manifestation.title = Updated Title')
+      add_field_update_change(I18n.t('admin.mass_update.record_type_manifestation'),
+                              'title', 'Updated Title', record_type_key: 'manifestation')
+      expect(page).to have_content(I18n.t('admin.mass_update.fields.manifestation.title') + ' = Updated Title')
     end
   end
 


### PR DESCRIPTION
## Summary

- New admin tool at `/admin/mass_update` (linked from dashboard) for catalog editors to apply batch metadata corrections to multiple Manifestations and/or Collections at once
- Selection supports three modes: by direct ID, title autocomplete, or authority name search (showing volumes/manifestations the authority is involved in)
- When adding a Collection, editors choose how to expand it: collection only, collection + all contents, contents only, manifestations only, or custom checkbox tree
- Selections can be saved (private or shared with other editors), with automatic 90-day expiry to prevent bloat
- Changes support: field updates (all fields from edit_metadata / manage_collection forms, including Work/Expression fields), InvolvedAuthority add/remove, ExternalLink add/remove
- Changes applied synchronously with per-record-per-change error collection (one failure doesn't abort the batch)
- Results shown inline after apply

## New files

| File | Purpose |
|------|---------|
| `MassUpdateService` | Core batch-apply logic |
| `Admin::MassUpdatesController` | Routes + AJAX endpoints |
| `Admin::SavedSelectionsController` | CRUD for saved selections |
| `SavedSelection` / `SavedSelectionItem` | Models + migrations |
| `app/views/admin/mass_updates/new.html.haml` | Full UI |
| `spec/services/mass_update_service_spec.rb` | 21 unit tests |
| `spec/system/admin/mass_update_spec.rb` | Capybara system spec |

## Test plan

- [ ] `bundle exec rspec spec/services/mass_update_service_spec.rb` — 21 examples, 0 failures
- [ ] `bundle exec rspec spec/system/admin/mass_update_spec.rb` — runs if webdriver available
- [ ] Visit `/admin/mass_update` as an edit_catalog editor and verify all three selection modes work
- [ ] Verify collection expansion options (collection only / all contents / etc.)
- [ ] Verify save selection (private vs shared), load selection, expiry field
- [ ] Verify field_update change applies to correct entity (Work/Expression/Manifestation/Collection)
- [ ] Verify involved_authority add/remove and external_link add/remove

Fixes #111.

🤖 Generated with [Claude Code](https://claude.com/claude-code)