### PR TITLE
Handle invalid POST to CollectionItemsController gracefully

### DIFF
--- a/app/controllers/collection_items_controller.rb
+++ b/app/controllers/collection_items_controller.rb
@@ -31,10 +31,15 @@ class CollectionItemsController < ApplicationController
           @collection_item.item_id = nil
           @collection_item.item_type = nil
         else
-          c = Collection.create!(title: params[:collection_item][:alt_title],
-                                 collection_type: params[:collection_item][:item_type])
-          @collection_item.item = c # this overrides the passed item_type which is actually collection_type
-          @collection_item.alt_title = nil
+          c = Collection.new(title: params[:collection_item][:alt_title],
+                             collection_type: params[:collection_item][:item_type])
+          if c.save
+            @collection_item.item = c # this overrides the passed item_type which is actually collection_type
+            @collection_item.alt_title = nil
+          else
+            c.errors.each { |e| @collection_item.errors.import(e) }
+            success = false
+          end
         end
       else
         success = false
@@ -57,6 +62,7 @@ class CollectionItemsController < ApplicationController
         format.js
       else
         format.html { render :new, status: :unprocessable_content }
+        format.js { head :unprocessable_content }
         format.json { render json: @collection_item.errors, status: :unprocessable_content }
       end
     end

--- a/spec/controllers/collection_items_controller_spec.rb
+++ b/spec/controllers/collection_items_controller_spec.rb
@@ -5,6 +5,32 @@ require 'rails_helper'
 describe CollectionItemsController do
   include_context 'when editor logged in'
 
+  describe '#create' do
+    let!(:collection) { create(:collection) }
+
+    context 'when creating a sub-collection with a blank title' do
+      subject(:call) do
+        post :create, format: :js, params: {
+          collection_item: {
+            collection_id: collection.id,
+            item_id: '',
+            item_type: 'volume',
+            alt_title: ''
+          }
+        }
+      end
+
+      it 'returns unprocessable_content instead of raising an exception' do
+        expect { call }.not_to raise_error
+        expect(response).to have_http_status(:unprocessable_content)
+      end
+
+      it 'does not create a new Collection' do
+        expect { call }.not_to change(Collection, :count)
+      end
+    end
+  end
+
   describe '#drag_item' do
     subject(:call) do
       post :drag_item, params: {


### PR DESCRIPTION
## Summary

- `Collection.create!` on the sub-collection creation path raised `ActiveRecord::RecordInvalid` (e.g. blank title) instead of returning a 422, crashing the controller
- Replaced with `Collection.new` + `save`, importing any validation errors onto `@collection_item` so the existing `success = false` path handles the response
- Added `format.js { head :unprocessable_content }` to the failure branch — the AJAX calls use `dataType: "script"`, so JS format requests were also crashing with `ActionController::UnknownFormat` on invalid input

## Test plan

- [x] New controller spec: `CollectionItemsController#create when creating a sub-collection with a blank title` — covers both the no-crash and no-Collection-created assertions
- [x] All 15 existing controller spec examples still pass
- [x] `bundle exec rspec spec/controllers/collection_items_controller_spec.rb` — green

🤖 Generated with [Claude Code](https://claude.com/claude-code)