### PR TITLE
Fix epubcheck RSC-016: strip data-* attributes before entity decoding

### DIFF
--- a/lib/bybe_utils.rb
+++ b/lib/bybe_utils.rb
@@ -105,8 +105,13 @@ module BybeUtils
   end
 
   def epub_sanitize_html(html)
+    # Strip data-* attributes BEFORE entity decoding: popover data-content is entity-encoded
+    # (&lt; etc.) in source HTML, but HTMLEntities.decode converts those back to literal <
+    # inside the attribute value, producing invalid XHTML that fails epubcheck RSC-016.
+    buf = html.gsub(/\s+data-[a-z-]+=(?:"[^"]*"|'[^']*'|\S+)/, '')
+
     coder = HTMLEntities.new
-    buf = coder.decode(html) # convert HTML entities back to actual characters.
+    buf = coder.decode(buf) # convert HTML entities back to actual characters.
 
     buf.gsub!('<br>', '<br />') # W3C epubcheck doesn't like <br> without closing
     epub_footnote_transform!(buf)

--- a/spec/lib/bybe_utils_epub_spec.rb
+++ b/spec/lib/bybe_utils_epub_spec.rb
@@ -55,6 +55,34 @@ RSpec.describe 'BybeUtils EPUB generation' do
       expect(result).to include('Footnote body text.')
     end
 
+    context 'with Bootstrap popover data attributes (as added by add_footnote_popovers)' do
+      let(:popover_html) do
+        <<~HTML
+          <p>Text<a data-toggle="popover" data-trigger="focus" data-html="true" data-content="&lt;span&gt;Note text&lt;/span&gt;&lt;div class=&quot;mt-2&quot;&gt;&lt;a href=&quot;#fn:1&quot;&gt;Jump&lt;/a&gt;&lt;/div&gt;" data-placement="top" data-container="body" href="#fn:1" id="fnref:1" class="footnote"><sup>1</sup></a>.</p>
+          <div class="footnotes">
+          <hr />
+          <ol>
+          <li id="fn:1">
+          <span>Note text.</span>
+          </li>
+          </ol>
+          </div>
+        HTML
+      end
+
+      it 'strips data-* attributes so epubcheck passes (data-content with raw HTML is invalid XHTML)' do
+        result = epub_sanitize_html(popover_html)
+        expect(result).not_to include('data-content')
+        expect(result).not_to include('data-toggle')
+        expect(result).not_to include('data-html')
+      end
+
+      it 'still adds epub:type="noteref" after stripping data-* attributes' do
+        result = epub_sanitize_html(popover_html)
+        expect(result).to include('epub:type="noteref"')
+      end
+    end
+
     it 'handles HTML with no footnotes unchanged (except br fix)' do
       plain = '<p>Simple text without footnotes.</p>'
       result = epub_sanitize_html(plain)


### PR DESCRIPTION
## Summary

- Fixes a fatal epubcheck error (RSC-016) that affects any EPUB containing footnotes
- `add_footnote_popovers` stores Bootstrap popover content in `data-content` as HTML entities (e.g. `&lt;span&gt;`)
- `HTMLEntities.decode` in `epub_sanitize_html` then converts those back to literal `<` inside the attribute value
- This makes the XHTML invalid — epubcheck rejects it as fatal RSC-016
- Fix: strip all `data-*` attributes **before** entity decoding, while they are still safely entity-encoded
- `data-*` attributes are Bootstrap/web-only and correct to omit from EPUB output

Verified with `epubcheck` on a real manifestation (id=10) with footnotes:
```
No errors or warnings detected.
Messages: 0 fatals / 0 errors / 0 warnings / 0 infos
```

## Test plan

- [x] New unit tests: `epub_sanitize_html` strips `data-content`, `data-toggle`, `data-html` and still adds `epub:type="noteref"`
- [x] All 31 EPUB spec examples pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)