### PR TITLE
Treat J9U identifiers as NLI during legacy lexicon ingestion

### DIFF
--- a/app/helpers/lexicon_helper.rb
+++ b/app/helpers/lexicon_helper.rb
@@ -61,8 +61,7 @@ module LexiconHelper
     'viaf' => 'VIAF',
     'nli' => 'NLI',
     'wikidata' => 'Wikidata',
-    'openlibrary' => 'OpenLibrary',
-    'j9u' => 'J9U'
+    'openlibrary' => 'OpenLibrary'
   }.freeze
 
   def render_external_identifiers(external_identifiers)

--- a/app/services/lexicon/ingest_base.rb
+++ b/app/services/lexicon/ingest_base.rb
@@ -63,6 +63,9 @@ module Lexicon
         end
       end
 
+      # J9U is the new-generation NLI ID; prefer it over any legacy NLI value
+      identifiers['nli'] = identifiers.delete('j9u') if identifiers.key?('j9u')
+
       identifiers.presence # Return nil if empty, otherwise return the hash
     end
   end

--- a/config/locales/lexicon.en.yml
+++ b/config/locales/lexicon.en.yml
@@ -302,4 +302,3 @@ en:
           nli: NLI
           wikidata: Wikidata
           openlibrary: OpenLibrary
-          j9u: J9U

--- a/config/locales/lexicon.he.yml
+++ b/config/locales/lexicon.he.yml
@@ -303,4 +303,3 @@ he:
           nli: NLI
           wikidata: Wikidata
           openlibrary: OpenLibrary
-          j9u: J9U

--- a/spec/fixtures/files/lexicon/j9u_only.php
+++ b/spec/fixtures/files/lexicon/j9u_only.php
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>test person with j9u only identifier</title>
+</head>
+<body dir="rtl">
+<table border="0" width="100%">
+  <tr>
+    <td><p align="center"><font size="5" color="#FF0000">ישראלי, ישראל</font><font size="4" color="#FF0000">(1970)</font></p></td>
+  </tr>
+</table>
+<p>פרטים ביוגרפיים.</p>
+<p><font size="4" color="#0000FF"><a name="Books">ספריו:</a></font></p>
+<p>לא נמצאו ספרים.</p>
+<p><font size="4" color="#0000FF"><a name="Bib.">על המחבר ויצירתו:</a></font></p>
+<p>לא נמצאו מקורות.</p>
+<font size="4" color="#0000FF"><a name="links">קישורים:</a></font>
+<ul>
+</ul>
+<table>
+  <tr>
+    <td dir="ltr"><font size="2">J9U – <a target="_blank" href="http://uli.nli.org.il/F/?func=find-b&local_base=NLX10&find_code=UID&request=987007258174109999">987007258174109999</a></font></td>
+  </tr>
+</table>
+</body>
+</html>

--- a/spec/services/lexicon/ingest_person_spec.rb
+++ b/spec/services/lexicon/ingest_person_spec.rb
@@ -39,15 +39,37 @@ describe Lexicon::IngestPerson do
 
       expect(entry.english_title).to eq('Gabriela Avigur-Rotem')
 
-      # External identifiers
+      # External identifiers: J9U value overrides legacy NLI value, stored as nli
       expect(entry.external_identifiers).to include(
         'openlibrary' => 'OL4181279A',
         'wikidata' => 'Q12404844',
-        'j9u' => '987007258174105171',
-        'nli' => '000013455',
+        'nli' => '987007258174105171',
         'lc' => 'n82204318',
         'viaf' => '22255259'
       )
+      expect(entry.external_identifiers).not_to have_key('j9u')
+    end
+  end
+
+  context 'when only a J9U identifier is present (no legacy NLI)' do
+    let!(:file) do
+      create(
+        :lex_file,
+        {
+          entrytype: :person,
+          status: :classified,
+          title: 'Test J9U Person',
+          fname: 'j9u_only.php',
+          full_path: Rails.root.join('spec/fixtures/files/lexicon/j9u_only.php')
+        }
+      )
+    end
+
+    it 'stores the J9U value as nli' do
+      call
+      entry = file.lex_entry
+      expect(entry.external_identifiers).to eq('nli' => '987007258174109999')
+      expect(entry.external_identifiers).not_to have_key('j9u')
     end
   end
 


### PR DESCRIPTION
## Summary

- When a J9U identifier is present in a legacy lexicon PHP page, its value is now stored as `nli` (overriding any legacy NLI value on the same page)
- The `j9u` key is never written to `external_identifiers`
- J9U is the new-generation NLI catalog ID; the transition is complete, so these IDs should be recorded and displayed as NLI

## Details

In `extract_external_identifiers`, both J9U and NLI entries are still collected during the loop (order-independent). After the loop, if a J9U value was found, it replaces any NLI value and the `j9u` key is deleted. No display-layer changes were needed — the existing `nli` key already maps to the correct NLI URL and label.

## Test plan

- [ ] Re-ingest a legacy person page that has both J9U and NLI entries; verify only `nli` is stored and its value is the J9U ID
- [ ] Re-ingest a page with only J9U; verify it is stored as `nli`
- [ ] Re-ingest a page with only NLI; verify it is stored as `nli` unchanged