### PR TITLE
Fix false positives in pubs_maybe_done list

### DIFF
--- a/app/controllers/bib_controller.rb
+++ b/app/controllers/bib_controller.rb
@@ -145,7 +145,7 @@ class BibController < ApplicationController
       mm = item.authority.all_works_including_unpublished
       # add the first work by this authority whose title matches the pub's title when compared via pub_title_for_comparison
       to_add = mm.find_all { |work| pub_title_for_comparison(work.title) == pub_title_for_comparison(item.title) }
-      @pubs << [item, to_add] if to_add
+      @pubs << [item, to_add] if to_add.any?
     end
   end
 

--- a/app/controllers/bib_controller.rb
+++ b/app/controllers/bib_controller.rb
@@ -143,7 +143,7 @@ class BibController < ApplicationController
     ListItem.includes(:item).where(listkey: 'pubs_maybe_done').each do |pub|
       item = pub.item
       mm = item.authority.all_works_including_unpublished
-      # add the first work by this authority whose title matches the pub's title when compared via pub_title_for_comparison
+      # add all works by this authority whose title matches the pub's title when compared via pub_title_for_comparison
       to_add = mm.find_all { |work| pub_title_for_comparison(work.title) == pub_title_for_comparison(item.title) }
       @pubs << [item, to_add] if to_add.any?
     end

--- a/app/models/publication.rb
+++ b/app/models/publication.rb
@@ -31,10 +31,11 @@ class Publication < ApplicationRecord
       print "\nHandling #{i} out of #{total}..." if i % 50 == 0
       if pub.authority_id != last_author
         last_author = pub.authority_id
-        author_title_cache = pub.authority.all_works_title_sorted.pluck(:title)
+        titles = pub.authority.all_works_title_sorted.pluck(:title)
+        author_title_cache = Set.new(titles.map { |t| pub_title_for_comparison(t) })
       end
       searchtitle = pub_title_for_comparison(pub.title)
-      if author_title_cache.any? { |title| pub_title_for_comparison(title) == searchtitle }
+      if author_title_cache.include?(searchtitle)
         li = ListItem.new(listkey: 'pubs_maybe_done', item: pub)
         li.save!
         added += 1

--- a/app/models/publication.rb
+++ b/app/models/publication.rb
@@ -34,7 +34,7 @@ class Publication < ApplicationRecord
         author_title_cache = pub.authority.all_works_title_sorted.pluck(:title)
       end
       searchtitle = pub_title_for_comparison(pub.title)
-      if author_title_cache.bsearch { |title| searchtitle <=> searchtitle }
+      if author_title_cache.any? { |title| pub_title_for_comparison(title) == searchtitle }
         li = ListItem.new(listkey: 'pubs_maybe_done', item: pub)
         li.save!
         added += 1

--- a/spec/controllers/bib_contoller_spec.rb
+++ b/spec/controllers/bib_contoller_spec.rb
@@ -152,5 +152,15 @@ describe BibController do
         [translated_maybe_done_pub, [translated_manifestation_1, translated_manifestation_2]]
       ]
     end
+
+    context 'when a publication in the list has no matching manifestation titles' do
+      let!(:unmatched_pub) { create(:publication, :pubs_maybe_done, title: 'completely unique title') }
+
+      it 'excludes the publication from the results' do
+        expect(request).to be_successful
+        pub_items = assigns(:pubs).map(&:first)
+        expect(pub_items).not_to include(unmatched_pub)
+      end
+    end
   end
 end

--- a/spec/models/publication_spec.rb
+++ b/spec/models/publication_spec.rb
@@ -6,14 +6,7 @@ RSpec.describe Publication, type: :model do
   describe '.update_publications_that_may_be_done_list' do
     subject(:run) { described_class.update_publications_that_may_be_done_list }
 
-    def pub_title_for_comparison(str)
-      ret = if str['/'].nil?
-              str[0..[10, str.length].min]
-            else
-              str[0..[10, str.index('/') - 1].min]
-            end
-      ret.strip
-    end
+    before { allow($stdout).to receive(:write) }
 
     # Use a known prefix so we can craft matching/non-matching titles reliably.
     let(:shared_prefix) { 'אבגדהוזחטי' } # 10 Hebrew chars → first 11 chars are deterministic

--- a/spec/models/publication_spec.rb
+++ b/spec/models/publication_spec.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Publication, type: :model do
+  describe '.update_publications_that_may_be_done_list' do
+    subject(:run) { described_class.update_publications_that_may_be_done_list }
+
+    def pub_title_for_comparison(str)
+      ret = if str['/'].nil?
+              str[0..[10, str.length].min]
+            else
+              str[0..[10, str.index('/') - 1].min]
+            end
+      ret.strip
+    end
+
+    # Use a known prefix so we can craft matching/non-matching titles reliably.
+    let(:shared_prefix) { 'אבגדהוזחטי' } # 10 Hebrew chars → first 11 chars are deterministic
+
+    let(:authority) { create(:authority) }
+
+    let!(:matching_pub) do
+      create(:publication, status: :todo, authority: authority, title: "#{shared_prefix} additional words")
+    end
+
+    let!(:non_matching_pub) do
+      create(:publication, status: :todo, authority: authority, title: 'fully different title here')
+    end
+
+    let!(:_matching_manifestation) do
+      create(:manifestation, title: "#{shared_prefix} different suffix", author: authority)
+    end
+
+    context 'when the author has a work whose title prefix matches the publication title prefix' do
+      it 'adds the matching publication to the pubs_maybe_done list' do
+        expect { run }.to change {
+          ListItem.where(listkey: 'pubs_maybe_done', item: matching_pub).count
+        }.from(0).to(1)
+      end
+    end
+
+    context 'when the author has works but none with a matching title prefix' do
+      it 'does not add the non-matching publication to the list' do
+        expect { run }.not_to(change do
+          ListItem.where(listkey: 'pubs_maybe_done', item: non_matching_pub).count
+        end)
+      end
+    end
+
+    context 'when the author has no works at all' do
+      let(:authority_without_works) { create(:authority) }
+      let!(:orphan_pub) do
+        create(:publication, status: :todo, authority: authority_without_works, title: shared_prefix)
+      end
+
+      it 'does not add the publication to the list' do
+        expect { run }.not_to(change do
+          ListItem.where(listkey: 'pubs_maybe_done', item: orphan_pub).count
+        end)
+      end
+    end
+
+    context 'when the publication is already uploaded' do
+      let!(:uploaded_pub) do
+        create(:publication, status: :uploaded, authority: authority, title: "#{shared_prefix} suffix")
+      end
+
+      it 'skips uploaded publications' do
+        expect { run }.not_to(change do
+          ListItem.where(listkey: 'pubs_maybe_done', item: uploaded_pub).count
+        end)
+      end
+    end
+
+    context 'when the publication is already in the pubs_maybe_done list' do
+      let!(:already_listed_pub) do
+        create(:publication, :pubs_maybe_done, status: :todo, authority: authority,
+                                               title: "#{shared_prefix} suffix")
+      end
+
+      it 'skips already-listed publications' do
+        expect { run }.not_to(change do
+          ListItem.where(listkey: 'pubs_maybe_done', item: already_listed_pub).count
+        end)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- **`publication.rb`**: Fixed a typo in `update_publications_that_may_be_done_list` where `bsearch { |title| searchtitle <=> searchtitle }` compared `searchtitle` to itself (always `0`), causing every publication whose author has any works to be added regardless of title. Replaced with `any? { |title| pub_title_for_comparison(title) == searchtitle }` which also avoids the secondary issue that the array was sorted by `sort_title` (not by `pub_title_for_comparison(title)`), making `bsearch` unreliable in any case.
- **`bib_controller.rb`**: Fixed `if to_add` in `pubs_maybe_done` — `find_all` returns `[]` on no match, which is truthy in Ruby. Changed to `if to_add.any?` so publications with no matching manifestations are excluded from the view.

## Test plan

- [ ] New `spec/models/publication_spec.rb` covers: title match adds to list; title mismatch skips; no works skips; uploaded status skips; already-listed skips.
- [ ] New controller context in `spec/controllers/bib_contoller_spec.rb`: pub in list with no matching manifestation titles is excluded from `@pubs`.
- [ ] `bundle exec rspec spec/models/publication_spec.rb spec/controllers/bib_contoller_spec.rb` — 19 examples, 0 failures.

Closes by-crh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)