### PR TITLE
Add external identifiers section to verification workbench

### DIFF
--- a/app/controllers/lexicon/verification_controller.rb
+++ b/app/controllers/lexicon/verification_controller.rb
@@ -3,7 +3,7 @@
 module Lexicon
   # Controller for migration verification workbench
   class VerificationController < ApplicationController
-    EXTERNAL_IDENTIFIER_KEYS = %w(lc viaf nli wikidata openlibrary j9u).freeze
+    EXTERNAL_IDENTIFIER_KEYS = LexiconHelper::EXTERNAL_IDENTIFIER_LABELS.keys.freeze
 
     before_action :set_entry, except: %i(index)
     before_action do |c|

--- a/app/controllers/lexicon/verification_controller.rb
+++ b/app/controllers/lexicon/verification_controller.rb
@@ -3,6 +3,8 @@
 module Lexicon
   # Controller for migration verification workbench
   class VerificationController < ApplicationController
+    EXTERNAL_IDENTIFIER_KEYS = %w(lc viaf nli wikidata openlibrary j9u).freeze
+
     before_action :set_entry, except: %i(index)
     before_action do |c|
       c.require_editor('edit_lexicon')
@@ -253,6 +255,17 @@ module Lexicon
       # submitting an empty string will clear the field instead of being ignored.
       entry_updates[:english_title] = params[:english_title] if params.key?(:english_title)
 
+      # Update external_identifiers if submitted: blank values are removed, nil if all blank
+      if params.key?(:external_identifiers)
+        # rubocop:disable Rails/StrongParametersExpect
+        raw = params.require(:external_identifiers)
+                    .permit(*Lexicon::VerificationController::EXTERNAL_IDENTIFIER_KEYS)
+                    .to_h
+        # rubocop:enable Rails/StrongParametersExpect
+        filtered = raw.compact_blank
+        entry_updates[:external_identifiers] = filtered.presence
+      end
+
       if entry_updates.present? && !@entry.update(entry_updates)
         success = false
         errors += @entry.errors.full_messages
@@ -348,15 +361,20 @@ module Lexicon
     end
 
     def item_params
-      # Permit params based on item type
-      # Using require().permit() for consistency with rest of codebase
+      # Permit params based on item type, but only if the relevant nested params were submitted.
+      # Some edit forms (e.g. external_identifiers) update only LexEntry fields and don't
+      # include lex_person / lex_publication nested params.
       # rubocop:disable Rails/StrongParametersExpect
       case @entry.lex_item_type
       when 'LexPerson'
+        return nil unless params.key?(:lex_person)
+
         params.require(:lex_person).permit(
           :birthdate, :deathdate, :bio, :works, :gender, :aliases, :copyrighted, :authority_id
         )
       when 'LexPublication'
+        return nil unless params.key?(:lex_publication)
+
         params.require(:lex_publication).permit(
           :description, :toc, :az_navbar
         )

--- a/app/helpers/lexicon_helper.rb
+++ b/app/helpers/lexicon_helper.rb
@@ -61,7 +61,8 @@ module LexiconHelper
     'viaf' => 'VIAF',
     'nli' => 'NLI',
     'wikidata' => 'Wikidata',
-    'openlibrary' => 'OpenLibrary'
+    'openlibrary' => 'OpenLibrary',
+    'j9u' => 'J9U'
   }.freeze
 
   def render_external_identifiers(external_identifiers)

--- a/app/models/lex_entry.rb
+++ b/app/models/lex_entry.rb
@@ -113,7 +113,7 @@ class LexEntry < ApplicationRecord
     verified = 0
 
     # Count top-level items (excluding collections)
-    %w(title life_years bio description toc az_navbar attachments).each do |key|
+    %w(title life_years bio description toc az_navbar external_identifiers attachments).each do |key|
       next unless checklist[key]
 
       total += 1
@@ -321,6 +321,9 @@ class LexEntry < ApplicationRecord
       checklist['toc'] = { 'verified' => false, 'notes' => '' }
       checklist['az_navbar'] = { 'verified' => false, 'notes' => '' }
     end
+
+    # External Identifiers (common to both)
+    checklist['external_identifiers'] = { 'verified' => false, 'notes' => '' }
 
     # Links (common to both)
     link_items = if lex_item&.links&.any?

--- a/app/views/lexicon/entries/_external_identifiers_form.html.haml
+++ b/app/views/lexicon/entries/_external_identifiers_form.html.haml
@@ -1,0 +1,13 @@
+-# Shared partial for editing external identifier fields on a LexEntry. Expects: `entry` (LexEntry).
+:ruby
+  current_identifiers = entry.external_identifiers || {}
+  identifier_keys = %w(lc viaf nli wikidata openlibrary j9u)
+  placeholder = t('lexicon.verification.edit.external_identifiers.leave_blank_to_remove')
+
+- identifier_keys.each do |key|
+  .form-group.mb-3
+    - label = t("lexicon.verification.edit.external_identifiers.#{key}")
+    = label_tag "external_identifiers_#{key}", label, class: 'form-label'
+    -# haml-lint:disable LineLength
+    = text_field_tag "external_identifiers[#{key}]", current_identifiers[key], class: 'form-control', placeholder: placeholder
+    -# haml-lint:enable LineLength

--- a/app/views/lexicon/entries/_external_identifiers_form.html.haml
+++ b/app/views/lexicon/entries/_external_identifiers_form.html.haml
@@ -1,7 +1,7 @@
 -# Shared partial for editing external identifier fields on a LexEntry. Expects: `entry` (LexEntry).
 :ruby
   current_identifiers = entry.external_identifiers || {}
-  identifier_keys = %w(lc viaf nli wikidata openlibrary j9u)
+  identifier_keys = LexiconHelper::EXTERNAL_IDENTIFIER_LABELS.keys
   placeholder = t('lexicon.verification.edit.external_identifiers.leave_blank_to_remove')
 
 - identifier_keys.each do |key|

--- a/app/views/lexicon/verification/_checklist.html.haml
+++ b/app/views/lexicon/verification/_checklist.html.haml
@@ -76,6 +76,12 @@
           %input{type: 'checkbox', checked: checklist['az_navbar']&.dig('verified'), disabled: true, data: {path: 'az_navbar', 'section-id': 'section-az-navbar'}}
           = t('lexicon.verification.checklist.publication.az_navbar')
 
+    -# External Identifiers (common to both)
+    %li.checklist-item
+      %label
+        %input{type: 'checkbox', checked: checklist['external_identifiers']&.dig('verified'), disabled: true, data: {path: 'external_identifiers', 'section-id': 'section-external-identifiers'}}
+        = t('lexicon.verification.checklist.person.external_identifiers')
+
     -# Links (common to both)
     %li.checklist-item
       %label

--- a/app/views/lexicon/verification/_checklist.html.haml
+++ b/app/views/lexicon/verification/_checklist.html.haml
@@ -79,7 +79,9 @@
     -# External Identifiers (common to both)
     %li.checklist-item
       %label
-        %input{type: 'checkbox', checked: checklist['external_identifiers']&.dig('verified'), disabled: true, data: {path: 'external_identifiers', 'section-id': 'section-external-identifiers'}}
+        -# haml-lint:disable LineLength
+        %input{ type: 'checkbox', checked: checklist['external_identifiers']&.dig('verified'), disabled: true, data: { path: 'external_identifiers', 'section-id': 'section-external-identifiers' } }
+        -# haml-lint:enable LineLength
         = t('lexicon.verification.checklist.person.external_identifiers')
 
     -# Links (common to both)

--- a/app/views/lexicon/verification/_edit_external_identifiers.html.haml
+++ b/app/views/lexicon/verification/_edit_external_identifiers.html.haml
@@ -7,7 +7,8 @@
   = render 'lexicon/entries/external_identifiers_form', entry: @entry
 
   .form-check.mt-3
-    = check_box_tag :mark_verified, '1', false, class: 'form-check-input'
+    - already_verified = @entry.verification_progress&.dig('checklist', 'external_identifiers', 'verified') || false
+    = check_box_tag :mark_verified, '1', already_verified, class: 'form-check-input'
     = label_tag :mark_verified, t('lexicon.verification.edit.mark_as_verified'), class: 'form-check-label'
 
   .modal-footer

--- a/app/views/lexicon/verification/_edit_external_identifiers.html.haml
+++ b/app/views/lexicon/verification/_edit_external_identifiers.html.haml
@@ -1,0 +1,16 @@
+-# haml-lint:disable LineLength
+= form_with url: lexicon_update_section_verification_path(@entry), method: :patch, local: false, html: { class: 'verification-edit-form' } do |f|
+  = hidden_field_tag :section, 'external_identifiers'
+
+  %p.text-muted= t('lexicon.verification.edit.external_identifiers.instructions')
+
+  = render 'lexicon/entries/external_identifiers_form', entry: @entry
+
+  .form-check.mt-3
+    = check_box_tag :mark_verified, '1', false, class: 'form-check-input'
+    = label_tag :mark_verified, t('lexicon.verification.edit.mark_as_verified'), class: 'form-check-label'
+
+  .modal-footer
+    %button.btn.btn-secondary{ type: 'button', data: { dismiss: 'modal' } }
+      = t('cancel')
+    = f.submit t('save'), class: 'btn btn-primary'

--- a/app/views/lexicon/verification/_person_sections.html.haml
+++ b/app/views/lexicon/verification/_person_sections.html.haml
@@ -1,3 +1,4 @@
+-# haml-lint:disable LineLength
 :css
   .count-mismatch-warning {
     background-color: #e87722;
@@ -219,21 +220,23 @@
     = link_to t('lexicon.verification.migrated.add_citation'), new_lexicon_person_citation_path(item), class: 'btn btn-sm btn-success', onclick: "event.preventDefault(); openModal(this.href);"
 
 -# Section 5: External Identifiers
-.section.verification-section{id: 'section-external-identifiers', class: checklist['external_identifiers']&.dig('verified') ? 'verified' : 'not-verified'}
+.section.verification-section{ id: 'section-external-identifiers', class: checklist['external_identifiers']&.dig('verified') ? 'verified' : 'not-verified' }
   .section-header
     %h5= t('lexicon.verification.sections.external_identifiers_section')
-    .verification-badge{class: checklist['external_identifiers']&.dig('verified') ? 'verified' : 'not-verified'}
+    .verification-badge{ class: checklist['external_identifiers']&.dig('verified') ? 'verified' : 'not-verified' }
       = checklist['external_identifiers']&.dig('verified') ? '✓ ' + t('lexicon.verification.migrated.verified') : t('lexicon.verification.migrated.not_verified')
   .section-content
     - if entry.external_identifiers.present?
       %dl.row
-        - entry.external_identifiers.each do |key, value|
-          %dt.col-sm-3= key.upcase
+        - LexiconHelper::EXTERNAL_IDENTIFIER_LABELS.each do |key, label|
+          - value = entry.external_identifiers[key]
+          - next if value.blank?
+          %dt.col-sm-3= label
           %dd.col-sm-9= value
     - else
       %p.text-muted= t('lexicon.verification.sections.no_external_identifiers')
   .section-actions
-    %button.btn.btn-sm.btn-outline-primary{onclick: "openModal('#{lexicon_edit_section_verification_path(entry, section: 'external_identifiers')}', onSectionEditSuccess('section-external-identifiers'))"}
+    %button.btn.btn-sm.btn-outline-primary{ onclick: "openModal('#{lexicon_edit_section_verification_path(entry, section: 'external_identifiers')}', onSectionEditSuccess('section-external-identifiers'))" }
       ✏️
       = t('lexicon.verification.migrated.edit')
     %button.btn.btn-sm{ class: checklist['external_identifiers']&.dig('verified') ? 'btn-success' : 'btn-outline-success', data: { action: 'click->verification#quickVerify', path: 'external_identifiers' } }

--- a/app/views/lexicon/verification/_person_sections.html.haml
+++ b/app/views/lexicon/verification/_person_sections.html.haml
@@ -218,7 +218,29 @@
   .section-actions
     = link_to t('lexicon.verification.migrated.add_citation'), new_lexicon_person_citation_path(item), class: 'btn btn-sm btn-success', onclick: "event.preventDefault(); openModal(this.href);"
 
--# Section 5: Links
+-# Section 5: External Identifiers
+.section.verification-section{id: 'section-external-identifiers', class: checklist['external_identifiers']&.dig('verified') ? 'verified' : 'not-verified'}
+  .section-header
+    %h5= t('lexicon.verification.sections.external_identifiers_section')
+    .verification-badge{class: checklist['external_identifiers']&.dig('verified') ? 'verified' : 'not-verified'}
+      = checklist['external_identifiers']&.dig('verified') ? '✓ ' + t('lexicon.verification.migrated.verified') : t('lexicon.verification.migrated.not_verified')
+  .section-content
+    - if entry.external_identifiers.present?
+      %dl.row
+        - entry.external_identifiers.each do |key, value|
+          %dt.col-sm-3= key.upcase
+          %dd.col-sm-9= value
+    - else
+      %p.text-muted= t('lexicon.verification.sections.no_external_identifiers')
+  .section-actions
+    %button.btn.btn-sm.btn-outline-primary{onclick: "openModal('#{lexicon_edit_section_verification_path(entry, section: 'external_identifiers')}', onSectionEditSuccess('section-external-identifiers'))"}
+      ✏️
+      = t('lexicon.verification.migrated.edit')
+    %button.btn.btn-sm{ class: checklist['external_identifiers']&.dig('verified') ? 'btn-success' : 'btn-outline-success', data: { action: 'click->verification#quickVerify', path: 'external_identifiers' } }
+      ✓
+      = t('lexicon.verification.migrated.mark_verified')
+
+-# Section 6: Links
 .section.verification-section{id: 'section-links', class: checklist['links']&.dig('verified') ? 'verified' : 'not-verified'}
   .section-header
     %h5= t('lexicon.verification.sections.links_section')
@@ -255,7 +277,7 @@
   .section-actions
     = link_to t('lexicon.verification.migrated.add_link'), new_lexicon_entry_link_path(entry), class: 'btn btn-sm btn-success', onclick: "event.preventDefault(); openModal(this.href, function() { location.reload(); });"
 
--# Section 6: Attachments
+-# Section 7: Attachments
 .section.verification-section{id: 'section-attachments', class: checklist['attachments']&.dig('verified') ? 'verified' : 'not-verified'}
   .section-header
     %h5= t('lexicon.verification.sections.attachments_section')

--- a/app/views/lexicon/verification/_publication_sections.html.haml
+++ b/app/views/lexicon/verification/_publication_sections.html.haml
@@ -76,22 +76,24 @@
       ✓
       = t('lexicon.verification.migrated.mark_verified')
 
--# Section 5: External Identifiers
-.section.verification-section{id: 'section-external-identifiers', class: checklist['external_identifiers']&.dig('verified') ? 'verified' : 'not-verified'}
+-# haml-lint:disable LineLength
+.section.verification-section{ id: 'section-external-identifiers', class: checklist['external_identifiers']&.dig('verified') ? 'verified' : 'not-verified' }
   .section-header
     %h5= t('lexicon.verification.sections.external_identifiers_section')
-    .verification-badge{class: checklist['external_identifiers']&.dig('verified') ? 'verified' : 'not-verified'}
+    .verification-badge{ class: checklist['external_identifiers']&.dig('verified') ? 'verified' : 'not-verified' }
       = checklist['external_identifiers']&.dig('verified') ? '✓ ' + t('lexicon.verification.migrated.verified') : t('lexicon.verification.migrated.not_verified')
   .section-content
     - if entry.external_identifiers.present?
       %dl.row
-        - entry.external_identifiers.each do |key, value|
-          %dt.col-sm-3= key.upcase
+        - LexiconHelper::EXTERNAL_IDENTIFIER_LABELS.each do |key, label|
+          - value = entry.external_identifiers[key]
+          - next if value.blank?
+          %dt.col-sm-3= label
           %dd.col-sm-9= value
     - else
       %p.text-muted= t('lexicon.verification.sections.no_external_identifiers')
   .section-actions
-    %button.btn.btn-sm.btn-outline-primary{onclick: "openModal('#{lexicon_edit_section_verification_path(entry, section: 'external_identifiers')}', onSectionEditSuccess('section-external-identifiers'))"}
+    %button.btn.btn-sm.btn-outline-primary{ onclick: "openModal('#{lexicon_edit_section_verification_path(entry, section: 'external_identifiers')}', onSectionEditSuccess('section-external-identifiers'))" }
       ✏️
       = t('lexicon.verification.migrated.edit')
     %button.btn.btn-sm{ class: checklist['external_identifiers']&.dig('verified') ? 'btn-success' : 'btn-outline-success', data: { action: 'click->verification#quickVerify', path: 'external_identifiers' } }

--- a/app/views/lexicon/verification/_publication_sections.html.haml
+++ b/app/views/lexicon/verification/_publication_sections.html.haml
@@ -76,7 +76,29 @@
       ✓
       = t('lexicon.verification.migrated.mark_verified')
 
--# Section 5: Links
+-# Section 5: External Identifiers
+.section.verification-section{id: 'section-external-identifiers', class: checklist['external_identifiers']&.dig('verified') ? 'verified' : 'not-verified'}
+  .section-header
+    %h5= t('lexicon.verification.sections.external_identifiers_section')
+    .verification-badge{class: checklist['external_identifiers']&.dig('verified') ? 'verified' : 'not-verified'}
+      = checklist['external_identifiers']&.dig('verified') ? '✓ ' + t('lexicon.verification.migrated.verified') : t('lexicon.verification.migrated.not_verified')
+  .section-content
+    - if entry.external_identifiers.present?
+      %dl.row
+        - entry.external_identifiers.each do |key, value|
+          %dt.col-sm-3= key.upcase
+          %dd.col-sm-9= value
+    - else
+      %p.text-muted= t('lexicon.verification.sections.no_external_identifiers')
+  .section-actions
+    %button.btn.btn-sm.btn-outline-primary{onclick: "openModal('#{lexicon_edit_section_verification_path(entry, section: 'external_identifiers')}', onSectionEditSuccess('section-external-identifiers'))"}
+      ✏️
+      = t('lexicon.verification.migrated.edit')
+    %button.btn.btn-sm{ class: checklist['external_identifiers']&.dig('verified') ? 'btn-success' : 'btn-outline-success', data: { action: 'click->verification#quickVerify', path: 'external_identifiers' } }
+      ✓
+      = t('lexicon.verification.migrated.mark_verified')
+
+-# Section 6: Links
 .section.verification-section{id: 'section-links', class: checklist['links']&.dig('verified') ? 'verified' : 'not-verified'}
   .section-header
     %h5= t('lexicon.verification.sections.links_section')
@@ -112,7 +134,7 @@
   .section-actions
     = link_to t('lexicon.verification.migrated.add_link'), new_lexicon_entry_link_path(entry), class: 'btn btn-sm btn-success', onclick: "event.preventDefault(); openModal(this.href, function() { location.reload(); });"
 
--# Section 6: Attachments
+-# Section 7: Attachments
 .section.verification-section{id: 'section-attachments', class: checklist['attachments']&.dig('verified') ? 'verified' : 'not-verified'}
   .section-header
     %h5= t('lexicon.verification.sections.attachments_section')

--- a/config/locales/lexicon.en.yml
+++ b/config/locales/lexicon.en.yml
@@ -183,6 +183,7 @@ en:
           citations: Citations
           links: Links
           attachments: Attachments
+          external_identifiers: Authority Control Identifiers
         publication:
           title: Title
           description: Description
@@ -190,6 +191,7 @@ en:
           az_navbar: A-Z Navigation
           links: Links
           attachments: Attachments
+          external_identifiers: Authority Control Identifiers
       source:
         header: Source File
         file_not_found: "⚠️ Source file not found"
@@ -225,6 +227,8 @@ en:
         no_description: "(No description)"
         no_toc: "(No table of contents)"
         no_az_navbar: "(No A-Z navigation)"
+        external_identifiers_section: Authority Control Identifiers
+        no_external_identifiers: "(No authority control identifiers)"
         citation_from_publication: "From:"
         citation_pages: "Pages:"
         count_mismatch: "Count mismatch: %{php_count} item(s) in the source file, but %{migrated_count} migrated. The mismatch may be justified and does not block verification."
@@ -258,3 +262,12 @@ en:
         confirm_match: Confirm match
         reject_match: Reject match
         proposed_collection: "(proposed: %{title})"
+        external_identifiers:
+          instructions: "Enter identifier values for authority control systems. Leave a field blank to remove that identifier."
+          leave_blank_to_remove: "Leave blank to remove"
+          lc: "Library of Congress (LC)"
+          viaf: VIAF
+          nli: NLI
+          wikidata: Wikidata
+          openlibrary: OpenLibrary
+          j9u: J9U

--- a/config/locales/lexicon.he.yml
+++ b/config/locales/lexicon.he.yml
@@ -184,6 +184,7 @@ he:
           citations: מראי מקום
           links: קישוריוֹת
           attachments: קבצים מצורפים
+          external_identifiers: מזהים חיצוניים
         publication:
           title: כותרת
           description: תיאור
@@ -191,6 +192,7 @@ he:
           az_navbar: ניווט א-ב
           links: קישוריוֹת
           attachments: קבצים מצורפים
+          external_identifiers: מזהים חיצוניים
       source:
         header: קובץ מקור
         file_not_found: "⚠️ קובץ מקור לא נמצא"
@@ -226,6 +228,8 @@ he:
         no_description: "(אין תיאור)"
         no_toc: "(אין תוכן עניינים)"
         no_az_navbar: "(אין ניווט א-ב)"
+        external_identifiers_section: מזהים חיצוניים
+        no_external_identifiers: "(אין מזהים חיצוניים)"
         citation_from_publication: "ממקור:"
         citation_pages: "עמ׳:"
         count_mismatch: "אי-התאמה בספירה: %{php_count} פריט/ים בקובץ המקור, אך %{migrated_count} פריטים מועברים. ייתכן שאי-ההתאמה מוצדקת ואינה מונעת את אישור הערך."
@@ -259,3 +263,12 @@ he:
         confirm_match: אשר התאמה
         reject_match: דחה התאמה
         proposed_collection: "(הצעה: %{title})"
+        external_identifiers:
+          instructions: "הכנס ערכי מזהה עבור מערכות בקרת סמכות. השאר שדה ריק כדי להסיר את המזהה."
+          leave_blank_to_remove: "השאר ריק כדי להסיר"
+          lc: "ספריית הקונגרס (LC)"
+          viaf: VIAF
+          nli: NLI
+          wikidata: Wikidata
+          openlibrary: OpenLibrary
+          j9u: J9U

--- a/spec/models/lex_entry_spec.rb
+++ b/spec/models/lex_entry_spec.rb
@@ -263,6 +263,54 @@ RSpec.describe LexEntry, type: :model do
     end
   end
 
+  describe 'external_identifiers verification' do
+    let(:person) { create(:lex_person) }
+    let(:entry) { create(:lex_entry, lex_item: person) }
+
+    describe '#build_checklist' do
+      it 'includes external_identifiers in the checklist for LexPerson entries' do
+        entry.start_verification!('test@example.com')
+        checklist = entry.verification_progress['checklist']
+
+        expect(checklist['external_identifiers']).to eq({ 'verified' => false, 'notes' => '' })
+      end
+
+      context 'when entry is a LexPublication' do
+        let(:publication) { create(:lex_publication) }
+        let(:pub_entry) { create(:lex_entry, lex_item: publication) }
+
+        it 'includes external_identifiers in the checklist for LexPublication entries' do
+          pub_entry.start_verification!('test@example.com')
+          checklist = pub_entry.verification_progress['checklist']
+
+          expect(checklist['external_identifiers']).to eq({ 'verified' => false, 'notes' => '' })
+        end
+      end
+    end
+
+    describe '#verification_percentage' do
+      it 'counts external_identifiers in the percentage calculation' do
+        entry.start_verification!('test@example.com')
+        percentage_before = entry.verification_percentage
+
+        entry.update_checklist_item('external_identifiers', true, '')
+        percentage_after = entry.verification_percentage
+
+        expect(percentage_after).to be > percentage_before
+      end
+    end
+
+    describe '#update_checklist_item for external_identifiers' do
+      before { entry.start_verification!('test@example.com') }
+
+      it 'marks external_identifiers as verified' do
+        entry.update_checklist_item('external_identifiers', true, 'Looks good')
+        expect(entry.verification_progress.dig('checklist', 'external_identifiers', 'verified')).to be true
+        expect(entry.verification_progress.dig('checklist', 'external_identifiers', 'notes')).to eq('Looks good')
+      end
+    end
+  end
+
   describe '#other_designation' do
     it 'can be read and written' do
       entry = create(:lex_entry, other_designation: 'alias1; alias2')

--- a/spec/requests/lexicon/verification_spec.rb
+++ b/spec/requests/lexicon/verification_spec.rb
@@ -256,6 +256,65 @@ RSpec.describe 'Lexicon::Verification', type: :request do
     end
   end
 
+  describe 'PATCH /lex/verification/:id/update_section – external_identifiers' do
+    let(:entry) do
+      e = create(:lex_entry, :person,
+                 status: :verifying,
+                 external_identifiers: { 'viaf' => '123', 'lc' => 'n456' })
+      e.start_verification!('editor@example.com')
+      e
+    end
+    let(:url) { "/lex/verification/#{entry.id}/update_section" }
+
+    it 'saves updated external_identifiers' do
+      patch url,
+            params: { section: 'external_identifiers',
+                      external_identifiers: { viaf: '999', lc: 'n456' } },
+            as: :json
+
+      expect(response).to have_http_status(:success)
+      entry.reload
+      expect(entry.external_identifiers['viaf']).to eq('999')
+      expect(entry.external_identifiers['lc']).to eq('n456')
+    end
+
+    it 'removes an identifier when its value is blank' do
+      patch url,
+            params: { section: 'external_identifiers',
+                      external_identifiers: { viaf: '', lc: 'n456' } },
+            as: :json
+
+      expect(response).to have_http_status(:success)
+      entry.reload
+      expect(entry.external_identifiers).not_to have_key('viaf')
+      expect(entry.external_identifiers['lc']).to eq('n456')
+    end
+
+    it 'marks the section verified when mark_verified is set' do
+      patch url,
+            params: { section: 'external_identifiers',
+                      external_identifiers: { viaf: '123', lc: 'n456' },
+                      mark_verified: '1' },
+            as: :json
+
+      expect(response).to have_http_status(:success)
+      expect(response.parsed_body['success']).to be true
+      entry.reload
+      expect(entry.verification_progress.dig('checklist', 'external_identifiers', 'verified')).to be true
+    end
+
+    it 'sets external_identifiers to nil when all values are blank' do
+      patch url,
+            params: { section: 'external_identifiers',
+                      external_identifiers: { viaf: '', lc: '' } },
+            as: :json
+
+      expect(response).to have_http_status(:success)
+      entry.reload
+      expect(entry.external_identifiers).to be_nil
+    end
+  end
+
   describe 'PATCH /lex/verification/:id/update_checklist' do
     context 'when verifying the title section for a LexPerson' do
       let(:entry) do
@@ -291,6 +350,7 @@ RSpec.describe 'Lexicon::Verification', type: :request do
         # Simulate user clicking quickVerify on every section (title path covers life_years)
         patch url, params: { path: 'title', verified: 'true' }, as: :json
         patch url, params: { path: 'bio', verified: 'true' }, as: :json
+        patch url, params: { path: 'external_identifiers', verified: 'true' }, as: :json
         patch url, params: { path: 'attachments', verified: 'true' }, as: :json
 
         # Verify all collection items (citations, links, works are empty for this entry)

--- a/spec/system/lexicon/verification_external_identifiers_spec.rb
+++ b/spec/system/lexicon/verification_external_identifiers_spec.rb
@@ -96,6 +96,12 @@ describe 'Lexicon Verification Workbench – External Identifiers', :js do
       end
     end
 
+    it 'mark_verified checkbox is unchecked when section is not yet verified' do
+      within('#generalDlgBody') do
+        expect(page).to have_unchecked_field('mark_verified')
+      end
+    end
+
     it 'updates identifiers when the form is saved' do
       within('#generalDlgBody') do
         fill_in 'external_identifiers[viaf]', with: '99999999'
@@ -128,6 +134,25 @@ describe 'Lexicon Verification Workbench – External Identifiers', :js do
       expect(page).to have_css('#section-external-identifiers.verified', wait: 10)
       entry.reload
       expect(entry.verification_progress.dig('checklist', 'external_identifiers', 'verified')).to be true
+    end
+  end
+
+  describe 'edit modal when section is already verified' do
+    before do
+      entry.start_verification!('test@example.com')
+      entry.update_checklist_item('external_identifiers', true, '')
+
+      visit "/lex/verification/#{entry.id}"
+      within('#section-external-identifiers .section-actions') do
+        click_button I18n.t('lexicon.verification.migrated.edit')
+      end
+      find('#generalDlg', visible: true, wait: 5)
+    end
+
+    it 'pre-checks the mark_verified checkbox' do
+      within('#generalDlgBody') do
+        expect(page).to have_checked_field('mark_verified')
+      end
     end
   end
 end

--- a/spec/system/lexicon/verification_external_identifiers_spec.rb
+++ b/spec/system/lexicon/verification_external_identifiers_spec.rb
@@ -1,0 +1,133 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe 'Lexicon Verification Workbench – External Identifiers', :js do
+  before do
+    skip 'WebDriver not available or misconfigured' unless webdriver_available?
+    login_as_lexicon_editor
+    visit "/lex/verification/#{entry.id}"
+  end
+
+  let!(:person) { create(:lex_person, birthdate: '1880', deathdate: '1945') }
+  let!(:entry) do
+    create(:lex_entry,
+           title: 'Test Author',
+           lex_item: person,
+           status: :draft,
+           external_identifiers: { 'viaf' => '12345678', 'lc' => 'n87654321' })
+  end
+
+  describe 'display section' do
+    it 'shows the external identifiers section in the migrated entry panel' do
+      within('.verification-migrated') do
+        expect(page).to have_css('#section-external-identifiers')
+        expect(page).to have_content(I18n.t('lexicon.verification.sections.external_identifiers_section'))
+      end
+    end
+
+    it 'displays the migrated identifier keys and values' do
+      within('#section-external-identifiers') do
+        expect(page).to have_content('VIAF')
+        expect(page).to have_content('12345678')
+        expect(page).to have_content('LC')
+        expect(page).to have_content('n87654321')
+      end
+    end
+
+    it 'shows an edit button for the section' do
+      within('#section-external-identifiers .section-actions') do
+        expect(page).to have_button(I18n.t('lexicon.verification.migrated.edit'))
+      end
+    end
+
+    it 'shows a mark-as-verified button for the section' do
+      within('#section-external-identifiers .section-actions') do
+        expect(page).to have_button(I18n.t('lexicon.verification.migrated.mark_verified'))
+      end
+    end
+
+    context 'when entry has no external identifiers' do
+      let!(:entry) do
+        create(:lex_entry,
+               title: 'Author Without IDs',
+               lex_item: person,
+               status: :draft,
+               external_identifiers: nil)
+      end
+
+      it 'shows the no-identifiers placeholder' do
+        within('#section-external-identifiers') do
+          expect(page).to have_content(I18n.t('lexicon.verification.sections.no_external_identifiers'))
+        end
+      end
+    end
+  end
+
+  describe 'checklist' do
+    it 'shows external_identifiers in the verification checklist' do
+      within('.verification-checklist') do
+        expect(page).to have_content(I18n.t('lexicon.verification.checklist.person.external_identifiers'))
+      end
+    end
+
+    it 'can mark external_identifiers as verified via the quick verify button' do
+      within('#section-external-identifiers .section-actions') do
+        find('button[data-action="click->verification#quickVerify"]').click
+      end
+
+      entry.reload
+      expect(entry.verification_progress.dig('checklist', 'external_identifiers', 'verified')).to be true
+    end
+  end
+
+  describe 'edit modal' do
+    before do
+      within('#section-external-identifiers .section-actions') do
+        click_button I18n.t('lexicon.verification.migrated.edit')
+      end
+      find('#generalDlg', visible: true, wait: 5)
+    end
+
+    it 'opens an edit modal with identifier fields' do
+      within('#generalDlgBody') do
+        expect(page).to have_field('external_identifiers[viaf]', with: '12345678')
+        expect(page).to have_field('external_identifiers[lc]', with: 'n87654321')
+      end
+    end
+
+    it 'updates identifiers when the form is saved' do
+      within('#generalDlgBody') do
+        fill_in 'external_identifiers[viaf]', with: '99999999'
+        find('[type="submit"]').click
+      end
+
+      expect(page).to have_css('#section-external-identifiers', wait: 5)
+      entry.reload
+      expect(entry.external_identifiers['viaf']).to eq('99999999')
+    end
+
+    it 'removes an identifier when its field is cleared' do
+      within('#generalDlgBody') do
+        fill_in 'external_identifiers[lc]', with: ''
+        find('[type="submit"]').click
+      end
+
+      expect(page).to have_css('#section-external-identifiers', wait: 5)
+      entry.reload
+      expect(entry.external_identifiers).not_to have_key('lc')
+    end
+
+    it 'marks the section as verified when the checkbox is checked' do
+      within('#generalDlgBody') do
+        check 'mark_verified'
+        find('[type="submit"]').click
+      end
+
+      # Wait for the section to reflect the verified state before querying the DB
+      expect(page).to have_css('#section-external-identifiers.verified', wait: 10)
+      entry.reload
+      expect(entry.verification_progress.dig('checklist', 'external_identifiers', 'verified')).to be true
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Adds an **External Identifiers** section to the Lexicon verification workbench for both LexPerson and LexPublication entries, displaying authority control identifiers (VIAF, LC, NLI, Wikidata, OpenLibrary, J9U)
- Section integrates with the existing verification checklist and quick-verify pattern
- Edit modal allows adding, updating, and removing individual identifiers (blank field = removal)
- Checkbox in edit modal pre-checks itself when the section is already verified
- Shared form partial `lexicon/entries/_external_identifiers_form` reusable from the general entry edit view

## Technical details

- `LexEntry#build_checklist` and `#verification_percentage` extended to include `external_identifiers` (common to both person and publication)
- `Lexicon::VerificationController#update_section` handles `external_identifiers` params with strong parameter filtering; guards `item_params` against missing model param keys (was raising HTTP 400 for forms that don't include `lex_person`/`lex_publication`)
- I18n keys added to `config/locales/lexicon.{en,he}.yml` for all new labels and placeholders

## Test plan

- [x] New model specs: `external_identifiers` in `build_checklist` for both types, `verification_percentage` counting, `update_checklist_item`
- [x] New request specs: `PATCH update_section` for external_identifiers (update, remove, mark verified, 400 guard fix)
- [x] New system spec (`spec/system/lexicon/verification_external_identifiers_spec.rb`): display, checklist, edit modal (update/remove/mark-verified), modal pre-checks checkbox when already verified
- [x] Existing request spec "allows verification_percentage to reach 100" updated to include external_identifiers step
- [x] Full suite run clean before PR

Closes b7y

🤖 Generated with [Claude Code](https://claude.com/claude-code)