### PR TITLE
Fix HTML-inserted images not appearing in PDF and EPUB exports

### DIFF
--- a/app/services/make_fresh_downloadable.rb
+++ b/app/services/make_fresh_downloadable.rb
@@ -120,33 +120,48 @@ class MakeFreshDownloadable < ApplicationService
 
   def images_to_absolute_url(buf)
     require 'base64'
-    # Handle /files/:record_type/:record_id/:filename URLs (custom download URLs for uploaded images).
-    # These must be embedded as base64 because Chromium/Pandoc cannot follow HTTP redirects back to
-    # the Rails server without deadlocking (server is blocked waiting for the subprocess).
-    result = buf.gsub(%r{/files/([^/"]+)/(\d+)/([^"'\s>]+)}) do |url|
-      record_type = ::Regexp.last_match(1)
-      record_id   = ::Regexp.last_match(2)
-      filename    = ::Regexp.last_match(3)
-      begin
-        record_class = DownloadLink.record_class(record_type)
-        next url unless record_class
+    root_url = Rails.application.routes.url_helpers.root_url.chomp('/')
 
-        record = record_class.find_by(id: record_id)
-        next url unless record
+    # Scope rewrites to <img src="..."> attributes only. A bare gsub on path patterns would also
+    # transform <a href="/files/..."> links and other non-image occurrences, and would miss
+    # filenames that contain spaces (download_path unescapes URI-encoded names).
+    buf.gsub(/<img\b([^>]*?)\bsrc=(["'])([^"']+)\2([^>]*>)/i) do
+      before_src = ::Regexp.last_match(1)
+      quote      = ::Regexp.last_match(2)
+      src        = ::Regexp.last_match(3)
+      after_src  = ::Regexp.last_match(4)
 
-        blob = record.blob_by_filename(filename)
-        next url unless blob
+      new_src =
+        if src =~ %r{\A/files/([^/"]+)/(\d+)/(.+)\z}
+          # Custom download URL: /files/:record_type/:record_id/:filename
+          # Embed as base64 so Chromium/Pandoc don't make HTTP requests back to the server.
+          record_type = ::Regexp.last_match(1)
+          record_id   = ::Regexp.last_match(2)
+          filename    = URI::DEFAULT_PARSER.unescape(::Regexp.last_match(3))
+          begin
+            record_class = DownloadLink.record_class(record_type)
+            next "<img#{before_src}src=#{quote}#{src}#{quote}#{after_src}" unless record_class
 
-        raw = blob.download
-        "data:#{blob.content_type};base64,#{Base64.strict_encode64(raw)}"
-      rescue StandardError => e
-        Rails.logger.warn "Image embedding failed for #{url}: #{e.message}"
-        url
-      end
+            record = record_class.find_by(id: record_id)
+            next "<img#{before_src}src=#{quote}#{src}#{quote}#{after_src}" unless record
+
+            blob = record.blob_by_filename(filename)
+            next "<img#{before_src}src=#{quote}#{src}#{quote}#{after_src}" unless blob
+
+            raw = blob.download
+            "data:#{blob.content_type};base64,#{Base64.strict_encode64(raw)}"
+          rescue StandardError => e
+            Rails.logger.warn "Image embedding failed for #{src}: #{e.message}"
+            src
+          end
+        elsif src.start_with?('/rails/active_storage')
+          # Legacy or directly-inserted ActiveStorage blob URL: make absolute for the renderer
+          "#{root_url}#{src}"
+        else
+          src
+        end
+
+      "<img#{before_src}src=#{quote}#{new_src}#{quote}#{after_src}"
     end
-
-    # Handle any remaining /rails/active_storage/... URLs (legacy or directly-inserted blob URLs)
-    result.gsub('<img src="/rails/active_storage',
-                "<img src=\"#{Rails.application.routes.url_helpers.root_url}/rails/active_storage")
   end
 end

--- a/app/services/make_fresh_downloadable.rb
+++ b/app/services/make_fresh_downloadable.rb
@@ -119,7 +119,34 @@ class MakeFreshDownloadable < ApplicationService
   private
 
   def images_to_absolute_url(buf)
-    return buf.gsub('<img src="/rails/active_storage',
-                    "<img src=\"#{Rails.application.routes.url_helpers.root_url}/rails/active_storage")
+    require 'base64'
+    # Handle /files/:record_type/:record_id/:filename URLs (custom download URLs for uploaded images).
+    # These must be embedded as base64 because Chromium/Pandoc cannot follow HTTP redirects back to
+    # the Rails server without deadlocking (server is blocked waiting for the subprocess).
+    result = buf.gsub(%r{/files/([^/"]+)/(\d+)/([^"'\s>]+)}) do |url|
+      record_type = ::Regexp.last_match(1)
+      record_id   = ::Regexp.last_match(2)
+      filename    = ::Regexp.last_match(3)
+      begin
+        record_class = DownloadLink.record_class(record_type)
+        next url unless record_class
+
+        record = record_class.find_by(id: record_id)
+        next url unless record
+
+        blob = record.blob_by_filename(filename)
+        next url unless blob
+
+        raw = blob.download
+        "data:#{blob.content_type};base64,#{Base64.strict_encode64(raw)}"
+      rescue StandardError => e
+        Rails.logger.warn "Image embedding failed for #{url}: #{e.message}"
+        url
+      end
+    end
+
+    # Handle any remaining /rails/active_storage/... URLs (legacy or directly-inserted blob URLs)
+    result.gsub('<img src="/rails/active_storage',
+                "<img src=\"#{Rails.application.routes.url_helpers.root_url}/rails/active_storage")
   end
 end

--- a/lib/bybe_utils.rb
+++ b/lib/bybe_utils.rb
@@ -113,9 +113,40 @@ module BybeUtils
 
   # Extract and embed images from HTML into EPUB
   def embed_images_in_epub(book, html, image_counter = 0)
-    # Find all ActiveStorage image URLs in the HTML
     modified_html = html.dup
     image_map = {}
+
+    # Handle /files/:record_type/:record_id/:filename URLs (custom download URLs for uploaded images)
+    html.scan(%r{<img[^>]*src=["'](/files/([^/"]+)/(\d+)/([^"'\s>]+))["'][^>]*>}i).each do |matches|
+      full_path   = matches[0]
+      record_type = matches[1]
+      record_id   = matches[2]
+      filename    = matches[3]
+      next if image_map[full_path]
+
+      begin
+        record_class = DownloadLink.record_class(record_type)
+        next unless record_class
+
+        record = record_class.find_by(id: record_id)
+        next unless record
+
+        blob = record.blob_by_filename(filename)
+        next unless blob
+
+        extension = File.extname(filename)
+        epub_filename = "images/image_#{image_counter}#{extension}"
+        image_counter += 1
+
+        image_data = String.new
+        blob.download { |chunk| image_data << chunk }
+
+        book.add_item(epub_filename, content: StringIO.new(image_data))
+        image_map[full_path] = epub_filename
+      rescue StandardError => e
+        Rails.logger.warn("Failed to embed image #{full_path}: #{e.message}")
+      end
+    end
 
     # Match ActiveStorage URLs in img tags
     html.scan(%r{<img[^>]*src=["'](/rails/active_storage/[^"']+)["'][^>]*>}i).each do |matches|

--- a/lib/bybe_utils.rb
+++ b/lib/bybe_utils.rb
@@ -116,12 +116,13 @@ module BybeUtils
     modified_html = html.dup
     image_map = {}
 
-    # Handle /files/:record_type/:record_id/:filename URLs (custom download URLs for uploaded images)
-    html.scan(%r{<img[^>]*src=["'](/files/([^/"]+)/(\d+)/([^"'\s>]+))["'][^>]*>}i).each do |matches|
+    # Handle /files/:record_type/:record_id/:filename URLs (custom download URLs for uploaded images).
+    # Use [^"']+ (stop at closing quote) instead of [^"'\s>]+ so that filenames with spaces are matched.
+    html.scan(%r{<img[^>]*src=["'](/files/([^/"]+)/(\d+)/([^"']+))["'][^>]*>}i).each do |matches|
       full_path   = matches[0]
       record_type = matches[1]
       record_id   = matches[2]
-      filename    = matches[3]
+      filename    = URI::DEFAULT_PARSER.unescape(matches[3])
       next if image_map[full_path]
 
       begin
@@ -138,7 +139,7 @@ module BybeUtils
         epub_filename = "images/image_#{image_counter}#{extension}"
         image_counter += 1
 
-        image_data = String.new
+        image_data = ''.b # binary buffer to avoid Encoding::CompatibilityError with image bytes
         blob.download { |chunk| image_data << chunk }
 
         book.add_item(epub_filename, content: StringIO.new(image_data))
@@ -169,8 +170,8 @@ module BybeUtils
           epub_filename = "images/image_#{image_counter}#{extension}"
           image_counter += 1
 
-          # Download the blob data into memory
-          image_data = String.new
+          # Download the blob data into memory; use binary buffer to avoid encoding errors
+          image_data = ''.b
           blob.download { |chunk| image_data << chunk }
 
           # Add image to EPUB using StringIO (keeps data in memory for GEPUB to access during generation)

--- a/spec/lib/bybe_utils_epub_spec.rb
+++ b/spec/lib/bybe_utils_epub_spec.rb
@@ -128,6 +128,35 @@ RSpec.describe 'BybeUtils EPUB generation' do
         expect(Rails.logger).to have_received(:warn)
       end
     end
+
+    context 'when HTML contains /files/:record_type/:record_id/:filename URLs (HTML-inserted images)' do
+      it 'extracts and embeds images referenced by custom file download URLs' do
+        html_with_file_url = "<p>Text</p><img src=\"/files/text/#{manifestation.id}/photo.jpg\" " \
+                             'alt="photo.jpg" style="width:800px;height:600px;object-fit:contain">'
+
+        blob = instance_double(ActiveStorage::Blob)
+        allow(manifestation).to receive(:blob_by_filename).with('photo.jpg').and_return(blob)
+        allow(blob).to receive(:download).and_yield('fake_image_data')
+        allow(Manifestation).to receive(:find_by).with(id: manifestation.id.to_s).and_return(manifestation)
+
+        modified_html, counter = embed_images_in_epub(book, html_with_file_url, 0)
+
+        expect(modified_html).to include('images/image_0.jpg')
+        expect(modified_html).not_to include('/files/text/')
+        expect(counter).to eq(1)
+      end
+
+      it 'leaves URL unchanged when the record is not found' do
+        html = '<img src="/files/text/99999/missing.png" alt="missing.png">'
+        allow(Manifestation).to receive(:find_by).with(id: '99999').and_return(nil)
+        allow(Rails.logger).to receive(:warn)
+
+        modified_html, counter = embed_images_in_epub(book, html, 0)
+
+        expect(modified_html).to include('/files/text/99999/missing.png')
+        expect(counter).to eq(0)
+      end
+    end
   end
 
   describe '#make_epub_from_collection' do

--- a/spec/services/make_fresh_downloadable_spec.rb
+++ b/spec/services/make_fresh_downloadable_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe MakeFreshDownloadable do
+  subject(:service) { described_class.new }
+
+  let(:work) { create(:work) }
+  let(:expression) { create(:expression, work: work) }
+  let(:manifestation) { create(:manifestation, expression: expression, title: 'Test') }
+
+  describe '#images_to_absolute_url (private)' do
+    # Expose private method for testing
+    def images_to_absolute_url(html)
+      service.send(:images_to_absolute_url, html)
+    end
+
+    context 'when HTML contains /files/:record_type/:record_id/:filename URLs (HTML-inserted images)' do
+      let(:html) do
+        "<p>Text</p><img src=\"/files/text/#{manifestation.id}/photo.jpg\" " \
+          'alt="photo.jpg" style="width:800px;height:600px;object-fit:contain">'
+      end
+
+      it 'embeds the image as a base64 data URL' do
+        blob = instance_double(ActiveStorage::Blob, content_type: 'image/jpeg')
+        allow(blob).to receive(:download).and_return('fake_jpeg_data')
+        allow(manifestation).to receive(:blob_by_filename).with('photo.jpg').and_return(blob)
+        allow(Manifestation).to receive(:find_by).with(id: manifestation.id.to_s).and_return(manifestation)
+
+        result = images_to_absolute_url(html)
+
+        expect(result).to include('data:image/jpeg;base64,')
+        expect(result).not_to include('/files/text/')
+      end
+
+      it 'leaves the URL unchanged when the record is not found' do
+        allow(Manifestation).to receive(:find_by).with(id: manifestation.id.to_s).and_return(nil)
+        allow(Rails.logger).to receive(:warn)
+
+        result = images_to_absolute_url(html)
+
+        expect(result).to include("/files/text/#{manifestation.id}/photo.jpg")
+      end
+
+      it 'leaves the URL unchanged when the blob is not found' do
+        allow(Manifestation).to receive(:find_by).with(id: manifestation.id.to_s).and_return(manifestation)
+        allow(manifestation).to receive(:blob_by_filename).with('photo.jpg').and_return(nil)
+
+        result = images_to_absolute_url(html)
+
+        expect(result).to include("/files/text/#{manifestation.id}/photo.jpg")
+      end
+    end
+
+    context 'when HTML has no image tags' do
+      it 'returns the HTML unchanged' do
+        html = '<p>Just text</p>'
+        expect(images_to_absolute_url(html)).to eq(html)
+      end
+    end
+  end
+end

--- a/spec/services/make_fresh_downloadable_spec.rb
+++ b/spec/services/make_fresh_downloadable_spec.rb
@@ -50,6 +50,26 @@ RSpec.describe MakeFreshDownloadable do
 
         expect(result).to include("/files/text/#{manifestation.id}/photo.jpg")
       end
+
+      it 'handles filenames with spaces (URI-decoded names from download_path)' do
+        spaced_html = "<img src=\"/files/text/#{manifestation.id}/my%20photo.jpg\" alt=\"my photo.jpg\">"
+        blob = instance_double(ActiveStorage::Blob, content_type: 'image/jpeg')
+        allow(blob).to receive(:download).and_return('fake_jpeg_data')
+        allow(manifestation).to receive(:blob_by_filename).with('my photo.jpg').and_return(blob)
+        allow(Manifestation).to receive(:find_by).with(id: manifestation.id.to_s).and_return(manifestation)
+
+        result = images_to_absolute_url(spaced_html)
+
+        expect(result).to include('data:image/jpeg;base64,')
+      end
+
+      it 'does not transform /files/... URLs in non-image tags like <a href>' do
+        link_html = "<a href=\"/files/text/#{manifestation.id}/document.pdf\">download</a>"
+
+        result = images_to_absolute_url(link_html)
+
+        expect(result).to eq(link_html)
+      end
     end
 
     context 'when HTML has no image tags' do


### PR DESCRIPTION
## Summary

- Images inserted via the HTML img tag (using the image picker in the editor) generate `<img src="/files/text/ID/filename.jpg">` URLs via `DownloadLink#download_path`
- PDF export (`images_to_absolute_url`) and EPUB export (`embed_images_in_epub`) only handled `/rails/active_storage/...` URLs — `/files/...` URLs were completely ignored, so HTML-inserted images appeared blank
- Fix: resolve `/files/:record_type/:record_id/:filename` URLs to their ActiveStorage blob, then:
  - **PDF**: embed as base64 `data:` URI (avoids HTTP deadlock with Chromium headless)
  - **EPUB**: stream blob data directly into the EPUB manifest

## Test plan

- [ ] New unit spec for `MakeFreshDownloadable#images_to_absolute_url`: verifies `/files/...` URLs are base64-embedded, and graceful fallback when record/blob not found
- [ ] New test in `bybe_utils_epub_spec.rb`: verifies `embed_images_in_epub` handles `/files/...` URLs and embeds them, with fallback for missing records
- [ ] 340 existing service/lib specs pass with no regressions

Closes by-023

🤖 Generated with [Claude Code](https://claude.com/claude-code)