### PR TITLE
Bumped version of Sidekiq

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -123,3 +123,6 @@ FactoryBot/ExcessiveCreateList:
 
 FactoryBot/FactoryAssociationWithStrategy:
   Enabled: false
+
+Bundler/OrderedGems:
+  Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,7 @@ gem 'rails', '8.1.3'
 gem 'rails-i18n', '~> 8' # version should match major version of Rails
 gem 'sass-rails', '~> 6.0.0'
 gem 'sprockets', '~> 4.2.1'
+gem 'sidekiq', '~> 8.1'
 
 gem 'damerau-levenshtein' # string distance
 gem 'mysql2'
@@ -160,5 +161,3 @@ group :test, :development do
   gem 'capybara' # for integration tests
   gem 'selenium-webdriver' # For system tests with a browser driver like Chrome/Firefox
 end
-
-gem 'sidekiq', '~> 7.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -360,7 +360,7 @@ GEM
       character_set (~> 1.4)
       regexp_parser (~> 2.11)
       regexp_property_values (~> 1.0)
-    json (2.19.3)
+    json (2.19.5)
     jwt (3.1.2)
       base64
     kaminari (1.2.2)
@@ -615,7 +615,7 @@ GEM
       erb
       psych (>= 4.0.0)
       tsort
-    redis-client (0.26.1)
+    redis-client (0.28.0)
       connection_pool
     regexp_parser (2.11.3)
     regexp_property_values (1.5.2)
@@ -742,12 +742,12 @@ GEM
     sentry-ruby (6.2.0)
       bigdecimal
       concurrent-ruby (~> 1.0, >= 1.0.2)
-    sidekiq (7.3.9)
-      base64
-      connection_pool (>= 2.3.0)
-      logger
-      rack (>= 2.2.4)
-      redis-client (>= 0.22.2)
+    sidekiq (8.1.3)
+      connection_pool (>= 3.0.0)
+      json (>= 2.16.0)
+      logger (>= 1.7.0)
+      rack (>= 3.2.0)
+      redis-client (>= 0.26.0)
     simple_form (5.3.1)
       actionpack (>= 5.2)
       activemodel (>= 5.2)
@@ -932,7 +932,7 @@ DEPENDENCIES
   selenium-webdriver
   sentry-rails
   sentry-ruby
-  sidekiq (~> 7.2)
+  sidekiq (~> 8.1)
   simple_form (~> 5.3.0)
   simplecov
   spring (= 4.2.1)


### PR DESCRIPTION
After we've upgraded to Rails 8.1 Sidekiq displayed an error message during start.
As far as I see it worked normally, but I've upgraded Sidekiq to 8.1 and error message gone.