### PR TITLE
Show citation notes in verification view and edit form

### DIFF
--- a/app/views/lexicon/citations/_form.html.haml
+++ b/app/views/lexicon/citations/_form.html.haml
@@ -11,6 +11,7 @@
   = f.input :from_publication
   = f.input :pages
   = f.input :link
+  = f.input :notes
   = f.submit t(:save)
 %hr
 

--- a/app/views/lexicon/verification/_person_sections.html.haml
+++ b/app/views/lexicon/verification/_person_sections.html.haml
@@ -221,6 +221,9 @@
                   %span.text-muted
                     = t('lexicon.verification.sections.citation_pages')
                     = citation.pages
+                - if citation.notes.present?
+                  %br
+                  %span.text-muted= citation.notes
                 - if citation.link.present?
                   %br
                   - if citation.link_broken?

--- a/config/locales/active_record.en.yml
+++ b/config/locales/active_record.en.yml
@@ -126,6 +126,7 @@ en:
       lex_citation:
         authors: Authors
         from_publication: From Publication
+        notes: Context notes
         pages: Pages
         person_work: Work
       lex_file:

--- a/config/locales/active_record.he.yml
+++ b/config/locales/active_record.he.yml
@@ -132,6 +132,7 @@ he:
       lex_citation:
         authors: מחברים
         from_publication: מתוך החיבור
+        notes: הקשר והערות
         pages: עמודים
         person_work: חיבור
       lex_file:


### PR DESCRIPTION
## Summary

- Display `LexCitation#notes` in the verification view citation cards (shown as muted text, between pages and the link)
- Add `notes` input to the citation edit form so it can be manually corrected
- Add I18n labels for the `notes` attribute on `LexCitation`: "Context notes" (EN) / "הקשר והערות" (HE)

## Background

During PHP migration, angled-bracket context at the end of citation lines (e.g. `<תגובה לסדרת מאמריו של דן מירון – להלן>`) is captured by the LLM parser and stored in `LexCitation#notes`. However, this field was never displayed anywhere, making it appear as though the context was not migrated at all.

## Test plan

- [ ] Open a lexicon entry in verification view that has citations with context notes (e.g. entry for 01730.php / אסף ענברי, citation "נקמה אישית, סילוף עובדות ועיוותים מגמתיים")
- [ ] Confirm notes text "תגובה לסדרת מאמריו של דן מירון – להלן; ענה על כך דן מירון – להלן" now appears in the citation card
- [ ] Open the citation edit modal and confirm a "הקשר והערות" field is present and editable

🤖 Generated with [Claude Code](https://claude.com/claude-code)