### PR TITLE
Fix side scrollbars not reaching bottom at zoom > 100%

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -252,7 +252,8 @@ header {overflow-x: hidden;} /* prevent horizontal scrollbar (caused by Slick's 
 }
 #chapternav{ width: min-content;}
 #chapter-nav{
-  max-height: min(400px, calc(100dvh - 200px));
+  max-height: 400px;
+  max-height: clamp(0px, calc(100dvh - 200px), 400px);
   overflow-y: auto;
 }
 .side-nav-col { pointer-events: none;}
@@ -263,7 +264,8 @@ header {overflow-x: hidden;} /* prevent horizontal scrollbar (caused by Slick's 
   .modal-dialog {height: 100%;}
   .modal-content {height: 100%;}
   #chapter-nav{
-    max-height: min(300px, calc(100dvh - 200px));
+    max-height: 300px;
+    max-height: clamp(0px, calc(100dvh - 200px), 300px);
   }
   #static_page img {
     width: 100%;

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -252,7 +252,7 @@ header {overflow-x: hidden;} /* prevent horizontal scrollbar (caused by Slick's 
 }
 #chapternav{ width: min-content;}
 #chapter-nav{
-  max-height: 400px;
+  max-height: min(400px, calc(100dvh - 200px));
   overflow-y: auto;
 }
 .side-nav-col { pointer-events: none;}
@@ -263,7 +263,7 @@ header {overflow-x: hidden;} /* prevent horizontal scrollbar (caused by Slick's 
   .modal-dialog {height: 100%;}
   .modal-content {height: 100%;}
   #chapter-nav{
-    max-height: 300px;
+    max-height: min(300px, calc(100dvh - 200px));
   }
   #static_page img {
     width: 100%;

--- a/app/assets/stylesheets/html_file.css.scss
+++ b/app/assets/stylesheets/html_file.css.scss
@@ -16,7 +16,7 @@ background-color:#fadafa;
 }
 .markdown { min-height:600px; max-height: 800px;}
 #preview { min-height:600px; max-height: 800px; overflow-y: auto;}
-.textarea100 { min-height:600px; max-height: min(800px, calc(100dvh - 150px)); width:100%; overflow-y: auto;}
+.textarea100 { min-height: 600px; min-height: min(600px, calc(100dvh - 150px)); max-height: 800px; max-height: clamp(0px, calc(100dvh - 150px), 800px); width:100%; overflow-y: auto;}
 //p { text-align:right; direction:rtl; font-family:"Alef", "serif"; font-size:1em; padding: 0px 0; margin: 6px 2px; text-indent: 50px; }
 //p { text-align:right; direction:rtl; font-family:"Times New Roman", "serif"; font-size:12pt; padding: 0px 0; margin: 6px 2px; text-indent: 50px; }
 .htmlfile h1 { text-align:right;direction:rtl; }

--- a/app/assets/stylesheets/html_file.css.scss
+++ b/app/assets/stylesheets/html_file.css.scss
@@ -16,7 +16,7 @@ background-color:#fadafa;
 }
 .markdown { min-height:600px; max-height: 800px;}
 #preview { min-height:600px; max-height: 800px; overflow-y: auto;}
-.textarea100 { min-height: 600px; min-height: min(600px, calc(100dvh - 150px)); max-height: 800px; max-height: clamp(0px, calc(100dvh - 150px), 800px); width:100%; overflow-y: auto;}
+.textarea100 { min-height: 600px; min-height: unquote("min(600px, calc(100dvh - 150px))"); max-height: 800px; max-height: clamp(0px, calc(100dvh - 150px), 800px); width:100%; overflow-y: auto;}
 //p { text-align:right; direction:rtl; font-family:"Alef", "serif"; font-size:1em; padding: 0px 0; margin: 6px 2px; text-indent: 50px; }
 //p { text-align:right; direction:rtl; font-family:"Times New Roman", "serif"; font-size:12pt; padding: 0px 0; margin: 6px 2px; text-indent: 50px; }
 .htmlfile h1 { text-align:right;direction:rtl; }

--- a/app/assets/stylesheets/html_file.css.scss
+++ b/app/assets/stylesheets/html_file.css.scss
@@ -16,7 +16,7 @@ background-color:#fadafa;
 }
 .markdown { min-height:600px; max-height: 800px;}
 #preview { min-height:600px; max-height: 800px; overflow-y: auto;}
-.textarea100 { min-height: 600px; min-height: unquote("min(600px, calc(100dvh - 150px))"); max-height: 800px; max-height: clamp(0px, calc(100dvh - 150px), 800px); width:100%; overflow-y: auto;}
+.textarea100 { min-height:600px; max-height: 800px; max-height: clamp(0px, calc(100dvh - 150px), 800px); width:100%; overflow-y: auto;}
 //p { text-align:right; direction:rtl; font-family:"Alef", "serif"; font-size:1em; padding: 0px 0; margin: 6px 2px; text-indent: 50px; }
 //p { text-align:right; direction:rtl; font-family:"Times New Roman", "serif"; font-size:12pt; padding: 0px 0; margin: 6px 2px; text-indent: 50px; }
 .htmlfile h1 { text-align:right;direction:rtl; }

--- a/app/assets/stylesheets/html_file.css.scss
+++ b/app/assets/stylesheets/html_file.css.scss
@@ -16,7 +16,7 @@ background-color:#fadafa;
 }
 .markdown { min-height:600px; max-height: 800px;}
 #preview { min-height:600px; max-height: 800px; overflow-y: auto;}
-.textarea100 { min-height:600px; max-height: 800px; width:100%; overflow-y: auto;}
+.textarea100 { min-height:600px; max-height: min(800px, calc(100dvh - 150px)); width:100%; overflow-y: auto;}
 //p { text-align:right; direction:rtl; font-family:"Alef", "serif"; font-size:1em; padding: 0px 0; margin: 6px 2px; text-indent: 50px; }
 //p { text-align:right; direction:rtl; font-family:"Times New Roman", "serif"; font-size:12pt; padding: 0px 0; margin: 6px 2px; text-indent: 50px; }
 .htmlfile h1 { text-align:right;direction:rtl; }


### PR DESCRIPTION
## Summary

- Changes `max-height: 400px` on `#chapter-nav` to `max-height: min(400px, calc(100dvh - 200px))` so the chapters sidebar never overflows the viewport regardless of browser zoom level.
- Same fix for the mobile breakpoint override (300px → `min(300px, ...)`).
- Changes `.textarea100` max-height in the text edit view from fixed `800px` to `min(800px, calc(100dvh - 150px))`.

At 100% zoom these behave identically to before. At higher zoom levels (e.g. 125%, 150%) the viewport shrinks in CSS pixels, so `dvh`-relative values kick in and keep the scrollable containers within the visible area.

Fixes: GitHub issue #1117

## Test plan

- [ ] Open a work with many chapters (e.g. /read/54202) at 100% zoom — chapter nav scrollbar works as before
- [ ] Set browser zoom to 125% — chapter nav scrollbar now reaches the bottom
- [ ] Set browser zoom to 150% — chapter nav scrollbar now reaches the bottom
- [ ] Open text edit mode at high zoom — textarea scrollbar behaves correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)