### PR TITLE
Add escalate button to lexicon verification workbench

### DIFF
--- a/app/assets/javascripts/verification.js
+++ b/app/assets/javascripts/verification.js
@@ -68,7 +68,10 @@ function initVerification() {
             },
             error: function(xhr) {
                 var statusInfo = xhr && xhr.status ? ' (' + xhr.status + ')' : '';
-                showToast(('Error escalating entry') + statusInfo);
+                var responseJson = xhr && xhr.responseJSON ? xhr.responseJSON : null;
+                var serverMessage = responseJson && (responseJson.message || responseJson.error);
+                var baseMessage = container.data('error-escalating-entry-text') || 'Error escalating entry';
+                showToast(baseMessage + statusInfo + (serverMessage ? ': ' + serverMessage : ''));
             }
         });
     });

--- a/app/assets/javascripts/verification.js
+++ b/app/assets/javascripts/verification.js
@@ -45,6 +45,34 @@ function initVerification() {
         });
     });
 
+    // Handle "Escalate" button
+    $('#escalate-btn').on('click', function(e) {
+        e.preventDefault();
+        const confirmMessage = container.data('escalate-confirm-text');
+        if (confirmMessage && !window.confirm(confirmMessage)) { return; }
+        const escalateUrl = container.data('verification-escalate-url');
+        const notes = $('#overall_notes').val();
+
+        $.ajax({
+            url: escalateUrl,
+            type: 'POST',
+            dataType: 'json',
+            headers: {
+                'X-CSRF-Token': $('meta[name="csrf-token"]').attr('content')
+            },
+            data: {
+                overall_notes: notes
+            },
+            success: function(data) {
+                window.location.href = data.redirect_url;
+            },
+            error: function(xhr) {
+                var statusInfo = xhr && xhr.status ? ' (' + xhr.status + ')' : '';
+                showToast(('Error escalating entry') + statusInfo);
+            }
+        });
+    });
+
     // Handle quick verify buttons on citations and links
     $('[data-action="click->verification#quickVerify"]').on('click', function(e) {
         e.preventDefault();

--- a/app/controllers/lexicon/verification_controller.rb
+++ b/app/controllers/lexicon/verification_controller.rb
@@ -30,7 +30,7 @@ module Lexicon
     # GET /lexicon/verification/:id
     def show
       # Initialize verification if not started
-      unless @entry.status_verifying? || @entry.status_verified?
+      unless @entry.status_verifying? || @entry.status_verified? || @entry.status_escalated?
         user_email = current_user&.email || 'anonymous@example.com'
         @entry.start_verification!(user_email)
       end
@@ -222,6 +222,24 @@ module Lexicon
     rescue StandardError => e
       redirect_to lexicon_verification_path(@entry),
                   alert: e.message
+    end
+
+    # POST /lexicon/verification/:id/escalate
+    def escalate
+      notes = params[:overall_notes]
+
+      progress = @entry.verification_progress.deep_dup
+      progress['overall_notes'] = notes if notes.present?
+      progress['last_updated_at'] = Time.current.iso8601
+
+      @entry.update!(verification_progress: progress, status: :escalated)
+
+      render json: {
+        success: true,
+        redirect_url: lexicon_verification_queue_path
+      }
+    rescue StandardError => e
+      render json: { success: false, error: e.message }, status: :unprocessable_content
     end
 
     # GET /lexicon/verification/:id/edit_section?section=title

--- a/app/controllers/lexicon/verification_controller.rb
+++ b/app/controllers/lexicon/verification_controller.rb
@@ -226,10 +226,10 @@ module Lexicon
 
     # POST /lexicon/verification/:id/escalate
     def escalate
-      notes = params[:overall_notes]
+      notes = params[:overall_notes] || ''
 
       progress = @entry.verification_progress.deep_dup
-      progress['overall_notes'] = notes if notes.present?
+      progress['overall_notes'] = notes
       progress['last_updated_at'] = Time.current.iso8601
 
       @entry.update!(verification_progress: progress, status: :escalated)

--- a/app/models/lex_entry.rb
+++ b/app/models/lex_entry.rb
@@ -22,7 +22,8 @@ class LexEntry < ApplicationRecord
     migrating: 102, # async migration in progress
     error: 103,     # error during migration
     verifying: 104, # under verification review
-    verified: 105   # verification complete, ready for publishing
+    verified: 105,  # verification complete, ready for publishing
+    escalated: 106  # escalated for further review due to some problem
   }, prefix: true
 
   has_many_attached :attachments # attachments referenced by link or image on the entry page

--- a/app/models/lex_entry.rb
+++ b/app/models/lex_entry.rb
@@ -32,7 +32,7 @@ class LexEntry < ApplicationRecord
   validates :title, :sort_title, :status, presence: true
 
   # Scopes for verification queue
-  scope :needs_verification, -> { where(status: %i(draft verifying error)) }
+  scope :needs_verification, -> { where(status: %i(draft verifying error escalated)) }
   scope :in_verification, -> { where(status: :verifying) }
   scope :verified_pending_publish, -> { where(status: :verified) }
 

--- a/app/models/lex_entry.rb
+++ b/app/models/lex_entry.rb
@@ -12,7 +12,7 @@ class LexEntry < ApplicationRecord
   belongs_to :lex_item, polymorphic: true, optional: true, dependent: :destroy, inverse_of: :entry
 
   # Statuses related to migration process
-  MIGRATION_STATUSES = %w(raw migrating error verifying verified).freeze
+  MIGRATION_STATUSES = %w(raw migrating error verifying verified escalated).freeze
 
   enum :status, {
     draft: 0,       # entry created but not ready for public access

--- a/app/views/lexicon/files/_file_row.html.haml
+++ b/app/views/lexicon/files/_file_row.html.haml
@@ -12,7 +12,7 @@
       = link_to t(:show), lexicon_entry_path(lex_entry)
     - elsif lex_entry.lex_item.present? && !lex_entry.status_error?
       = link_to t('lexicon.verification.queue.actions.start_or_continue'),
-                lexicon_verification_path(@lex_entry),
+                lexicon_verification_path(lex_entry),
                 class: 'btn btn-sm btn-outline-primary ms-2'
     - elsif (lex_entry.status_raw? || lex_entry.status_error?) && lf.entrytype_person?
       -# for now we only show the migrate link for person entries (stage 1)

--- a/app/views/lexicon/files/index.html.haml
+++ b/app/views/lexicon/files/index.html.haml
@@ -13,7 +13,7 @@
       = text_field_tag :title, @title, placeholder: t('.title_placeholder'), class: 'form-control mr-2'
       = label_tag :fname, LexFile.human_attribute_name(:fname), class: 'mr-2'
       = text_field_tag :fname, @fname, placeholder: t('.fname_placeholder'), class: 'form-control mr-2'
-      - %w(raw migrating error draft verifying verified published deprecated).each do |status|
+      - %w(raw migrating error draft verifying verified escalated published deprecated).each do |status|
         .form-check.form-check-inline
           = check_box_tag 'entry_statuses[]', status, @entry_statuses.include?(status),
                           id: "entry_status_#{status}", class: 'form-check-input'

--- a/app/views/lexicon/verification/index.html.haml
+++ b/app/views/lexicon/verification/index.html.haml
@@ -4,7 +4,7 @@
   = form_tag lexicon_verification_queue_path, method: :get, class: 'form-inline' do
     .form-group.me-2
       = label_tag :status, t('lexicon.verification.queue.columns.status'), class: 'me-1'
-      - status_options = [[t('lexicon.verification.queue.filters.all'), ''], [t('lexicon.verification.queue.filters.draft'), 'draft'], [t('lexicon.verification.queue.filters.verifying'), 'verifying'], [t('lexicon.verification.queue.filters.error'), 'error']]
+      - status_options = [[t('lexicon.verification.queue.filters.all'), ''], [t('lexicon.verification.queue.filters.draft'), 'draft'], [t('lexicon.verification.queue.filters.verifying'), 'verifying'], [t('lexicon.verification.queue.filters.error'), 'error'], [t('lexicon.verification.queue.filters.escalated'), 'escalated']]
       = select_tag :status, options_for_select(status_options, params[:status]), class: 'form-control'
 
     .form-group.me-2
@@ -42,7 +42,7 @@
         %td
           = t('lexicon.verification.queue.time_updated', time: time_ago_in_words(entry.updated_at))
         %td
-          - if entry.status_verifying?
+          - if entry.status_verifying? || entry.status_escalated?
             = link_to t('lexicon.verification.queue.actions.continue'), lexicon_verification_path(entry), class: 'btn btn-sm btn-primary'
           - else
             = link_to t('lexicon.verification.queue.actions.start'), lexicon_verification_path(entry), class: 'btn btn-sm btn-success'

--- a/app/views/lexicon/verification/index.html.haml
+++ b/app/views/lexicon/verification/index.html.haml
@@ -32,7 +32,7 @@
           %span.badge{class: badge_class_for_status(entry.status)}
             = entry.status.humanize
         %td
-          - if entry.status_verifying? || entry.status_verified?
+          - if entry.status_verifying? || entry.status_verified? || entry.status_escalated?
             - percentage = entry.verification_percentage
             .progress{style: 'width: 150px; height: 20px;'}
               .progress-bar{role: 'progressbar', style: "width: #{percentage}%", 'aria-valuenow': percentage, 'aria-valuemin': '0', 'aria-valuemax': '100'}

--- a/app/views/lexicon/verification/show.html.haml
+++ b/app/views/lexicon/verification/show.html.haml
@@ -42,11 +42,14 @@
         - else
           %button.btn.btn-success{disabled: true, id: 'mark-verified-btn', title: t('lexicon.verification.messages.verification_incomplete')}
             = t('lexicon.verification.show.mark_verified')
+        %button.btn#escalate-btn{ style: 'background-color: #f8d7da; border-color: #f5c6cb;' }
+          = t('lexicon.verification.show.escalate')
 
 - container_data = { controller: 'verification',
                      'verification-entry-id': @entry.id,
                      'verification-update-url': lexicon_update_checklist_verification_path(@entry),
                      'verification-save-progress-url': lexicon_save_progress_verification_path(@entry),
+                     'verification-escalate-url': lexicon_escalate_verification_path(@entry),
                      'verification-set-profile-image-url': lexicon_set_profile_image_verification_path(@entry),
                      'verification-remove-attachment-url': lexicon_remove_attachment_verification_path(@entry),
                      'profile-image-badge-text': t('lexicon.entries.show.profile_image_badge'),
@@ -61,7 +64,8 @@
                      'verified-badge-text': t('lexicon.verification.messages.verified_badge'),
                      'not-verified-badge-text': t('lexicon.verification.messages.not_verified_badge'),
                      'progress-saved-text': t('lexicon.verification.messages.progress_saved'),
-                     'section-updated-text': t('lexicon.verification.messages.section_updated') }
+                     'section-updated-text': t('lexicon.verification.messages.section_updated'),
+                     'escalate-confirm-text': t('lexicon.verification.show.escalate_confirm') }
 .verification-container{ data: container_data }
   .verification-checklist
     = render 'lexicon/verification/checklist', entry: @entry, checklist: @checklist, item: @item

--- a/app/views/lexicon/verification/show.html.haml
+++ b/app/views/lexicon/verification/show.html.haml
@@ -42,7 +42,7 @@
         - else
           %button.btn.btn-success{disabled: true, id: 'mark-verified-btn', title: t('lexicon.verification.messages.verification_incomplete')}
             = t('lexicon.verification.show.mark_verified')
-        %button.btn#escalate-btn{ style: 'background-color: #f8d7da; border-color: #f5c6cb;' }
+        %button.btn#escalate-btn{ type: 'button', style: 'background-color: #f8d7da; border-color: #f5c6cb;' }
           = t('lexicon.verification.show.escalate')
 
 - container_data = { controller: 'verification',
@@ -65,7 +65,8 @@
                      'not-verified-badge-text': t('lexicon.verification.messages.not_verified_badge'),
                      'progress-saved-text': t('lexicon.verification.messages.progress_saved'),
                      'section-updated-text': t('lexicon.verification.messages.section_updated'),
-                     'escalate-confirm-text': t('lexicon.verification.show.escalate_confirm') }
+                     'escalate-confirm-text': t('lexicon.verification.show.escalate_confirm'),
+                     'error-escalating-entry-text': t('lexicon.verification.messages.error_escalating_entry') }
 .verification-container{ data: container_data }
   .verification-checklist
     = render 'lexicon/verification/checklist', entry: @entry, checklist: @checklist, item: @item

--- a/config/locales/active_record.he.yml
+++ b/config/locales/active_record.he.yml
@@ -152,6 +152,7 @@ he:
           error: שגיאה
           verifying: בבדיקה
           verified: הסבה אושרה
+          escalated: ממתין לבדיקה נוספת
       lex_person:
         birthdate: תאריך לידה
         deathdate: תאריך פטירה

--- a/config/locales/lexicon.en.yml
+++ b/config/locales/lexicon.en.yml
@@ -160,6 +160,7 @@ en:
           draft: Draft
           verifying: Verifying
           error: Error
+          escalated: Escalated
           person: Person
           publication: Publication
         time_updated: "%{time} ago"
@@ -169,6 +170,8 @@ en:
         edit_entry: Edit Entry (Full Edit Screen)
         save_progress: Save Progress
         mark_verified: Mark as Verified
+        escalate: Escalate for Further Review
+        escalate_confirm: Escalate this entry for further review?
         progress: Progress
         hide_verified: Hide Verified Items
       checklist:

--- a/config/locales/lexicon.en.yml
+++ b/config/locales/lexicon.en.yml
@@ -241,6 +241,7 @@ en:
       messages:
         progress_saved: Progress saved successfully
         entry_verified: Entry verified successfully
+        error_escalating_entry: Error escalating entry
         section_updated: Section updated successfully
         verification_incomplete: Verification incomplete - please verify all components
         work_match_confirmed: Work matched to publication successfully

--- a/config/locales/lexicon.he.yml
+++ b/config/locales/lexicon.he.yml
@@ -242,6 +242,7 @@ he:
       messages:
         progress_saved: ההתקדמות נשמרה בהצלחה
         entry_verified: הערך אומת בהצלחה
+        error_escalating_entry: שגיאה בהעברה לבדיקה נוספת
         section_updated: הקטע עודכן בהצלחה
         verification_incomplete: אימות לא הושלם - אנא אמת את כל הרכיבים
         work_match_confirmed: היצירה הותאמה לפרסום בהצלחה

--- a/config/locales/lexicon.he.yml
+++ b/config/locales/lexicon.he.yml
@@ -161,6 +161,7 @@ he:
           draft: טיוטה
           verifying: בבדיקה
           error: שגיאה
+          escalated: הועבר לבדיקה נוספת
           person: יוצר/ת
           publication: פרסום
         time_updated: "לפני %{time}"
@@ -170,6 +171,8 @@ he:
         edit_entry: עריכת הערך במסך העריכה
         save_progress: שמור התקדמות
         mark_verified: סמן כבדוק
+        escalate: העברה לבדיקה נוספת
+        escalate_confirm: האם להעביר ערך זה לבדיקה נוספת?
         progress: התקדמות
         hide_verified: הסתר פריטים בדוקים
       checklist:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -97,6 +97,7 @@ Bybeconv::Application.routes.draw do
       delete ':id/remove_attachment', to: 'verification#remove_attachment', as: :remove_attachment_verification
       patch ':id/confirm_work_match', to: 'verification#confirm_work_match', as: :confirm_work_match_verification
       post ':id/mark_verified', to: 'verification#mark_verified', as: :mark_verified_verification
+      post ':id/escalate', to: 'verification#escalate', as: :escalate_verification
       get ':id/edit_section', to: 'verification#edit_section', as: :edit_section_verification
       patch ':id/update_section', to: 'verification#update_section', as: :update_section_verification
     end

--- a/spec/models/lex_entry_spec.rb
+++ b/spec/models/lex_entry_spec.rb
@@ -311,6 +311,21 @@ RSpec.describe LexEntry, type: :model do
     end
   end
 
+  describe '.needs_verification scope' do
+    it 'includes draft, verifying, error, and escalated entries' do
+      draft_entry     = create(:lex_entry, status: :draft)
+      verifying_entry = create(:lex_entry, status: :verifying, verification_progress: { 'checklist' => {} })
+      error_entry     = create(:lex_entry, status: :error)
+      escalated_entry = create(:lex_entry, status: :escalated, verification_progress: { 'checklist' => {} })
+      published_entry = create(:lex_entry, status: :published)
+      verified_entry  = create(:lex_entry, status: :verified, verification_progress: { 'checklist' => {} })
+
+      result = described_class.needs_verification
+      expect(result).to include(draft_entry, verifying_entry, error_entry, escalated_entry)
+      expect(result).not_to include(published_entry, verified_entry)
+    end
+  end
+
   describe '#other_designation' do
     it 'can be read and written' do
       entry = create(:lex_entry, other_designation: 'alias1; alias2')

--- a/spec/requests/lexicon/verification_spec.rb
+++ b/spec/requests/lexicon/verification_spec.rb
@@ -575,4 +575,58 @@ RSpec.describe 'Lexicon::Verification', type: :request do
       end
     end
   end
+
+  describe 'POST /lex/verification/:id/escalate' do
+    let(:entry) do
+      e = create(:lex_entry, :person, status: :verifying)
+      e.start_verification!('editor@example.com')
+      e
+    end
+    let(:url) { "/lex/verification/#{entry.id}/escalate" }
+
+    it 'sets entry status to escalated' do
+      post url, params: { overall_notes: 'needs expert review' }, as: :json
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body['success']).to be true
+      expect(entry.reload).to be_status_escalated
+    end
+
+    it 'saves the submitted overall_notes' do
+      post url, params: { overall_notes: 'needs expert review' }, as: :json
+
+      expect(entry.reload.verification_progress['overall_notes']).to eq('needs expert review')
+    end
+
+    it 'clears overall_notes when blank is submitted' do
+      entry.update!(verification_progress: entry.verification_progress.merge('overall_notes' => 'old notes'))
+
+      post url, params: { overall_notes: '' }, as: :json
+
+      expect(entry.reload.verification_progress['overall_notes']).to eq('')
+    end
+
+    it 'returns a redirect_url pointing to the verification queue' do
+      post url, params: {}, as: :json
+
+      expect(response.parsed_body['redirect_url']).to eq('/lex/verification/queue')
+    end
+  end
+
+  describe 'GET /lex/verification/:id (show) - escalated entry does not reset progress' do
+    let(:entry) do
+      e = create(:lex_entry, :person, status: :verifying)
+      e.start_verification!('editor@example.com')
+      e.update!(status: :escalated,
+                verification_progress: e.verification_progress.merge('overall_notes' => 'escalation note'))
+      e
+    end
+
+    it 'does not reinitialize verification progress for an escalated entry' do
+      get "/lex/verification/#{entry.id}"
+
+      expect(entry.reload.verification_progress['overall_notes']).to eq('escalation note')
+      expect(entry.reload).to be_status_escalated
+    end
+  end
 end


### PR DESCRIPTION
## Summary

- Adds an **Escalate for Further Review** button (light-red) to the verification show view, alongside Save Progress and Mark as Verified
- Clicking prompts a confirmation dialog (i18n), saves `overall_notes`, sets entry status to `:escalated`, and redirects to the queue
- Adds `escalated` checkbox to the **files index** status filter row
- Adds **Escalated** option to the **verification queue** status dropdown; escalated entries appear in the queue via `needs_verification` scope update
- Action button in the queue shows "Continue" (not "Start") for escalated entries
- Guards the show action so opening an escalated entry does not reset its verification progress
- Fixes local variable bug in `_file_row` partial (`@lex_entry` → `lex_entry`)

## Test plan

- [ ] Open a verifying entry in the verification workbench → Escalate button is visible with light-red background
- [ ] Click Escalate → confirmation dialog appears with translated text
- [ ] Confirm → entry status becomes `escalated`, redirected to queue
- [ ] Cancel → nothing happens, stays on page
- [ ] In verification queue, select "Escalated" from the dropdown → escalated entries appear with "Continue" action
- [ ] Click Continue on an escalated entry → workbench opens with existing progress intact (not reset)
- [ ] In files index, check the "escalated" checkbox → escalated entries appear in the list

🤖 Generated with [Claude Code](https://claude.com/claude-code)