### PR TITLE
Fix sidebar overlap at 992-1279px viewport on author TOC page

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1217,6 +1217,21 @@ p.by-genre-name-v02.headline-2-v02 {
   }
 }
 
+/* Fix: prevent sidebar overlap at 992-1279px viewports.
+ * The inner row (spacer + content col) can flex-wrap at narrow widths,
+ * causing the content col to take full row width and overlap the fixed sidebar.
+ * flex-wrap: nowrap forces them to share the row; min-width: 0 lets the
+ * content col shrink below its natural min-content-size. */
+@media (min-width: 992px) {
+  .author-page-content .col-12.col-lg-8 > .row {
+    flex-wrap: nowrap;
+  }
+
+  .author-page-content .col-12.col-lg-8 > .row > .col:not(.author-side-menu-area) {
+    min-width: 0;
+  }
+}
+
 /* Navbar hover expansion - show full text by wrapping instead of extending horizontally */
 
 /* Simple direct hover on truncate - apply to all truncate elements in sidebars */

--- a/spec/system/author_sidebar_overlap_spec.rb
+++ b/spec/system/author_sidebar_overlap_spec.rb
@@ -28,6 +28,9 @@ describe 'Author page sidebar overlap regression', :js do
     # Content (.col:not(.author-side-menu-area)) must end before that.
     content_col_selector =
       '.author-page-content .col-12.col-lg-8 > .row > .col:not(.author-side-menu-area)'
+    expect(page).to have_css('.author-side-nav-col')
+    expect(page).to have_css(content_col_selector)
+
     sidebar_left = page.evaluate_script(
       "document.querySelector('.author-side-nav-col').getBoundingClientRect().left"
     )
@@ -52,6 +55,9 @@ describe 'Author page sidebar overlap regression', :js do
 
     content_col_selector =
       '.author-page-content .col-12.col-lg-8 > .row > .col:not(.author-side-menu-area)'
+    expect(page).to have_css('.author-side-nav-col')
+    expect(page).to have_css(content_col_selector)
+
     sidebar_left = page.evaluate_script(
       "document.querySelector('.author-side-nav-col').getBoundingClientRect().left"
     )

--- a/spec/system/author_sidebar_overlap_spec.rb
+++ b/spec/system/author_sidebar_overlap_spec.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe 'Author page sidebar overlap regression', :js do
+  before do
+    skip 'WebDriver not available or misconfigured' unless webdriver_available?
+  end
+
+  after do
+    Chewy.massacre
+  end
+
+  # Reproduces the bug at 992-1279px where the flex-wrap caused the content col
+  # to take full row width, overlapping the fixed sidebar.
+  it 'does not overlap sidebar with content at 1054px viewport width' do
+    author = create(:authority, name: 'Test Author')
+    Chewy.strategy(:atomic) do
+      create(:manifestation, title: 'Test Work', status: :published, author: author)
+    end
+
+    page.driver.browser.manage.window.resize_to(1054, 768)
+    visit authority_path(author)
+    expect(page).to have_css('.book-nav-full')
+
+    # The main content right edge must not reach the sidebar left edge.
+    # Sidebar (.author-side-nav-col) is at x≈(viewport-215) from left.
+    # Content (.col:not(.author-side-menu-area)) must end before that.
+    content_col_selector =
+      '.author-page-content .col-12.col-lg-8 > .row > .col:not(.author-side-menu-area)'
+    sidebar_left = page.evaluate_script(
+      "document.querySelector('.author-side-nav-col').getBoundingClientRect().left"
+    )
+    content_right = page.evaluate_script(
+      "document.querySelector('#{content_col_selector}').getBoundingClientRect().right"
+    )
+
+    expect(content_right).to be <= sidebar_left,
+                             "Content right edge (#{content_right}px) overlaps " \
+                             "sidebar left edge (#{sidebar_left}px)"
+  end
+
+  it 'does not overlap sidebar with content at 992px viewport width' do
+    author = create(:authority, name: 'Test Author 992')
+    Chewy.strategy(:atomic) do
+      create(:manifestation, title: 'Test Work 992', status: :published, author: author)
+    end
+
+    page.driver.browser.manage.window.resize_to(992, 768)
+    visit authority_path(author)
+    expect(page).to have_css('.book-nav-full')
+
+    content_col_selector =
+      '.author-page-content .col-12.col-lg-8 > .row > .col:not(.author-side-menu-area)'
+    sidebar_left = page.evaluate_script(
+      "document.querySelector('.author-side-nav-col').getBoundingClientRect().left"
+    )
+    content_right = page.evaluate_script(
+      "document.querySelector('#{content_col_selector}').getBoundingClientRect().right"
+    )
+
+    expect(content_right).to be <= sidebar_left,
+                             "Content right edge (#{content_right}px) overlaps " \
+                             "sidebar left edge (#{sidebar_left}px)"
+  end
+end


### PR DESCRIPTION
## Summary

- At viewport widths between 992px and ~1300px, the side navigation bar (`.author-side-nav-col`) overlapped the main content on author pages.
- **Root cause**: the inner flex row (spacer col + content col) inside `.col-12.col-lg-8` had `flex-wrap: wrap`. When the content col's min-content-size exceeded the remaining space after the 230px spacer, Bootstrap's flex algorithm wrapped it to a new line — where it expanded to full row width and extended rightward into the fixed sidebar's pixel range.
- **Fix**: added `flex-wrap: nowrap` and `min-width: 0` to the affected row/col at `min-width: 992px` in `application.scss`. The content col now stays on the same flex line as the spacer and shrinks to fit.

## Test plan

- [x] Verified fix visually at 1054px viewport on `/author/89` (Bialik, the heavy-content case)
- [x] Verified no regression on `/author/2360` (previously unaffected)
- [x] Added `spec/system/author_sidebar_overlap_spec.rb` with two regression tests (1054px and 992px viewports)
- [x] New tests pass: `2 examples, 0 failures`

Closes beads_by-95o