### PR TITLE
Fix pre-existing spec failures in files and migrate_attachment specs

### DIFF
--- a/app/models/concerns/download_link.rb
+++ b/app/models/concerns/download_link.rb
@@ -16,6 +16,8 @@ module DownloadLink
     path = Rails.application.routes.url_helpers.file_download_path(
       record_type: file_record_type, record_id: id, filename: filename
     )
+    # Unescape URI so Hebrew/non-ASCII filenames are stored and displayed human-readably
+    URI::DEFAULT_PARSER.unescape(path)
   end
 
   def blob_by_filename(filename)

--- a/spec/requests/files_spec.rb
+++ b/spec/requests/files_spec.rb
@@ -22,21 +22,13 @@ describe '/files' do
 
     context 'when entry is a LexEntry' do
       let(:record_type) { 'lex' }
-      let(:record) { create(:lex_entry) }
-      let(:record_id) { record.id }
-
-      before do
-        record.attachments.attach(
-          io: StringIO.new('First'),
-          filename: 'file_1.txt',
-          content_type: 'text/plain'
-        )
-        record.attachments.attach(
-          io: StringIO.new('Second'),
-          filename: 'file_2',
-          content_type: 'text/plain'
-        )
+      let(:record) do
+        create(:lex_entry).tap do |entry|
+          entry.attachments.attach(io: StringIO.new('First'), filename: 'file_1.txt', content_type: 'text/plain')
+          entry.attachments.attach(io: StringIO.new('Second'), filename: 'file_2', content_type: 'text/plain')
+        end
       end
+      let(:record_id) { record.id }
 
       context 'when wrong entry_id is given' do
         let(:record_id) { record.id + 1 }


### PR DESCRIPTION
## Summary

Two pre-existing spec failures on the `lexicon` branch, unrelated to any active feature work.

### 1. `spec/requests/files_spec.rb` — LexEntry attachment timing

**Root cause**: PR #1139 changed `subject(:call)` to `subject!(:call)`. `subject!` registers a `before` hook at the outer `describe` level, which runs *before* the inner `before` block that attaches files to the LexEntry. By the time the GET request fires, the files don't exist yet → 404.

**Fix**: Move the `before do ... attach ...` block into `let(:record)` (using `.tap`), matching the pattern already used by the Manifestation tests. Files are attached during lazy evaluation of `record`, which is triggered as part of building the request URL.

### 2. `spec/services/lexicon/migrate_attachment_spec.rb` — URL-encoded Hebrew filename

**Root cause**: PR #1039 removed `URI::DEFAULT_PARSER.unescape(path)` from `DownloadLink#download_path`. Hebrew filenames are now stored as `%D7%A1%D7%A4%D7%A8%D7%99...` in `LexLegacyLink#new_path` instead of `ספרי דורות קודמים.pdf`.

**Fix**: Restore the unescape call so `new_path` stores human-readable paths (the `FilesController` URL-decodes params on inbound requests regardless, so both forms work functionally, but human-readable is the intended behavior per the original comment).

## Test plan

- [ ] `bundle exec rspec spec/requests/files_spec.rb spec/services/lexicon/migrate_attachment_spec.rb` → 22 examples, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)