### PR TITLE
Fix period work counts to exclude non-primary works

### DIFF
--- a/app/models/expression.rb
+++ b/app/models/expression.rb
@@ -45,7 +45,10 @@ class Expression < ApplicationRecord
   # @return hash where keys are period names and value is a number of works from the given period
   def self.cached_work_count_by_periods
     Rails.cache.fetch('e_works_by_periods', expires_in: 24.hours) do
-      Expression.joins(:manifestations).merge(Manifestation.all_published).group(:period).count
+      Expression.joins(:manifestations, :work)
+               .merge(Manifestation.all_published)
+               .where(works: { primary: true })
+               .group(:period).count
     end
   end
 

--- a/spec/models/expression_spec.rb
+++ b/spec/models/expression_spec.rb
@@ -27,11 +27,18 @@ describe Expression do
       create(:manifestation, period: :ancient)
       create(:manifestation, period: :medieval)
       create(:manifestation, period: :medieval)
+      non_primary_work = create(:work, primary: false)
+      non_primary_expr = create(:expression, period: :medieval, work: non_primary_work)
+      create(:manifestation, period: :medieval, expression: non_primary_expr)
     end
 
-    it 'does not counts unpublished works' do
+    it 'does not count unpublished works' do
       expect(subject.size).to eq 2
       expect(subject['ancient']).to eq 1
+      expect(subject['medieval']).to eq 2
+    end
+
+    it 'does not count non-primary works' do
       expect(subject['medieval']).to eq 2
     end
   end


### PR DESCRIPTION
## Summary

- `cached_work_count_by_periods` (used by nav menu) was not filtering `works.primary = true`
- The ES-based browse/search page unconditionally applies `{ term: { primary: true } }`
- This caused the nav menu to show ~34 more works in the Modern period than the browse pages

## Fix

Added `.joins(:work).where(works: { primary: true })` to the SQL query in `Expression.cached_work_count_by_periods`, aligning it with what Elasticsearch returns.

## Test plan

- [x] Existing spec updated with a regression test for non-primary work exclusion
- [x] All 5 specs in `expression_spec.rb` pass

Closes: by-h0p