### PR TITLE
Footnote popovers: prevent navigation, add jump and close links

### DIFF
--- a/app/assets/javascripts/footnote_popovers.js
+++ b/app/assets/javascripts/footnote_popovers.js
@@ -1,0 +1,13 @@
+// Footnote popover behavior:
+// - Prevent anchor navigation when clicking a footnote reference (let the popover show via focus)
+// - Close the open popover when the in-popover [x] link is clicked
+$(function() {
+  $(document).on('click', 'a.footnote[data-toggle="popover"]', function(e) {
+    e.preventDefault();
+  });
+
+  $(document).on('click', '.fn-popover-close', function(e) {
+    e.preventDefault();
+    $('a.footnote[data-toggle="popover"]').popover('hide');
+  });
+});

--- a/app/services/markdown_to_html.rb
+++ b/app/services/markdown_to_html.rb
@@ -46,13 +46,20 @@ class MarkdownToHtml < ApplicationService
       if content.blank?
         "<a #{attrs}>"
       else
+        fn_id = match[1]
         # Bootstrap would use the title attribute as the popover header; strip it so
         # the popover shows only the footnote body.
         stripped = attrs.sub(/\s*\btitle="[^"]*"/, '')
         popover_attrs = 'tabindex="0" data-toggle="popover" data-trigger="focus" data-html="true"'
-        %(<a #{stripped} #{popover_attrs} data-content="#{CGI.escapeHTML(content)}">)
+        full_content = "#{content}#{footnote_popover_footer(fn_id)}"
+        %(<a #{stripped} #{popover_attrs} data-content="#{CGI.escapeHTML(full_content)}">)
       end
     end
+  end
+
+  def footnote_popover_footer(fn_id)
+    %(<div class="mt-2 pt-1 border-top"><a href="##{fn_id}">להערת השוליים בסוף הטקסט</a> ) +
+      %(<a href="#" class="fn-popover-close">[x]</a></div>)
   end
 
   # Builds { "fn:1" => "<inner html without reverse link>", ... } from the footnote list.

--- a/app/services/markdown_to_html.rb
+++ b/app/services/markdown_to_html.rb
@@ -58,8 +58,8 @@ class MarkdownToHtml < ApplicationService
   end
 
   def footnote_popover_footer(fn_id)
-    %(<div class="mt-2 pt-1 border-top"><a href="##{fn_id}">להערת השוליים בסוף הטקסט</a> ) +
-      %(<a href="#" class="fn-popover-close">[x]</a></div>)
+    %(<div class="mt-2 pt-1 border-top"><a href="##{fn_id}">#{I18n.t(:footnote_popover_jump_link)}</a> ) +
+      %(<a href="#" class="fn-popover-close" aria-label="#{I18n.t(:footnote_popover_close)}">[x]</a></div>)
   end
 
   # Builds { "fn:1" => "<inner html without reverse link>", ... } from the footnote list.

--- a/app/services/markdown_to_html.rb
+++ b/app/services/markdown_to_html.rb
@@ -24,6 +24,44 @@ class MarkdownToHtml < ApplicationService
         "<a #{attributes} target=\"_blank\">"
       end
     end
-    html
+    add_footnote_popovers(html)
+  end
+
+  private
+
+  # Decorates footnote reference links (e.g. <a href="#fn:1" class="footnote">) with
+  # Bootstrap popover data attributes carrying the footnote body HTML, so readers can
+  # see the footnote inline without jumping to the bottom of the document.
+  # Only the reference <a> tags are rewritten; everything else is preserved byte-for-byte.
+  def add_footnote_popovers(html)
+    return html unless html.include?('class="footnote"') && html.include?('id="fn:')
+
+    contents_by_id = footnote_contents_by_id(html)
+    return html if contents_by_id.empty?
+
+    html.gsub(/<a\s+([^>]*?\bclass="footnote"[^>]*?)>/) do
+      attrs = ::Regexp.last_match(1)
+      match = attrs.match(/\bhref="#(fn:\d+)"/)
+      content = match && contents_by_id[match[1]]
+      if content.blank?
+        "<a #{attrs}>"
+      else
+        # Bootstrap would use the title attribute as the popover header; strip it so
+        # the popover shows only the footnote body.
+        stripped = attrs.sub(/\s*\btitle="[^"]*"/, '')
+        popover_attrs = 'tabindex="0" data-toggle="popover" data-trigger="focus" data-html="true"'
+        %(<a #{stripped} #{popover_attrs} data-content="#{CGI.escapeHTML(content)}">)
+      end
+    end
+  end
+
+  # Builds { "fn:1" => "<inner html without reverse link>", ... } from the footnote list.
+  def footnote_contents_by_id(html)
+    {}.tap do |hash|
+      html.scan(%r{<li id="(fn:\d+)"[^>]*>(.*?)</li>}m) do |id, inner|
+        cleaned = inner.gsub(%r{\s*<a[^>]*class="reversefootnote"[^>]*>.*?</a>}m, '').strip
+        hash[id] = cleaned unless cleaned.empty?
+      end
+    end
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1546,6 +1546,8 @@ en:
   folder_list: Folder List
   font_size: Font Size
   footnotes: Footnotes
+  footnote_popover_jump_link: "To the footnote at the end of the text"
+  footnote_popover_close: "Close footnote"
   for_pasting: Text for Pasting
   for_publishers_project: For works uploaded as part of the publishers' project only
   for_tag: For tag "%{tag}"

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -182,6 +182,8 @@ he:
   mark_as_manual: סמן כדורש הסבה ידנית
   nikkud: ניקוד
   footnotes: הערות שוליים
+  footnote_popover_jump_link: "להערת השוליים בסוף הטקסט"
+  footnote_popover_close: "סגירת חלונית הערת השוליים"
   images: תמונות
   tables: טבלאות
   some: חלקי

--- a/spec/services/manifestation_html_with_chapters_spec.rb
+++ b/spec/services/manifestation_html_with_chapters_spec.rb
@@ -190,42 +190,32 @@ describe ManifestationHtmlWithChapters do
           [^ftn2]: Footnote 2
         MD
       end
-      let(:expected_html) do
-        <<~HTML
-          <h1 id="maintitle">Main Title</h1>
-
-          <p><a name="ch2" class="ch_anch" id="ch2">&nbsp;</a></p>
-
-          <h2 id="heading-1">Chapter 1<a href="#fn:1" id="fnref:1" title="see footnote" class="footnote"><sup>1</sup></a> &nbsp;&nbsp; <span style="font-size: 50%;"><a title="#{I18n.t(:permalink)}" href="#{permalink_base_url}#heading-1">🔗</a></span></h2>
-
-          <p>Content with footnote</p>
-
-          <p><a name="ch5" class="ch_anch" id="ch5">&nbsp;</a></p>
-
-          <h2 id="heading-2">Chapter 2<a href="#fn:2" id="fnref:2" title="see footnote" class="footnote"><sup>2</sup></a> &nbsp;&nbsp; <span style="font-size: 50%;"><a title="#{I18n.t(:permalink)}" href="#{permalink_base_url}#heading-2">🔗</a></span></h2>
-
-          <p>More content</p>
-
-          <div class="footnotes">
-          <hr />
-          <ol>
-
-          <li id="fn:1">
-          <span>Footnote 1 <a href="#fnref:1" title="return to body" class="reversefootnote">&#160;&#8617;&#xfe0e;</a></span>
-          </li>
-
-          <li id="fn:2">
-          <span>Footnote 2 <a href="#fnref:2" title="return to body" class="reversefootnote">&#160;&#8617;&#xfe0e;</a></span>
-          </li>
-
-          </ol>
-          </div>
-        HTML
-      end
       let(:expected_chapters) { [['Chapter 1', '2'], ['Chapter 2', '5']] }
-      let(:expected_title_footnote) { nil }
 
-      it_behaves_like 'produces expected result'
+      # Footnote reference anchors are now decorated with Bootstrap popover
+      # attributes by MarkdownToHtml, so we check key structural properties
+      # rather than the exact anchor markup (which includes a long data-content).
+      it 'returns chapters and nil title_footnote' do
+        expect(result[:chapters]).to eq(expected_chapters)
+        expect(result[:title_footnote]).to be_nil
+      end
+
+      it 'includes chapter headings in the html' do
+        expect(result[:html]).to include('<h2 id="heading-1">Chapter 1')
+        expect(result[:html]).to include('<h2 id="heading-2">Chapter 2')
+      end
+
+      it 'decorates heading footnote anchors with popover attributes, not plain title' do
+        expect(result[:html]).to include('href="#fn:1"')
+        expect(result[:html]).to include('href="#fn:2"')
+        expect(result[:html]).to include('data-toggle="popover"')
+        expect(result[:html]).not_to include('title="see footnote"')
+      end
+
+      it 'preserves the footnote list at the bottom' do
+        expect(result[:html]).to include('<span>Footnote 1')
+        expect(result[:html]).to include('<span>Footnote 2')
+      end
     end
 
     context 'when manifestation has headings with HTML tags' do
@@ -290,11 +280,23 @@ describe ManifestationHtmlWithChapters do
         HTML
       end
       let(:expected_chapters) { [] }
-      let(:expected_title_footnote) do
-        '<a href="#fn:1" id="fnref:1" title="see footnote" class="footnote"><sup>1</sup></a>'
+
+      it 'returns the correct html and chapters' do
+        expect(result[:html]).to eq(expected_html)
+        expect(result[:chapters]).to eq(expected_chapters)
       end
 
-      it_behaves_like 'produces expected result'
+      # title_footnote is the extracted footnote anchor, now decorated with popover
+      # attributes by MarkdownToHtml. We check key properties rather than exact markup
+      # because the data-content attribute is long and an implementation detail.
+      it 'extracts the standalone footnote as a popover-decorated anchor' do
+        title_fn = result[:title_footnote]
+        expect(title_fn).not_to be_nil
+        expect(title_fn).to include('href="#fn:1"')
+        expect(title_fn).to include('class="footnote"')
+        expect(title_fn).to include('data-toggle="popover"')
+        expect(title_fn).not_to include('title="see footnote"')
+      end
     end
   end
 end

--- a/spec/services/markdown_to_html_spec.rb
+++ b/spec/services/markdown_to_html_spec.rb
@@ -70,6 +70,7 @@ describe MarkdownToHtml do
         result = described_class.call(markdown)
 
         fn_tag = result[/<a[^>]*href="#fn:1"[^>]*data-toggle="popover"[^>]*>/]
+        expect(fn_tag).not_to be_nil
         expect(fn_tag).not_to include('onclick')
       end
 
@@ -78,9 +79,10 @@ describe MarkdownToHtml do
         result = described_class.call(markdown)
 
         fn_tag = result[/<a[^>]*href="#fn:1"[^>]*data-toggle="popover"[^>]*>/]
+        expect(fn_tag).not_to be_nil
         decoded = CGI.unescapeHTML(fn_tag[/data-content="([^"]*)"/, 1])
         expect(decoded).to include('href="#fn:1"')
-        expect(decoded).to include('להערת השוליים בסוף הטקסט')
+        expect(decoded).to include(I18n.t(:footnote_popover_jump_link))
       end
 
       it 'includes a [x] close link with fn-popover-close class in the popover footer' do
@@ -88,9 +90,11 @@ describe MarkdownToHtml do
         result = described_class.call(markdown)
 
         fn_tag = result[/<a[^>]*href="#fn:1"[^>]*data-toggle="popover"[^>]*>/]
+        expect(fn_tag).not_to be_nil
         decoded = CGI.unescapeHTML(fn_tag[/data-content="([^"]*)"/, 1])
         expect(decoded).to include('[x]')
         expect(decoded).to include('class="fn-popover-close"')
+        expect(decoded).to include(%[aria-label="#{I18n.t(:footnote_popover_close)}"])
         expect(decoded).not_to include('onclick')
       end
 

--- a/spec/services/markdown_to_html_spec.rb
+++ b/spec/services/markdown_to_html_spec.rb
@@ -50,6 +50,80 @@ describe MarkdownToHtml do
         expect(result).to include('class="reversefootnote"')
         expect(result).to include('href="#fnref:1"')
       end
+
+      it 'adds a Bootstrap popover to each footnote reference' do
+        markdown = "Text with footnote[^1] and another[^2].\n\n[^1]: First note.\n\n[^2]: Second note."
+        result = described_class.call(markdown)
+
+        # First reference carries first note's content; second carries second note's content.
+        expect(result).to match(
+          /<a[^>]*href="#fn:1"[^>]*data-toggle="popover"[^>]*data-content="First note\."[^>]*>/
+        )
+        expect(result).to match(
+          /<a[^>]*href="#fn:2"[^>]*data-toggle="popover"[^>]*data-content="Second note\."[^>]*>/
+        )
+      end
+
+      it 'configures the popover for focus-triggered HTML content' do
+        markdown = "Text[^1].\n\n[^1]: Note."
+        result = described_class.call(markdown)
+
+        expect(result).to match(/<a[^>]*href="#fn:1"[^>]*data-trigger="focus"/)
+        expect(result).to match(/<a[^>]*href="#fn:1"[^>]*data-html="true"/)
+        expect(result).to match(/<a[^>]*href="#fn:1"[^>]*tabindex="0"/)
+      end
+
+      it 'omits the popover title by stripping the reference title attribute' do
+        markdown = "Text[^1].\n\n[^1]: Note."
+        result = described_class.call(markdown)
+
+        # The footnote reference must not carry a title attribute, so Bootstrap
+        # renders no popover header.
+        reference_tag = result[/<a[^>]*href="#fn:1"[^>]*>/]
+        expect(reference_tag).not_to be_nil
+        expect(reference_tag).not_to include('title=')
+      end
+
+      it 'strips the reverse link from popover content but keeps it in the list' do
+        markdown = "Text[^1].\n\n[^1]: Note."
+        result = described_class.call(markdown)
+
+        # Popover content does not include the back-arrow link.
+        reference_tag = result[/<a[^>]*href="#fn:1"[^>]*>/]
+        expect(reference_tag).not_to include('reversefootnote')
+        # The bottom footnote list still has the reverse link.
+        expect(result).to match(%r{<li id="fn:1".*?class="reversefootnote".*?</li>}m)
+      end
+
+      it 'HTML-escapes popover content so it is safe inside a data-content attribute' do
+        markdown = "Text[^1].\n\n[^1]: A \"quoted\" <em>phrase</em>."
+        result = described_class.call(markdown)
+
+        # Extract the value of data-content for the fn:1 reference anchor.
+        reference_tag = result[/<a[^>]*href="#fn:1"[^>]*>/]
+        data_content = reference_tag[/data-content="([^"]*)"/, 1]
+        expect(data_content).not_to be_nil
+
+        # The attribute value itself must not contain raw '<', '>' or '"'
+        # characters - those would terminate the attribute or be interpreted
+        # as markup when the popover is rendered.
+        expect(data_content).not_to include('<')
+        expect(data_content).not_to include('>')
+        expect(data_content).not_to include('"')
+
+        # And after one level of HTML-entity decoding (what the browser does
+        # when reading an attribute), we should see the escaped footnote body
+        # that the popover will then render as HTML (data-html="true").
+        decoded_once = CGI.unescapeHTML(data_content)
+        expect(decoded_once).to include('phrase')
+      end
+
+      it 'does not add popover attributes when no footnotes are present' do
+        markdown = "# Title\n\nJust a paragraph."
+        result = described_class.call(markdown)
+
+        expect(result).not_to include('data-toggle="popover"')
+      end
     end
 
     context 'when markdown does not contain footnotes' do

--- a/spec/services/markdown_to_html_spec.rb
+++ b/spec/services/markdown_to_html_spec.rb
@@ -55,13 +55,43 @@ describe MarkdownToHtml do
         markdown = "Text with footnote[^1] and another[^2].\n\n[^1]: First note.\n\n[^2]: Second note."
         result = described_class.call(markdown)
 
-        # First reference carries first note's content; second carries second note's content.
-        expect(result).to match(
-          /<a[^>]*href="#fn:1"[^>]*data-toggle="popover"[^>]*data-content="First note\."[^>]*>/
-        )
-        expect(result).to match(
-          /<a[^>]*href="#fn:2"[^>]*data-toggle="popover"[^>]*data-content="Second note\."[^>]*>/
-        )
+        # Each reference carries its corresponding note's content (HTML-escaped) in data-content.
+        fn1_tag = result[/<a[^>]*href="#fn:1"[^>]*data-toggle="popover"[^>]*>/]
+        expect(fn1_tag).not_to be_nil
+        expect(CGI.unescapeHTML(fn1_tag[/data-content="([^"]*)"/, 1])).to include('First note.')
+
+        fn2_tag = result[/<a[^>]*href="#fn:2"[^>]*data-toggle="popover"[^>]*>/]
+        expect(fn2_tag).not_to be_nil
+        expect(CGI.unescapeHTML(fn2_tag[/data-content="([^"]*)"/, 1])).to include('Second note.')
+      end
+
+      it 'does not add onclick to footnote reference anchors (navigation is prevented by JS)' do
+        markdown = "Text[^1].\n\n[^1]: Note."
+        result = described_class.call(markdown)
+
+        fn_tag = result[/<a[^>]*href="#fn:1"[^>]*data-toggle="popover"[^>]*>/]
+        expect(fn_tag).not_to include('onclick')
+      end
+
+      it 'includes a link to the footnote body in the popover footer' do
+        markdown = "Text[^1].\n\n[^1]: Note."
+        result = described_class.call(markdown)
+
+        fn_tag = result[/<a[^>]*href="#fn:1"[^>]*data-toggle="popover"[^>]*>/]
+        decoded = CGI.unescapeHTML(fn_tag[/data-content="([^"]*)"/, 1])
+        expect(decoded).to include('href="#fn:1"')
+        expect(decoded).to include('להערת השוליים בסוף הטקסט')
+      end
+
+      it 'includes a [x] close link with fn-popover-close class in the popover footer' do
+        markdown = "Text[^1].\n\n[^1]: Note."
+        result = described_class.call(markdown)
+
+        fn_tag = result[/<a[^>]*href="#fn:1"[^>]*data-toggle="popover"[^>]*>/]
+        decoded = CGI.unescapeHTML(fn_tag[/data-content="([^"]*)"/, 1])
+        expect(decoded).to include('[x]')
+        expect(decoded).to include('class="fn-popover-close"')
+        expect(decoded).not_to include('onclick')
       end
 
       it 'configures the popover for focus-triggered HTML content' do

--- a/spec/system/footnote_popover_spec.rb
+++ b/spec/system/footnote_popover_spec.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Footnote popovers', :js, type: :system do
+  before do
+    skip 'WebDriver not available or misconfigured' unless webdriver_available?
+  end
+
+  let(:markdown_content) do
+    <<~MARKDOWN
+      This is a text with a footnote reference.[^1]
+
+      [^1]: This is the footnote body.
+    MARKDOWN
+  end
+
+  let!(:manifestation) do
+    m = create(:manifestation, markdown: markdown_content, status: :published)
+    m.recalc_heading_lines
+    m.save!
+    m
+  end
+
+  def footnote_anchor
+    find('a.footnote[data-toggle="popover"]', visible: :all)
+  end
+
+  describe 'clicking a footnote reference' do
+    it 'shows the popover without navigating to the footnote body' do
+      visit manifestation_path(manifestation)
+
+      initial_url = current_url
+      footnote_anchor.click
+
+      expect(page).to have_css('.popover', visible: true, wait: 5)
+      expect(current_url).to eq(initial_url)
+    end
+
+    it 'shows the footnote body text in the popover' do
+      visit manifestation_path(manifestation)
+
+      footnote_anchor.click
+
+      expect(page).to have_css('.popover', visible: true, wait: 5)
+      expect(find('.popover')).to have_content('This is the footnote body.')
+    end
+
+    it 'shows a link to the footnote body in the popover' do
+      visit manifestation_path(manifestation)
+
+      footnote_anchor.click
+
+      expect(page).to have_css('.popover', visible: true, wait: 5)
+      within('.popover') do
+        expect(page).to have_link('להערת השוליים בסוף הטקסט')
+      end
+    end
+
+    it 'shows a [x] close link in the popover' do
+      visit manifestation_path(manifestation)
+
+      footnote_anchor.click
+
+      expect(page).to have_css('.popover', visible: true, wait: 5)
+      within('.popover') do
+        expect(page).to have_link('[x]')
+      end
+    end
+
+    it 'dismisses the popover when the [x] link is clicked' do
+      visit manifestation_path(manifestation)
+
+      footnote_anchor.click
+      expect(page).to have_css('.popover', visible: true, wait: 5)
+
+      within('.popover') { find('.fn-popover-close').click }
+
+      expect(page).not_to have_css('.popover', visible: true, wait: 5)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Clicking a footnote reference was showing the popover but *also* jumping to the footnote anchor at the bottom of the page
- The popover had no explicit close control, and no link to reach the footnote body

## Changes

- **`app/assets/javascripts/footnote_popovers.js`** (new): event delegation that (1) calls `e.preventDefault()` on clicks of `.footnote[data-toggle="popover"]` anchors so focus fires (triggering the popover) without the href jump, and (2) handles `.fn-popover-close` clicks to hide all footnote popovers via jQuery
- **`app/services/markdown_to_html.rb`**: appends a footer `<div>` to each popover's `data-content` containing:
  - A link to the footnote body: `להערת השוליים בסוף הטקסט`
  - A close link: `[x]`
  - Removed the broken `onclick="return false;"` approach (it was preventing focus in some browsers, stopping the popover from appearing at all)
- **`spec/services/markdown_to_html_spec.rb`**: updated unit tests for the new format
- **`spec/system/footnote_popover_spec.rb`** (new): 5 Capybara system specs that exercise the full behavior in a real browser — popover shows without navigation, body text present, Hebrew jump link present, [x] present, [x] dismisses the popover

## Test plan

- [x] `bundle exec rspec spec/services/markdown_to_html_spec.rb` — 23 examples, 0 failures
- [x] `bundle exec rspec spec/system/footnote_popover_spec.rb` — 5 examples, 0 failures
- [x] Verified on http://localhost:3000/read/7448 — popover appears with footnote text, jump link, and [x] close button; clicking the reference no longer scrolls the page

## Notes

The rendered HTML is cached via `Rails.cache` for 24 hours. Existing cached pages will serve old popovers (without the footer) until their cache entries expire or the cache is cleared.

🤖 Generated with [Claude Code](https://claude.com/claude-code)