### PR TITLE
Move verification checklist into a modal

### DIFF
--- a/app/assets/javascripts/verification.js
+++ b/app/assets/javascripts/verification.js
@@ -200,7 +200,7 @@ function initVerification() {
         });
     });
 
-    // Handle checklist label clicks - scroll to section
+    // Handle checklist label clicks - close the checklist modal then scroll to section
     $('.checklist-items label').on('click', function(e) {
         // Only scroll if clicked on label text, not checkbox
         if ($(e.target).is('input[type="checkbox"]')) {
@@ -213,15 +213,28 @@ function initVerification() {
 
         if (sectionId) {
             const section = $('#' + sectionId);
-            if (section.length > 0) {
-                // Scroll to section
-                section[0].scrollIntoView({ behavior: 'smooth', block: 'start' });
+            if (section.length === 0) { return; }
 
-                // Flash highlight
+            const scrollToTarget = function() {
+                var scrollParent = section[0].closest('.migrated-content');
+                if (scrollParent) {
+                    var offset = section[0].getBoundingClientRect().top
+                               - scrollParent.getBoundingClientRect().top
+                               + scrollParent.scrollTop;
+                    scrollParent.scrollTop = Math.max(0, offset - 8);
+                } else {
+                    section[0].scrollIntoView({ behavior: 'smooth', block: 'start' });
+                }
                 section.addClass('highlight-flash');
-                setTimeout(function() {
-                    section.removeClass('highlight-flash');
-                }, 2000);
+                setTimeout(function() { section.removeClass('highlight-flash'); }, 2000);
+            };
+
+            const checklistModal = $('#checklistModal');
+            if (checklistModal.hasClass('show')) {
+                checklistModal.one('hidden.bs.modal', scrollToTarget);
+                checklistModal.modal('hide');
+            } else {
+                scrollToTarget();
             }
         }
     });

--- a/app/assets/stylesheets/verification.scss
+++ b/app/assets/stylesheets/verification.scss
@@ -27,35 +27,28 @@
 
 .verification-container {
   display: grid;
-  grid-template-columns: 280px 1fr 1fr;
+  grid-template-columns: 1fr 1fr;
   gap: 1.5rem;
   height: calc(100vh - 300px);
   max-height: calc(100vh - 300px);
 
-  @media (max-width: 1400px) {
-    grid-template-columns: 250px 1fr 1fr;
-  }
-
-  @media (max-width: 1200px) {
-    grid-template-columns: 1fr 1fr;
-    grid-template-rows: auto 1fr;
-
-    .verification-checklist {
-      grid-column: 1 / -1;
-      height: auto;
-    }
-  }
-
   @media (max-width: 768px) {
     grid-template-columns: 1fr;
-    grid-template-rows: auto auto auto;
+    grid-template-rows: auto auto;
   }
 }
 
-// Checklist Column
-.verification-checklist {
-  height: 100%;
+// Checklist Modal
+#checklistModal .modal-body {
   overflow-y: auto;
+  max-height: 70vh;
+}
+
+#checklistModal .checklist-card {
+  background: none;
+  border: none;
+  padding: 0;
+  border-radius: 0;
 }
 
 .checklist-card {
@@ -63,12 +56,6 @@
   padding: 1.5rem;
   border-radius: 8px;
   border: 1px solid #dee2e6;
-
-  .checklist-title {
-    margin-bottom: 1rem;
-    font-size: 1.1rem;
-    font-weight: 600;
-  }
 
   .checklist-items {
     list-style: none;
@@ -548,11 +535,6 @@
 
 // RTL Support
 [dir="rtl"] {
-  .verification-checklist ul li.nested-item {
-    padding-left: 0;
-    padding-right: 1.5rem;
-  }
-
   .verification-section .section-header {
     text-align: right;
   }

--- a/app/assets/stylesheets/verification.scss
+++ b/app/assets/stylesheets/verification.scss
@@ -535,6 +535,11 @@
 
 // RTL Support
 [dir="rtl"] {
+  .checklist-card .nested-checklist {
+    padding-left: 0;
+    padding-right: 1.5rem;
+  }
+
   .verification-section .section-header {
     text-align: right;
   }

--- a/app/views/lexicon/verification/_checklist.html.haml
+++ b/app/views/lexicon/verification/_checklist.html.haml
@@ -1,6 +1,4 @@
 .checklist-card
-  %h4.checklist-title= t('lexicon.verification.checklist.title')
-
   %ul.checklist-items
     - if item.is_a?(LexPerson)
       -# Authority

--- a/app/views/lexicon/verification/show.html.haml
+++ b/app/views/lexicon/verification/show.html.haml
@@ -46,6 +46,8 @@
           %label.form-check-label{for: 'hide-verified-toggle'}
             = t('lexicon.verification.show.hide_verified')
       .actions
+        %button.btn.btn-outline-secondary{ type: 'button', data: { toggle: 'modal', target: '#checklistModal' } }
+          = t('lexicon.verification.checklist.title')
         - if @entry.verification_complete?
           = button_to t('lexicon.verification.show.mark_verified'), lexicon_mark_verified_verification_path(@entry), method: :post, class: 'btn btn-success', id: 'mark-verified-btn'
         - else
@@ -77,9 +79,6 @@
                      'link-check-toast-type': flash[:link_check_toast_type],
                      'link-check-toast-message': flash[:link_check_toast_message] }
 .verification-container{ data: container_data }
-  .verification-checklist
-    = render 'lexicon/verification/checklist', entry: @entry, checklist: @checklist, item: @item
-
   .verification-source
     = render 'lexicon/verification/source_php', entry: @entry
 
@@ -87,3 +86,13 @@
     = render 'lexicon/verification/migrated_entry', entry: @entry, item: @item, checklist: @checklist, php_counts: @php_counts
 
 #modal-container
+
+.modal#checklistModal{ tabindex: '-1', role: 'dialog', data: { keyboard: 'true', backdrop: 'true' } }
+  .modal-dialog.modal-lg{ role: 'document' }
+    .modal-content
+      .modal-header
+        %h5.modal-title= t('lexicon.verification.checklist.title')
+        %button.close{ type: :button, data: { dismiss: :modal }, aria: { label: t(:close) } }
+          %span{ aria: { hidden: true } } &times;
+      .modal-body
+        = render 'lexicon/verification/checklist', entry: @entry, checklist: @checklist, item: @item

--- a/app/views/lexicon/verification/show.html.haml
+++ b/app/views/lexicon/verification/show.html.haml
@@ -87,11 +87,11 @@
 
 #modal-container
 
-.modal#checklistModal{ tabindex: '-1', role: 'dialog', data: { keyboard: 'true', backdrop: 'true' } }
+.modal#checklistModal{ tabindex: '-1', role: 'dialog', aria: { hidden: true, labelledby: 'checklistModalTitle' }, data: { keyboard: 'true', backdrop: 'true' } }
   .modal-dialog.modal-lg{ role: 'document' }
     .modal-content
       .modal-header
-        %h5.modal-title= t('lexicon.verification.checklist.title')
+        %h5.modal-title{ id: 'checklistModalTitle' }= t('lexicon.verification.checklist.title')
         %button.close{ type: :button, data: { dismiss: :modal }, aria: { label: t(:close) } }
           %span{ aria: { hidden: true } } &times;
       .modal-body

--- a/app/views/lexicon/verification/show.html.haml
+++ b/app/views/lexicon/verification/show.html.haml
@@ -87,11 +87,13 @@
 
 #modal-container
 
-.modal#checklistModal{ tabindex: '-1', role: 'dialog', aria: { hidden: true, labelledby: 'checklistModalTitle' }, data: { keyboard: 'true', backdrop: 'true' } }
+.modal#checklistModal{ tabindex: '-1', role: 'dialog',
+                       aria: { hidden: true, labelledby: 'checklistModalTitle' },
+                       data: { keyboard: 'true', backdrop: 'true' } }
   .modal-dialog.modal-lg{ role: 'document' }
     .modal-content
       .modal-header
-        %h5.modal-title{ id: 'checklistModalTitle' }= t('lexicon.verification.checklist.title')
+        %h5.modal-title#checklistModalTitle= t('lexicon.verification.checklist.title')
         %button.close{ type: :button, data: { dismiss: :modal }, aria: { label: t(:close) } }
           %span{ aria: { hidden: true } } &times;
       .modal-body


### PR DESCRIPTION
## Summary

- The checklist pane (previously a fixed 280px right-side column in RTL layout) is removed from the 3-column grid
- A **"Verification Checklist"** button in the header actions opens it as a Bootstrap modal on demand
- The two remaining panes (legacy PHP source and migrated entry) now share equal `1fr 1fr` width — roughly doubling the space available to each
- Clicking a checklist label to jump to a section closes the modal first, then scrolls the migrated-content pane to the target section with a highlight flash

Note: checklist checkboxes are **read-only** (rendered with `disabled: true`). Progress is updated by the per-section "Mark as Verified" actions in the migrated entry pane, not by ticking the checklist directly.

## Files changed

| File | Change |
|------|--------|
| `show.html.haml` | Added checklist button; removed `.verification-checklist` from grid; added `#checklistModal` with aria attributes |
| `_checklist.html.haml` | Removed internal `h4` title (modal header provides it) |
| `verification.scss` | Grid `280px 1fr 1fr` → `1fr 1fr`; removed checklist column styles; added modal overrides; restored RTL nested-checklist padding |
| `verification.js` | Label click handler closes modal before scrolling to section |

## Test plan

- [ ] Open a verification entry — two equal-width panes fill the screen
- [ ] Click the "Verification Checklist" button — modal opens with read-only checklist items and overall notes textarea
- [ ] Checklist checkboxes reflect verified state but cannot be toggled directly
- [ ] Click a checklist label — modal closes, migrated pane scrolls to the section and flashes
- [ ] Overall notes textarea blurs — auto-save fires (toast appears)
- [ ] Escape key / click outside modal — modal closes
- [ ] RTL: nested checklist items (citations, links) indent to the right inside the modal
- [ ] Mobile width (≤768px) — two panes stack vertically

🤖 Generated with [Claude Code](https://claude.com/claude-code)