### PR TITLE
Add UI to remove a Collection's cover image

### DIFF
--- a/app/controllers/collections_controller.rb
+++ b/app/controllers/collections_controller.rb
@@ -297,6 +297,12 @@ class CollectionsController < ApplicationController
     render plain: e.message, status: :unprocessable_content
   end
 
+  def remove_cover_image
+    @collection = Collection.find(params[:collection_id])
+    @collection.cover_image.purge
+    redirect_back fallback_location: collection_manage_path(@collection), notice: t(:updated_successfully)
+  end
+
   # Display KWIC concordance browser for a collection
   def kwic
     @collection = Collection.find(params[:collection_id])

--- a/app/views/shared/_manage_collection.html.haml
+++ b/app/views/shared/_manage_collection.html.haml
@@ -49,6 +49,9 @@
       %p
         %img{ src: url_for(collection.cover_image), alt: collection.title,
               style: 'max-width: 300px; max-height: 300px;' }
+      = button_to t(:remove_cover_image), collection_remove_cover_image_path(collection),
+                  method: :post, class: 'by-button-v02',
+                  data: { confirm: t(:are_you_sure) }
     = form_for collection, url: collection_path(collection.id), namespace: "cover_#{collection.id}", method: :put, multipart: true do |f|
       .form-group
         = f.file_field :cover_image, class: 'form-control', accept: 'image/*'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -69,6 +69,7 @@ en:
   cover_image: Cover Image
   cover_text: Cover Text
   upload_cover_image: Upload Cover Image
+  remove_cover_image: Remove Cover Image
   issue_covers: Issue Covers
   add_feature_date: Add feature date
   feature_on: Featuring Periods

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -1225,6 +1225,7 @@ he:
   cover_image: תמונת שער
   cover_text: כיתוב תמונת שער
   upload_cover_image: העלאת תמונת שער
+  remove_cover_image: הסרת תמונת שער
   issue_covers: שערי גיליונות
   link_description: "תיאור הקישורית, או מה ייכתב אחרי 'מוגש באדיבות:'"
   "BY blog": 'התייחסויות ביומן הרשת של פב"י'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -110,6 +110,7 @@ Bybeconv::Application.routes.draw do
     post 'add_periodical_issue'
     post 'add_external_link'
     post 'remove_external_link'
+    post 'remove_cover_image'
   end
 
   # Not inside resources block because it doesn't require a collection_id (creates new periodical)

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_11_020041) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_22_215030) do
   create_table "aboutnesses", id: :integer, charset: "utf8mb4", collation: "utf8mb4_bin", force: :cascade do |t|
     t.integer "aboutable_id"
     t.string "aboutable_type"

--- a/spec/controllers/collections_controller_spec.rb
+++ b/spec/controllers/collections_controller_spec.rb
@@ -567,6 +567,29 @@ describe CollectionsController do
     end
   end
 
+  describe '#remove_cover_image' do
+    include_context 'when editor logged in'
+
+    let(:collection_with_cover) do
+      create(:collection).tap do |c|
+        c.cover_image.attach(io: StringIO.new(Rails.root.join('spec/fixtures/files/test_image.jpg').binread),
+                             filename: 'cover.jpg', content_type: 'image/jpeg')
+      end
+    end
+
+    it 'purges the cover image and redirects back' do
+      post :remove_cover_image, params: { collection_id: collection_with_cover.id }
+      expect(collection_with_cover.reload.cover_image).not_to be_attached
+      expect(response).to redirect_to(collection_manage_path(collection_with_cover))
+    end
+
+    it 'is a no-op when no cover image is attached' do
+      collection = create(:collection)
+      post :remove_cover_image, params: { collection_id: collection.id }
+      expect(response).to redirect_to(collection_manage_path(collection))
+    end
+  end
+
   describe 'cover image and cover_text' do
     let(:editor_user) { create(:user, :edit_catalog) }
 


### PR DESCRIPTION
## Summary
- Adds a **Remove Cover Image** button in the collection manage view, shown only when a cover image is attached
- Adds `POST /collections/:id/remove_cover_image` route and controller action that purges the attachment
- Adds `remove_cover_image` I18n keys in English and Hebrew
- Adds controller specs covering both the happy path and the no-op case

## Test plan
- [ ] Open collection manage page for a collection with a cover image — verify "Remove Cover Image" button appears
- [ ] Click the button, confirm the confirmation dialog, verify image is removed and the button disappears
- [ ] Verify the upload form still works after removal (replace image)
- [ ] Open manage page for a collection without a cover image — verify no remove button shown
- [ ] `bundle exec rspec spec/controllers/collections_controller_spec.rb -e "remove_cover_image"` — 2 examples, 0 failures

Closes by-gyd

🤖 Generated with [Claude Code](https://claude.com/claude-code)