### PR TITLE
Replace URI.parse with Addressable::URI.parse to support non-ASCII URLs

### DIFF
--- a/app/controllers/ingestibles_controller.rb
+++ b/app/controllers/ingestibles_controller.rb
@@ -157,7 +157,7 @@ class IngestiblesController < ApplicationController
     end
     if params[:docx].present?
       file = URI.open(params[:docx])
-      uri = URI.parse(params[:docx])
+      uri = Addressable::URI.parse(params[:docx])
       @ingestible.docx.attach(io: file, filename: CGI.unescape(File.basename(uri.path)))
     end
     if @ingestible.save

--- a/app/helpers/collections_helper.rb
+++ b/app/helpers/collections_helper.rb
@@ -35,8 +35,8 @@ module CollectionsHelper
     # Normalize the base URL (remove trailing slash) and parse
     normalized_base = base_url.chomp('/')
     begin
-      base_uri = URI.parse(normalized_base)
-    rescue URI::InvalidURIError
+      base_uri = Addressable::URI.parse(normalized_base)
+    rescue Addressable::URI::InvalidURIError
       # If the base URL itself is malformed, return the original HTML unchanged
       return html_string
     end
@@ -59,7 +59,7 @@ module CollectionsHelper
 
       begin
         # Parse the href URL
-        href_uri = URI.parse(href)
+        href_uri = Addressable::URI.parse(href)
 
         # Check if it's an absolute URL pointing to our base URL
         if href_uri.absolute? && href_uri.host == base_uri.host && href_uri.scheme == base_uri.scheme
@@ -79,7 +79,7 @@ module CollectionsHelper
             link.remove_attribute('target')
           end
         end
-      rescue URI::InvalidURIError
+      rescue Addressable::URI::InvalidURIError
         # Skip malformed URIs
         next
       end

--- a/app/models/external_link.rb
+++ b/app/models/external_link.rb
@@ -34,11 +34,11 @@ class ExternalLink < ApplicationRecord
     return if url.blank?
 
     begin
-      uri = URI.parse(url.to_s)
+      uri = Addressable::URI.parse(url.to_s)
       unless %w[http https].include?(uri.scheme&.downcase)
         errors.add(:url, :invalid_scheme, message: 'must use http or https protocol')
       end
-    rescue URI::InvalidURIError
+    rescue Addressable::URI::InvalidURIError
       errors.add(:url, :invalid_uri, message: 'is not a valid URL')
     end
   end

--- a/app/models/news_item.rb
+++ b/app/models/news_item.rb
@@ -36,7 +36,7 @@ class NewsItem < ApplicationRecord
   def self.from_external_link(link)
     # Only use :youtube (embeddable iframe) for actual YouTube URLs; validate by host to
     # prevent substring attacks like "youtube.com.evil.example"
-    host = URI.parse(link.url.to_s).host.to_s.downcase
+    host = Addressable::URI.parse(link.url.to_s).host.to_s.downcase
     embeddable = link.linktype_youtube? && YOUTUBE_HOSTS.include?(host)
     return NewsItem.new(
       itemtype: embeddable ? :youtube : :audio,


### PR DESCRIPTION
## Summary

- Ruby's stdlib `URI` rejects URLs with percent-encoded non-ASCII characters (e.g. Hebrew paths like `https://iton77.com/category/%D7%A1%D7%A4%D7%A8%D7%99%D7%9D/`), raising `URI::InvalidURIError`
- `Addressable::URI` handles these correctly and is already a project dependency (used in `application_helper.rb`)
- Replaced all four remaining `URI.parse` call sites in application code:
  - `app/models/external_link.rb` — URL validation (the original bug report)
  - `app/models/news_item.rb` — host extraction for YouTube embed check
  - `app/controllers/ingestibles_controller.rb` — filename extraction from DOCX URL
  - `app/helpers/collections_helper.rb` — base URL and href parsing in link rewriter

## Test plan

- [ ] Submit an external link with a Hebrew percent-encoded URL (e.g. `https://iton77.com/category/%D7%A1%D7%A4%D7%A8%D7%99%D7%9D/`) — should be accepted
- [ ] Verify YouTube host detection still works for normal YouTube URLs
- [ ] Run `bundle exec rspec spec/models/external_link_spec.rb spec/helpers/collections_helper_spec.rb`

🤖 Generated with [Claude Code](https://claude.com/claude-code)