### PR TITLE
Show collections filters by default, removing intro/toggle

### DIFF
--- a/app/views/collections/_browse_top.html.haml
+++ b/app/views/collections/_browse_top.html.haml
@@ -6,4 +6,4 @@
     .texts-list-top-info-card
       .headline-1-v02= @collections_list_title
       .author-page-top-sort-mobile
-        %button.btn-small-outline-v02.btn-text-v02{ href: '#' }= t(:sort_and_filter)
+        %button.btn-small-outline-v02.btn-text-v02#mobile_filter_btn{ type: 'button' }= t(:sort_and_filter)

--- a/app/views/collections/_browse_top.html.haml
+++ b/app/views/collections/_browse_top.html.haml
@@ -1,28 +1,9 @@
 / Browse collections top header
-#header-author.container-fluid
+.container-fluid#header-author
   = render partial: 'shared/breadcrumbs'
   .top-space
   .texts-list-top
     .texts-list-top-info-card
       .headline-1-v02= @collections_list_title
-      .author-sort-area#sort_filter_toggle{title: t(:toggle_filters_tt)}
-        .author-page-top-sort-desktop
-          = t(:filter_state)
-          .toggle-background-no
-            .toggle-button-no{style:"display:#{ @filters.empty? ? 'show' : 'none'}"}
-            .toggle-button-yes{style:"display:#{ @filters.empty? ? 'none' : 'show'}"}
-        .author-page-top-sort-mobile
-          %button.btn-small-outline-v02.btn-text-v02{:href => "#"}= t(:sort_and_filter)
-:javascript
-  $(document).ready(function(){
-    $('#sort_filter_toggle').click(function() {
-      $('#sort_filter_panel').toggle();
-      if (isMobile()) {
-        $('#thelist').toggle();
-      } else {
-        $('#browse_intro').toggle();
-        $('.toggle-button-no').toggle();
-        $('.toggle-button-yes').toggle();
-      }
-    });
-  });
+      .author-page-top-sort-mobile
+        %button.btn-small-outline-v02.btn-text-v02{ href: '#' }= t(:sort_and_filter)

--- a/app/views/collections/browse.html.haml
+++ b/app/views/collections/browse.html.haml
@@ -1,29 +1,17 @@
 -# Browse collections
-#content.container-fluid
+.container-fluid#content
   .row.list-all-texts
     .col-sm-12.col-md-4
-      .by-card-v02#browse_intro
-        .work-area
-          .work-content
-            .headline-1-v02= t(:welcome_to_collections_browsing)
-            %p!= t(:collections_browsing_intro_html)
-          .work-side-color
-            .work-genre.prose-side-icon
       .by-card-v02.text-sorting#sort_filter_panel
         = render partial: 'browse_filters'
     .col-sm-12.col-md-8
       .by-card-v02#thelist
         = render partial: 'browse_list'
 
-#authoritiesDlg.modal{'aria-hidden' => 'true', role: 'dialog', tabindex: '-1'}
-  = render partial: 'authorities_select', locals: {authorities: @authorities, list: @authorities_list}
+.modal#authoritiesDlg{ 'aria-hidden' => 'true', role: 'dialog', tabindex: '-1' }
+  = render partial: 'authorities_select', locals: { authorities: @authorities, list: @authorities_list }
 
 :javascript
-  $(function() {
-    $('#browse_intro').toggle(#{@filters.empty?} && !isMobile());
-    $('#sort_filter_panel').toggle(#{@filters.present?} && !isMobile());
-  });
-
   function submit_filters() {
     window.history.pushState($('#collections_filters').serialize(), null, '/collections');
     startModal('spinnerdiv');

--- a/app/views/collections/browse.html.haml
+++ b/app/views/collections/browse.html.haml
@@ -12,6 +12,13 @@
   = render partial: 'authorities_select', locals: { authorities: @authorities, list: @authorities_list }
 
 :javascript
+  $(function() {
+    $('#mobile_filter_btn').click(function() {
+      $('#sort_filter_panel').show();
+      $('#thelist').hide();
+    });
+  });
+
   function submit_filters() {
     window.history.pushState($('#collections_filters').serialize(), null, '/collections');
     startModal('spinnerdiv');


### PR DESCRIPTION
## Summary
- `/collections` now always shows the filter panel on page load, matching the existing behaviour of `/works` and `/authors`
- Removed the `#browse_intro` card (the welcome text shown when no filters were active)
- Removed the `#sort_filter_toggle` button and its click handler from the top header partial
- Fixed pre-existing haml-lint warnings in both modified files (ClassesBeforeIds, HashSyntax, SpaceInsideHashAttributes)

## Test plan
- [ ] Visit `/collections` with no params — filter panel should be visible immediately
- [ ] Visit `/collections?search_input=foo` — filter panel should also be visible (as before)
- [ ] Mobile: "Sort and filter" button still present in top header