### PR TITLE
Collapse verified status into published for LexEntries

### DIFF
--- a/app/controllers/lexicon/verification_controller.rb
+++ b/app/controllers/lexicon/verification_controller.rb
@@ -30,7 +30,7 @@ module Lexicon
     # GET /lexicon/verification/:id
     def show
       # Initialize verification if not started
-      unless @entry.status_verifying? || @entry.status_verified? || @entry.status_escalated?
+      unless @entry.status_verifying? || @entry.status_verified? || @entry.status_escalated? || @entry.status_published?
         user_email = current_user&.email || 'anonymous@example.com'
         @entry.start_verification!(user_email)
       end

--- a/app/models/lex_entry.rb
+++ b/app/models/lex_entry.rb
@@ -39,7 +39,6 @@ class LexEntry < ApplicationRecord
   # Scopes for verification queue
   scope :needs_verification, -> { where(status: %i(draft verifying error escalated)) }
   scope :in_verification, -> { where(status: :verifying) }
-  scope :verified_pending_publish, -> { where(status: :verified) }
 
   update_index('lex_entries') { self }
   update_index('lex_entries_autocomplete') { self }
@@ -152,7 +151,7 @@ class LexEntry < ApplicationRecord
     raise 'Verification not complete' unless verification_complete?
 
     updates = {
-      status: :verified,
+      status: :published,
       verification_progress: verification_progress.merge(
         'ready_for_publish' => true,
         'completed_at' => Time.current.iso8601

--- a/db/migrate/20260517172942_migrate_verified_entries_to_published.rb
+++ b/db/migrate/20260517172942_migrate_verified_entries_to_published.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+# Verified status (105) has no distinct meaning from published (1); collapse them.
+class MigrateVerifiedEntriesToPublished < ActiveRecord::Migration[8.1]
+  def up
+    execute 'UPDATE lex_entries SET status = 1 WHERE status = 105'
+  end
+
+  def down
+    # Cannot reliably restore the original verified status after collapsing to published.
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_04_080857) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_17_172942) do
   create_table "aboutnesses", id: :integer, charset: "utf8mb4", collation: "utf8mb4_bin", force: :cascade do |t|
     t.integer "aboutable_id"
     t.string "aboutable_type"

--- a/spec/models/lex_entry_spec.rb
+++ b/spec/models/lex_entry_spec.rb
@@ -355,9 +355,9 @@ RSpec.describe LexEntry, type: :model do
         expect(entry.reload.other_designation).to eq('שם א; שם ב')
       end
 
-      it 'sets status to verified' do
+      it 'sets status to published' do
         entry.mark_verified!
-        expect(entry.reload).to be_status_verified
+        expect(entry.reload).to be_status_published
       end
     end
 


### PR DESCRIPTION
## Summary

- `mark_verified!` now sets `status: :published` directly instead of `:verified`, so verified entries are immediately visible in the reader view and Elasticsearch index
- Added a DB migration to update any existing `verified` (105) entries to `published` (1)
- Guard in `VerificationController#show` now also allows `published` entries so opening the workbench after verification doesn't reset the entry back to `verifying`
- Removed the now-unused `verified_pending_publish` scope
- Updated the corresponding spec

The `verified: 105` enum value is retained for backward compatibility (the migration handles all existing rows), and can be cleaned up in a future PR once we confirm no residual rows exist.

## Test plan

- [ ] `bundle exec rspec spec/models/lex_entry_spec.rb spec/requests/lexicon/verification_spec.rb` — 61 examples, 0 failures
- [ ] Manually verify: after clicking "Mark as Verified" on an entry with 100% checklist, the entry status shows as published and it appears in the public lexicon index

🤖 Generated with [Claude Code](https://claude.com/claude-code)