### PR TITLE
Smtp emails and domain name settings

### DIFF
--- a/.env
+++ b/.env
@@ -6,6 +6,8 @@ REDIS_URL=redis://127.0.0.1:16379
 # You can toggle it by running command `rails dev:cache` or `rails test:cache`
 MEMCACHE_SERVERS=127.0.0.1:21211
 
+APP_HOSTNAME=benyehuda.org
+
 S3_BUCKET=bybeprod
 S3_REGION=us-east-1
 AWS_ACCESS_KEY_ID=sample-access-key-id

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -96,13 +96,9 @@ Rails.application.configure do
   # Skip DNS rebinding protection for the default health check endpoint.
   # config.host_authorization = { exclude: ->(request) { request.path == "/up" } }
 
-  pwd = `pwd`
-  if pwd =~ /staging/
-    routes.default_url_options[:host] = 'staging.benyehuda.org'
-    config.action_mailer.default_url_options = { host: 'staging.benyehuda.org' }
-  else
-    routes.default_url_options[:host] = 'benyehuda.org'
-    config.action_mailer.default_url_options = { host: 'benyehuda.org' }
-  end
-  routes.default_url_options[:protocol] = 'https'
+  routes.default_url_options = {
+    host: ENV.fetch('APP_HOSTNAME', 'benyehuda.org'),
+    protocol: 'https'
+  }
+  config.action_mailer.default_url_options = { host: ENV.fetch('APP_HOSTNAME', 'benyehuda.org') }
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -34,7 +34,6 @@ Rails.application.configure do
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   config.force_ssl = true
 
-  config.action_mailer.delivery_method = :sendmail # let's start sending mail :)
   config.i18n.available_locales = :he # to not load other locales in memory
 
   # Store Active Storage files on the S3 service
@@ -96,9 +95,6 @@ Rails.application.configure do
   # Skip DNS rebinding protection for the default health check endpoint.
   # config.host_authorization = { exclude: ->(request) { request.path == "/up" } }
 
-  routes.default_url_options = {
-    host: ENV.fetch('APP_HOSTNAME', 'benyehuda.org'),
-    protocol: 'https'
-  }
-  config.action_mailer.default_url_options = { host: ENV.fetch('APP_HOSTNAME', 'benyehuda.org') }
+  routes.default_url_options = { host: SiteConstants::APP_HOSTNAME, protocol: 'https' }
+  config.action_mailer.default_url_options = { host: SiteConstants::APP_HOSTNAME }
 end

--- a/config/initializers/mail.rb
+++ b/config/initializers/mail.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+if Rails.env.production?
+  ActionMailer::Base.smtp_settings = {
+    address: 'smtp-relay.gmail.com',
+    domain: SiteConstants::APP_HOSTNAME
+  }
+end

--- a/lib/site_constants.rb
+++ b/lib/site_constants.rb
@@ -7,6 +7,8 @@ module SiteConstants
   TAGGING_POLICY_URL = 'https://benyehuda.org/page/tagging'
   YOUTUBE_CHANNEL_ID = 'UClsusG2EWu45WZ-yNJsdFAw' # Ben-Yehuda YouTube channel ID
 
+  APP_HOSTNAME = ENV.fetch('APP_HOSTNAME', 'benyehuda.org')
+
   TASK_SYSTEM_HOST = ENV.fetch('TASK_SYSTEM_HOST')
   TASK_SYSTEM_PORT = Integer(ENV.fetch('TASK_SYSTEM_PORT'))
   TASK_SYSTEM_URL = "#{TASK_SYSTEM_PORT == 443 ? 'https' : 'http'}://#{TASK_SYSTEM_HOST}" \


### PR DESCRIPTION
This PR targets two issues:

1. In production.rb env file we had a hardcoded logic for setting default hostname to routes and mailer, based on folder name.
This logic will definetely not work with Docker so I've extracted it to ENV variable APP_HOSTNAME (defaults to benyehuda.org)

2. I've configured it to use SMTP relay service by Gmail for sending emails instead of our postfix 