### PR TITLE
Use I18n for all user-facing strings in verification flow

### DIFF
--- a/app/controllers/lexicon/verification_controller.rb
+++ b/app/controllers/lexicon/verification_controller.rb
@@ -71,7 +71,7 @@ module Lexicon
         render html: processed_content.html_safe, layout: false
       else
         not_found_msg = '<div style="padding: 20px; text-align: center; color: #999;">' \
-                        '⚠️ קובץ מקור לא נמצא (Source file not found)</div>'
+                        "#{I18n.t('lexicon.verification.source.file_not_found')}</div>"
         render html: not_found_msg.html_safe, layout: false
       end
     end
@@ -102,7 +102,7 @@ module Lexicon
         complete: @entry.verification_complete?
       }
     rescue StandardError => e
-      render json: { success: false, error: e.message }, status: :unprocessable_entity
+      render json: { success: false, error: e.message }, status: :unprocessable_content
     end
 
     # PATCH /lexicon/verification/:id/save_progress
@@ -120,7 +120,7 @@ module Lexicon
         message: I18n.t('lexicon.verification.messages.progress_saved')
       }
     rescue StandardError => e
-      render json: { success: false, error: e.message }, status: :unprocessable_entity
+      render json: { success: false, error: e.message }, status: :unprocessable_content
     end
 
     # PATCH /lexicon/verification/:id/confirm_work_match
@@ -136,15 +136,15 @@ module Lexicon
       # Validate that publication belongs to the person's authority
       person = @entry.lex_item
       if person.authority.blank?
-        render json: { success: false, error: 'Person has no associated authority' },
-               status: :unprocessable_entity
+        render json: { success: false, error: I18n.t('lexicon.verification.messages.person_no_authority') },
+               status: :unprocessable_content
         return
       end
 
       publication = person.authority.publications.find_by(id: publication_id)
       unless publication
-        render json: { success: false, error: 'Publication does not belong to authority' },
-               status: :unprocessable_entity
+        render json: { success: false, error: I18n.t('lexicon.verification.messages.publication_not_in_authority') },
+               status: :unprocessable_content
         return
       end
 
@@ -152,8 +152,8 @@ module Lexicon
       if collection_id.present?
         collection = Collection.find_by(id: collection_id, publication_id: publication_id)
         unless collection
-          render json: { success: false, error: 'Collection does not belong to publication' },
-                 status: :unprocessable_entity
+          render json: { success: false, error: I18n.t('lexicon.verification.messages.collection_not_in_publication') },
+                 status: :unprocessable_content
           return
         end
       end
@@ -169,9 +169,9 @@ module Lexicon
         message: I18n.t('lexicon.verification.messages.work_match_confirmed')
       }
     rescue ActiveRecord::RecordNotFound
-      render json: { success: false, error: 'Work not found' }, status: :not_found
+      render json: { success: false, error: I18n.t('lexicon.verification.messages.work_not_found') }, status: :not_found
     rescue StandardError => e
-      render json: { success: false, error: e.message }, status: :unprocessable_entity
+      render json: { success: false, error: e.message }, status: :unprocessable_content
     end
 
     # PATCH /lexicon/verification/:id/set_profile_image
@@ -180,7 +180,8 @@ module Lexicon
 
       # Verify the attachment belongs to this entry using an efficient query
       unless attachment_id.positive? && @entry.attachments.exists?(id: attachment_id)
-        render json: { success: false, error: 'Attachment not found' }, status: :not_found
+        render json: { success: false, error: I18n.t('lexicon.verification.messages.attachment_not_found') },
+               status: :not_found
         return
       end
 
@@ -191,7 +192,7 @@ module Lexicon
         profile_image_id: attachment_id
       }
     rescue StandardError => e
-      render json: { success: false, error: e.message }, status: :unprocessable_entity
+      render json: { success: false, error: e.message }, status: :unprocessable_content
     end
 
     # DELETE /lexicon/verification/:id/remove_attachment
@@ -200,7 +201,8 @@ module Lexicon
       attachment = attachment_id.positive? ? @entry.attachments.find_by(id: attachment_id) : nil
 
       unless attachment
-        render json: { success: false, error: 'Attachment not found' }, status: :not_found
+        render json: { success: false, error: I18n.t('lexicon.verification.messages.attachment_not_found') },
+               status: :not_found
         return
       end
 
@@ -317,7 +319,7 @@ module Lexicon
         render json: {
           success: false,
           errors: errors
-        }, status: :unprocessable_entity
+        }, status: :unprocessable_content
       end
     end
 

--- a/app/views/lexicon/verification/_edit_works.html.haml
+++ b/app/views/lexicon/verification/_edit_works.html.haml
@@ -196,6 +196,13 @@
   (function() {
     const entryId = #{@entry.id};
     const personId = #{@item.id};
+    const i18n = {
+      errorUpdatingWork: #{t('lexicon.verification.messages.error_updating_work_verification').to_json},
+      errorUpdatingSection: #{t('lexicon.verification.messages.error_updating_works_section').to_json},
+      errorConfirmingMatch: #{t('lexicon.verification.messages.error_confirming_match').to_json},
+      errorReloadingWorks: #{t('lexicon.verification.messages.error_reloading_works').to_json},
+      unknownError: #{t('lexicon.verification.messages.unknown_error').to_json}
+    };
 
     // Handle individual work verification checkbox changes
     $('.verify-work-checkbox').on('change', function() {
@@ -224,7 +231,7 @@
           updateMarkAllCheckbox();
         },
         error: function(xhr) {
-          alert('Error updating work verification: ' + (xhr.responseJSON?.error || 'Unknown error'));
+          alert(i18n.errorUpdatingWork + ': ' + (xhr.responseJSON?.error || i18n.unknownError));
           // Revert checkbox
           checkbox.prop('checked', !verified);
         }
@@ -260,7 +267,7 @@
           setTimeout(() => location.reload(), 500);
         },
         error: function(xhr) {
-          alert('Error updating works section: ' + (xhr.responseJSON?.error || 'Unknown error'));
+          alert(i18n.errorUpdatingSection + ': ' + (xhr.responseJSON?.error || i18n.unknownError));
           // Revert checkbox
           checkbox.prop('checked', !verified);
         }
@@ -314,7 +321,7 @@
           reloadWorksSection();
         },
         error: function(xhr) {
-          alert('Error confirming match: ' + (xhr.responseJSON?.error || 'Unknown error'));
+          alert(i18n.errorConfirmingMatch + ': ' + (xhr.responseJSON?.error || i18n.unknownError));
           btn.prop('disabled', false);
         }
       });
@@ -362,7 +369,7 @@
           $('#generalDlgBody').html(html);
         },
         error: function(xhr) {
-          alert('Error reloading works: ' + (xhr.responseJSON?.error || 'Unknown error'));
+          alert(i18n.errorReloadingWorks + ': ' + (xhr.responseJSON?.error || i18n.unknownError));
         }
       });
     }

--- a/app/views/lexicon/verification/index.html.haml
+++ b/app/views/lexicon/verification/index.html.haml
@@ -27,10 +27,10 @@
     - @entries.each do |entry|
       %tr{class: "status-#{entry.status}"}
         %td= entry.title
-        %td= entry.lex_item_type&.demodulize
+        %td= t("lexicon.verification.queue.filters.#{entry.lex_item_type == 'LexPerson' ? 'person' : 'publication'}")
         %td
           %span.badge{class: badge_class_for_status(entry.status)}
-            = entry.status.humanize
+            = t("lexicon.verification.queue.filters.#{entry.status}", default: entry.status.humanize)
         %td
           - if entry.status_verifying? || entry.status_verified? || entry.status_escalated?
             - percentage = entry.verification_percentage

--- a/app/views/lexicon/verification/index.html.haml
+++ b/app/views/lexicon/verification/index.html.haml
@@ -27,7 +27,12 @@
     - @entries.each do |entry|
       %tr{class: "status-#{entry.status}"}
         %td= entry.title
-        %td= t("lexicon.verification.queue.filters.#{entry.lex_item_type == 'LexPerson' ? 'person' : 'publication'}")
+        - type_filter_key = { 'LexPerson' => 'person', 'LexPublication' => 'publication' }[entry.lex_item_type]
+        %td
+          - if type_filter_key
+            = t("lexicon.verification.queue.filters.#{type_filter_key}")
+          - else
+            = entry.lex_item_type&.demodulize.presence || t('unknown')
         %td
           %span.badge{class: badge_class_for_status(entry.status)}
             = t("lexicon.verification.queue.filters.#{entry.status}", default: entry.status.humanize)

--- a/config/locales/lexicon.en.yml
+++ b/config/locales/lexicon.en.yml
@@ -159,6 +159,7 @@ en:
           all: All
           draft: Draft
           verifying: Verifying
+          verified: Verified
           error: Error
           escalated: Escalated
           person: Person
@@ -254,6 +255,16 @@ en:
         saved: Saved
         verified_badge: "✓ Verified"
         not_verified_badge: Not Verified
+        person_no_authority: Person has no associated authority
+        publication_not_in_authority: Publication does not belong to authority
+        collection_not_in_publication: Collection does not belong to publication
+        work_not_found: Work not found
+        attachment_not_found: Attachment not found
+        unknown_error: Unknown error
+        error_updating_work_verification: Error updating work verification
+        error_updating_works_section: Error updating works section
+        error_confirming_match: Error confirming match
+        error_reloading_works: Error reloading works
       edit:
         mark_as_verified: Mark this section as verified
         mark_all_works_verified: Mark all works as verified

--- a/config/locales/lexicon.he.yml
+++ b/config/locales/lexicon.he.yml
@@ -160,6 +160,7 @@ he:
           all: הכל
           draft: טיוטה
           verifying: בבדיקה
+          verified: מאומת
           error: שגיאה
           escalated: הועבר לבדיקה נוספת
           person: יוצר/ת
@@ -255,6 +256,16 @@ he:
         saved: נשמר
         verified_badge: "✓ מאומת"
         not_verified_badge: לא אומת
+        person_no_authority: אין ישות מקושרת לאדם זה
+        publication_not_in_authority: הפרסום אינו שייך לישות
+        collection_not_in_publication: האוסף אינו שייך לפרסום
+        work_not_found: יצירה לא נמצאה
+        attachment_not_found: קובץ מצורף לא נמצא
+        unknown_error: שגיאה לא ידועה
+        error_updating_work_verification: שגיאה בעדכון אימות יצירה
+        error_updating_works_section: שגיאה בעדכון קטע היצירות
+        error_confirming_match: שגיאה באישור ההתאמה
+        error_reloading_works: שגיאה בטעינה מחדש של היצירות
       edit:
         mark_as_verified: סמן קטע זה כמאומת
         mark_all_works_verified: סמן את כל היצירות כמאומתות

--- a/spec/requests/lexicon/verification_auto_matching_spec.rb
+++ b/spec/requests/lexicon/verification_auto_matching_spec.rb
@@ -304,5 +304,54 @@ RSpec.describe 'Lexicon::Verification Auto-Matching', type: :request do
       json = response.parsed_body
       expect(json['success']).to be false
     end
+
+    context 'when person has no associated authority' do
+      let(:person_no_auth) { create(:lex_person, authority: nil) }
+      let(:entry_no_auth) { create(:lex_entry, lex_item: person_no_auth, status: :verifying) }
+      let!(:work_no_auth) { create(:lex_person_work, person: person_no_auth, title: 'Some Book', publication_id: nil) }
+
+      it 'returns unprocessable with a translated error' do
+        patch "/lex/verification/#{entry_no_auth.id}/confirm_work_match",
+              params: { work_id: work_no_auth.id, publication_id: publication.id },
+              headers: { 'Accept' => 'application/json' }
+
+        expect(response).to have_http_status(:unprocessable_content)
+        json = response.parsed_body
+        expect(json['success']).to be false
+        expect(json['error']).to eq(I18n.t('lexicon.verification.messages.person_no_authority'))
+      end
+    end
+
+    context 'when publication does not belong to the person\'s authority' do
+      let(:other_authority) { create(:authority) }
+      let!(:other_publication) { create(:publication, authority: other_authority, title: 'Foreign Book') }
+
+      it 'returns unprocessable with a translated error' do
+        patch "/lex/verification/#{entry.id}/confirm_work_match",
+              params: { work_id: work.id, publication_id: other_publication.id },
+              headers: { 'Accept' => 'application/json' }
+
+        expect(response).to have_http_status(:unprocessable_content)
+        json = response.parsed_body
+        expect(json['success']).to be false
+        expect(json['error']).to eq(I18n.t('lexicon.verification.messages.publication_not_in_authority'))
+      end
+    end
+
+    context 'when collection does not belong to the publication' do
+      let(:other_publication) { create(:publication, authority: authority, title: 'Other Book') }
+      let!(:other_collection) { create(:collection, publication: other_publication, title: 'Other Collection') }
+
+      it 'returns unprocessable with a translated error' do
+        patch "/lex/verification/#{entry.id}/confirm_work_match",
+              params: { work_id: work.id, publication_id: publication.id, collection_id: other_collection.id },
+              headers: { 'Accept' => 'application/json' }
+
+        expect(response).to have_http_status(:unprocessable_content)
+        json = response.parsed_body
+        expect(json['success']).to be false
+        expect(json['error']).to eq(I18n.t('lexicon.verification.messages.collection_not_in_publication'))
+      end
+    end
   end
 end

--- a/spec/requests/lexicon/verification_spec.rb
+++ b/spec/requests/lexicon/verification_spec.rb
@@ -429,7 +429,7 @@ RSpec.describe 'Lexicon::Verification', type: :request do
 
         json_response = response.parsed_body
         expect(json_response['success']).to be false
-        expect(json_response['error']).to eq('Attachment not found')
+        expect(json_response['error']).to eq(I18n.t('lexicon.verification.messages.attachment_not_found'))
       end
     end
 


### PR DESCRIPTION
## Summary

Audit and fix of raw English strings in the lexicon migration verification flow:

- **Queue table** (`index.html.haml`): replace `.demodulize` and `.humanize` with `t()` calls for type and status columns, reusing existing `filters.*` locale keys
- **Controller** (`verification_controller.rb`): replace 6 hardcoded English error strings with `I18n.t()`; fix source-file-not-found HTML to use the existing locale key; auto-correct pre-existing `:unprocessable_entity` → `:unprocessable_content` warnings
- **Works edit partial** (`_edit_works.html.haml`): JS `alert()` error messages now use an `i18n` object rendered from `t()` at page load
- **Locale files**: add `filters.verified` and 10 new `messages.*` keys in both `lexicon.en.yml` and `lexicon.he.yml`
- **Spec**: update hardcoded `'Attachment not found'` expectation to use `I18n.t()`

Also audited `show.html.haml`, `_person_sections.html.haml`, `_publication_sections.html.haml`, `_checklist.html.haml`, `_migrated_entry.html.haml` — all were already fully I18n'd. `EXTERNAL_IDENTIFIER_LABELS` (LC, VIAF, NLI, etc.) are proper-noun acronyms, unchanged.

## Test plan

- [x] `bundle exec rspec spec/requests/lexicon/verification_spec.rb` — 51 examples, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)