### PR TITLE
Fix periodical issue EPUB: titles, TOC authors, editor as creator

### DIFF
--- a/lib/bybe_utils.rb
+++ b/lib/bybe_utils.rb
@@ -273,12 +273,17 @@ module BybeUtils
     aus = []
     contributors = []
     collection.authorities.each do |ia|
-      if ia.role == 'author' || ia.role == 'editor'
-        # Treat editors as creators too — for periodical issues the editor is the primary responsible party
+      if ia.role == 'author'
         aus << ia.authority.name
       else
         contributors << [ia.authority.name, epub_role_from_ia_role(ia.role)]
       end
+    end
+    # When no authors exist, promote editors to creators so EPUB readers don't show "UNKNOWN"
+    if aus.empty?
+      editors, others = contributors.partition { |_, role| role == 'edt' }
+      aus = editors.map(&:first)
+      contributors = others
     end
     aus.each { |a| book.add_creator(a) }
     contributors.each { |c, r| book.add_contributor(c, role: r) }
@@ -321,9 +326,12 @@ module BybeUtils
     collection.flatten_items.each do |ci|
       # Build section HTML with title, authority information, and content
       section_html = ''
+      content_html = ci.collection? ? '<p/>' : ci.to_html
 
-      # Add manifestation/section title first
-      section_html += "<h1>#{ci.title}</h1>\n" if ci.title.present? && !ci.markdown.present?
+      # Prepend title unless this is a paratext item or the content already opens with <h1>
+      if ci.title.present? && ci.markdown.blank? && !content_html.lstrip.start_with?('<h1')
+        section_html += "<h1>#{CGI.escapeHTML(ci.title)}</h1>\n"
+      end
 
       # Add involved authorities for this section
       if ci.involved_authorities.present?
@@ -338,7 +346,6 @@ module BybeUtils
       end
 
       # Add the actual content
-      content_html = ci.collection? ? '<p/>' : ci.to_html
       section_html += content_html
 
       # Process and embed images (adds images to manifest, but outside ordered block so not in spine)

--- a/lib/bybe_utils.rb
+++ b/lib/bybe_utils.rb
@@ -273,7 +273,8 @@ module BybeUtils
     aus = []
     contributors = []
     collection.authorities.each do |ia|
-      if ia.role == 'author'
+      if ia.role == 'author' || ia.role == 'editor'
+        # Treat editors as creators too — for periodical issues the editor is the primary responsible party
         aus << ia.authority.name
       else
         contributors << [ia.authority.name, epub_role_from_ia_role(ia.role)]
@@ -318,10 +319,13 @@ module BybeUtils
     # This ensures images are only in the manifest, not the spine
     processed_sections = []
     collection.flatten_items.each do |ci|
-      # Build section HTML with authority information
+      # Build section HTML with title, authority information, and content
       section_html = ''
 
-      # Add involved authorities for this manifestation
+      # Add manifestation/section title first
+      section_html += "<h1>#{ci.title}</h1>\n" if ci.title.present? && !ci.markdown.present?
+
+      # Add involved authorities for this section
       if ci.involved_authorities.present?
         InvolvedAuthority::ROLES_PRESENTATION_ORDER.each do |role|
           ras = ci.involved_authorities.select { |ia| ia.role == role }
@@ -343,7 +347,7 @@ module BybeUtils
       processed_sections << {
         html: section_html,
         content_html: content_html,
-        toc_title: ci.markdown.present? ? I18n.t(:paratext_description) : ci.title,
+        toc_title: ci.markdown.present? ? I18n.t(:paratext_description) : ci.title_and_authors,
         is_collection: ci.collection?
       }
     end

--- a/spec/lib/bybe_utils_epub_spec.rb
+++ b/spec/lib/bybe_utils_epub_spec.rb
@@ -240,6 +240,89 @@ RSpec.describe 'BybeUtils EPUB generation' do
       File.delete(epub_file)
     end
 
+    context 'when collection is a periodical_issue' do
+      let(:periodical) { create(:collection, collection_type: :periodical) }
+      let(:issue) { create(:collection, collection_type: :periodical_issue, title: 'Issue 1') }
+      let(:article1) do
+        create(:manifestation,
+               expression: expression,
+               title: 'Article One',
+               markdown: 'This is the content of article one.')
+      end
+      let(:article2) do
+        create(:manifestation,
+               expression: expression,
+               title: 'Article Two',
+               markdown: 'This is the content of article two.')
+      end
+      let(:author1) { create(:authority, name: 'Writer Aleph') }
+      let(:editor) { create(:authority, name: 'Editor Bet') }
+
+      before do
+        create(:collection_item, collection: issue, item: article1, seqno: 1)
+        create(:collection_item, collection: issue, item: article2, seqno: 2)
+      end
+
+      it 'includes manifestation titles at the beginning of each section' do
+        epub_file = make_epub_from_collection(issue)
+
+        Zip::File.open(epub_file) do |zip_file|
+          first_section = zip_file.read('OEBPS/1_text.xhtml').force_encoding('UTF-8')
+          expect(first_section).to include('<h1>Article One</h1>')
+
+          second_section = zip_file.read('OEBPS/2_text.xhtml').force_encoding('UTF-8')
+          expect(second_section).to include('<h1>Article Two</h1>')
+        end
+
+        File.delete(epub_file)
+      end
+
+      it 'includes manifestation title before involved authorities in each section' do
+        create(:involved_authority, authority: author1, role: 'author', item: article1.expression.work)
+
+        epub_file = make_epub_from_collection(issue)
+
+        Zip::File.open(epub_file) do |zip_file|
+          first_section = zip_file.read('OEBPS/1_text.xhtml').force_encoding('UTF-8')
+          title_pos = first_section.index('<h1>Article One</h1>')
+          author_pos = first_section.index('Writer Aleph')
+
+          expect(title_pos).to be_present
+          expect(author_pos).to be_present
+          expect(title_pos).to be < author_pos
+        end
+
+        File.delete(epub_file)
+      end
+
+      it 'includes involved authorities in TOC entries' do
+        create(:involved_authority, authority: author1, role: 'author', item: article1.expression.work)
+
+        epub_file = make_epub_from_collection(issue)
+
+        Zip::File.open(epub_file) do |zip_file|
+          nav_content = zip_file.read('OEBPS/nav.xhtml').force_encoding('UTF-8')
+          expect(nav_content).to include('Writer Aleph')
+        end
+
+        File.delete(epub_file)
+      end
+
+      it 'uses editor as EPUB creator when collection has no author' do
+        create(:involved_authority, authority: editor, role: 'editor', item: issue)
+
+        epub_file = make_epub_from_collection(issue)
+
+        Zip::File.open(epub_file) do |zip_file|
+          opf_content = zip_file.read('OEBPS/package.opf').force_encoding('UTF-8')
+          expect(opf_content).to include('Editor Bet')
+          expect(opf_content).to include('dc:creator')
+        end
+
+        File.delete(epub_file)
+      end
+    end
+
     it 'includes publication date and EPUB generation date on title page' do
       collection.update(pub_year: '1965')
 

--- a/spec/lib/bybe_utils_epub_spec.rb
+++ b/spec/lib/bybe_utils_epub_spec.rb
@@ -241,7 +241,6 @@ RSpec.describe 'BybeUtils EPUB generation' do
     end
 
     context 'when collection is a periodical_issue' do
-      let(:periodical) { create(:collection, collection_type: :periodical) }
       let(:issue) { create(:collection, collection_type: :periodical_issue, title: 'Issue 1') }
       let(:article1) do
         create(:manifestation,
@@ -257,14 +256,20 @@ RSpec.describe 'BybeUtils EPUB generation' do
       end
       let(:author1) { create(:authority, name: 'Writer Aleph') }
       let(:editor) { create(:authority, name: 'Editor Bet') }
+      let(:generated_epub_files) { [] }
 
       before do
         create(:collection_item, collection: issue, item: article1, seqno: 1)
         create(:collection_item, collection: issue, item: article2, seqno: 2)
       end
 
+      after do
+        generated_epub_files.each { |f| FileUtils.rm_f(f) }
+      end
+
       it 'includes manifestation titles at the beginning of each section' do
         epub_file = make_epub_from_collection(issue)
+        generated_epub_files << epub_file
 
         Zip::File.open(epub_file) do |zip_file|
           first_section = zip_file.read('OEBPS/1_text.xhtml').force_encoding('UTF-8')
@@ -273,14 +278,13 @@ RSpec.describe 'BybeUtils EPUB generation' do
           second_section = zip_file.read('OEBPS/2_text.xhtml').force_encoding('UTF-8')
           expect(second_section).to include('<h1>Article Two</h1>')
         end
-
-        File.delete(epub_file)
       end
 
       it 'includes manifestation title before involved authorities in each section' do
         create(:involved_authority, authority: author1, role: 'author', item: article1.expression.work)
 
         epub_file = make_epub_from_collection(issue)
+        generated_epub_files << epub_file
 
         Zip::File.open(epub_file) do |zip_file|
           first_section = zip_file.read('OEBPS/1_text.xhtml').force_encoding('UTF-8')
@@ -291,35 +295,49 @@ RSpec.describe 'BybeUtils EPUB generation' do
           expect(author_pos).to be_present
           expect(title_pos).to be < author_pos
         end
-
-        File.delete(epub_file)
       end
 
       it 'includes involved authorities in TOC entries' do
         create(:involved_authority, authority: author1, role: 'author', item: article1.expression.work)
 
         epub_file = make_epub_from_collection(issue)
+        generated_epub_files << epub_file
 
         Zip::File.open(epub_file) do |zip_file|
           nav_content = zip_file.read('OEBPS/nav.xhtml').force_encoding('UTF-8')
           expect(nav_content).to include('Writer Aleph')
         end
-
-        File.delete(epub_file)
       end
 
       it 'uses editor as EPUB creator when collection has no author' do
         create(:involved_authority, authority: editor, role: 'editor', item: issue)
 
         epub_file = make_epub_from_collection(issue)
+        generated_epub_files << epub_file
 
         Zip::File.open(epub_file) do |zip_file|
           opf_content = zip_file.read('OEBPS/package.opf').force_encoding('UTF-8')
           expect(opf_content).to include('Editor Bet')
           expect(opf_content).to include('dc:creator')
         end
+      end
 
-        File.delete(epub_file)
+      it 'keeps editor as contributor (not creator) when authors are also present at collection level' do
+        create(:involved_authority, authority: author1, role: 'author', item: issue)
+        create(:involved_authority, authority: editor, role: 'editor', item: issue)
+
+        epub_file = make_epub_from_collection(issue)
+        generated_epub_files << epub_file
+
+        Zip::File.open(epub_file) do |zip_file|
+          opf_content = zip_file.read('OEBPS/package.opf').force_encoding('UTF-8')
+          # Author should be creator, editor should be contributor (not creator)
+          expect(opf_content).to include('Writer Aleph')
+          author_creator_pattern = %r{<dc:creator[^>]*>Writer Aleph</dc:creator>}
+          editor_creator_pattern = %r{<dc:creator[^>]*>Editor Bet</dc:creator>}
+          expect(opf_content).to match(author_creator_pattern)
+          expect(opf_content).not_to match(editor_creator_pattern)
+        end
       end
     end
 


### PR DESCRIPTION
## Summary

- **Issue 3**: Each EPUB section now starts with `<h1>title</h1>` before the involved authorities, so article titles are visible at the top of each section rather than just showing the authority lines
- **Issue 1**: TOC entries now use `title_and_authors` instead of bare `title`, so author/editor names appear alongside article titles in the navigation
- **Issue 2**: Editors are now treated as book-level EPUB creators (not just contributors), so EPUB readers display the editor's name instead of "UNKNOWN" when the collection has no author at the collection level

## Test plan

- [ ] 4 new regression specs in `spec/lib/bybe_utils_epub_spec.rb` covering all three fixes for periodical_issue collections
- [ ] All 18 EPUB specs pass: `bundle exec rspec spec/lib/bybe_utils_epub_spec.rb`
- [ ] No regressions in existing specs

Closes by-j0f

🤖 Generated with [Claude Code](https://claude.com/claude-code)