### PR TITLE
Add export_catalog rake task for JSON catalog dump

### DIFF
--- a/lib/tasks/export_catalog.rake
+++ b/lib/tasks/export_catalog.rake
@@ -14,10 +14,12 @@ module ExportCatalogHelpers
     result
   end
 
-  def serialize_manifestation(manifestation)
+  def serialize_manifestation(manifestation, url_helpers)
     lang = manifestation.expression.work.orig_lang
     entry = {
       type: 'manifestation',
+      id: manifestation.id,
+      url: url_helpers.manifestation_url(manifestation),
       title: manifestation.title,
       authorities: authorities_by_role(manifestation),
       tags: manifestation.tags.map(&:name)
@@ -52,7 +54,7 @@ module ExportCatalogHelpers
       next if ci.item.nil?
 
       if ci.item_type == 'Manifestation'
-        items << serialize_manifestation(ci.item)
+        items << serialize_manifestation(ci.item, url_helpers)
       else
         next if visited_ids.include?(ci.item_id)
 

--- a/lib/tasks/export_catalog.rake
+++ b/lib/tasks/export_catalog.rake
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+require 'json'
+
+# rubocop:disable Style/Documentation
+module ExportCatalogHelpers
+  # rubocop:enable Style/Documentation
+  def authorities_by_role(record)
+    result = {}
+    InvolvedAuthority.roles.each_key do |role|
+      auths = record.involved_authorities_by_role(role)
+      result[role] = auths.map(&:name) unless auths.empty?
+    end
+    result
+  end
+
+  def serialize_manifestation(manifestation)
+    lang = manifestation.expression.work.orig_lang
+    entry = {
+      type: 'manifestation',
+      title: manifestation.title,
+      authorities: authorities_by_role(manifestation),
+      tags: manifestation.tags.map(&:name)
+    }
+    alts = manifestation.alternate_titles.presence&.split('; ')&.reject(&:empty?) || []
+    entry[:alternate_titles] = alts unless alts.empty?
+    entry[:original_language] = lang unless lang.blank? || lang == 'he'
+    entry
+  end
+
+  def serialize_collection(collection, url_helpers, visited_ids)
+    entry = {
+      type: 'collection',
+      id: collection.id,
+      url: url_helpers.collection_url(collection),
+      title: collection.title,
+      authorities: authorities_by_role(collection),
+      tags: collection.tags.map(&:name),
+      contents: serialize_contents(collection.collection_items, url_helpers, visited_ids)
+    }
+    entry[:subtitle] = collection.subtitle if collection.subtitle.present?
+    alts = collection.alternate_titles.presence&.split('; ')&.reject(&:empty?) || []
+    entry[:alternate_titles] = alts unless alts.empty?
+    entry[:publisher_line] = collection.publisher_line if collection.publisher_line.present?
+    entry
+  end
+
+  def serialize_contents(collection_items, url_helpers, visited_ids)
+    items = []
+    collection_items.each do |ci|
+      next unless ci.item_type.in?(%w(Manifestation Collection))
+      next if ci.item.nil?
+
+      if ci.item_type == 'Manifestation'
+        items << serialize_manifestation(ci.item)
+      else
+        next if visited_ids.include?(ci.item_id)
+
+        items << serialize_collection(ci.item, url_helpers, visited_ids + [ci.item_id])
+      end
+    end
+    items
+  end
+end
+
+desc 'Export catalog as JSON. Default: first 50 qualifying collections. Pass --all to export everything.'
+task export_catalog: :environment do
+  extend ExportCatalogHelpers
+
+  all_mode = ARGV.include?('--all')
+  limit = 50
+  output_file = 'catalog_export.json'
+  mode_label = all_mode ? 'all collections' : "first #{limit} qualifying collections"
+
+  puts "Mode: #{mode_label}"
+
+  url_helpers = Rails.application.routes.url_helpers
+
+  qualifying = []
+  Collection.where(collection_type: %i(volume periodical_issue)).find_each do |collection|
+    next unless collection.any_published_manifestations?
+
+    qualifying << serialize_collection(collection, url_helpers, [collection.id])
+    if !all_mode && qualifying.size >= limit
+      puts "Reached limit of #{limit}. Pass --all to export everything."
+      break
+    end
+  end
+
+  output = {
+    mode: mode_label,
+    count: qualifying.size,
+    collections: qualifying
+  }
+
+  File.write(output_file, JSON.pretty_generate(output))
+  puts "Exported #{qualifying.size} collections to #{output_file}"
+end

--- a/lib/tasks/export_catalog.rake
+++ b/lib/tasks/export_catalog.rake
@@ -1,10 +1,13 @@
 # frozen_string_literal: true
 
 require 'json'
+require 'bybe_utils'
 
 # rubocop:disable Style/Documentation
 module ExportCatalogHelpers
   # rubocop:enable Style/Documentation
+  include BybeUtils
+
   def authorities_by_role(record)
     result = {}
     InvolvedAuthority.roles.each_key do |role|
@@ -26,7 +29,7 @@ module ExportCatalogHelpers
     }
     alts = manifestation.alternate_titles.presence&.split('; ')&.reject(&:empty?) || []
     entry[:alternate_titles] = alts unless alts.empty?
-    entry[:original_language] = lang unless lang.blank? || lang == 'he'
+    entry[:original_language] = textify_lang(lang) unless lang.blank? || lang == 'he'
     entry
   end
 

--- a/lib/tasks/export_catalog.rake
+++ b/lib/tasks/export_catalog.rake
@@ -8,13 +8,23 @@ module ExportCatalogHelpers
   # rubocop:enable Style/Documentation
   include BybeUtils
 
+  def approved_tag_names(taggable)
+    taggable.taggings.to_a.select { |t| t.approved? && t.tag.approved? }.map { |t| t.tag.name }
+  end
+
   def authorities_by_role(record)
     result = {}
     InvolvedAuthority.roles.each_key do |role|
       auths = record.involved_authorities_by_role(role)
-      result[role] = auths.map(&:name) unless auths.empty?
+      result[role] = auths.map(&:name).sort unless auths.empty?
     end
     result
+  end
+
+  def split_alternate_titles(raw)
+    return [] if raw.blank?
+
+    raw.split(';').map(&:strip).compact_blank
   end
 
   def serialize_manifestation(manifestation, url_helpers)
@@ -25,9 +35,9 @@ module ExportCatalogHelpers
       url: url_helpers.manifestation_url(manifestation),
       title: manifestation.title,
       authorities: authorities_by_role(manifestation),
-      tags: manifestation.tags.map(&:name)
+      tags: approved_tag_names(manifestation)
     }
-    alts = manifestation.alternate_titles.presence&.split('; ')&.reject(&:empty?) || []
+    alts = split_alternate_titles(manifestation.alternate_titles)
     entry[:alternate_titles] = alts unless alts.empty?
     entry[:original_language] = textify_lang(lang) unless lang.blank? || lang == 'he'
     entry
@@ -40,11 +50,11 @@ module ExportCatalogHelpers
       url: url_helpers.collection_url(collection),
       title: collection.title,
       authorities: authorities_by_role(collection),
-      tags: collection.tags.map(&:name),
+      tags: approved_tag_names(collection),
       contents: serialize_contents(collection.collection_items, url_helpers, visited_ids)
     }
     entry[:subtitle] = collection.subtitle if collection.subtitle.present?
-    alts = collection.alternate_titles.presence&.split('; ')&.reject(&:empty?) || []
+    alts = split_alternate_titles(collection.alternate_titles)
     entry[:alternate_titles] = alts unless alts.empty?
     entry[:publisher_line] = collection.publisher_line if collection.publisher_line.present?
     entry
@@ -74,31 +84,37 @@ task export_catalog: :environment do
 
   all_mode = ARGV.include?('--all')
   limit = 50
-  output_file = 'catalog_export.json'
+  output_file = ENV.fetch('EXPORT_CATALOG_OUTPUT', 'catalog_export.json')
   mode_label = all_mode ? 'all collections' : "first #{limit} qualifying collections"
 
   puts "Mode: #{mode_label}"
 
   url_helpers = Rails.application.routes.url_helpers
+  count = 0
 
-  qualifying = []
-  Collection.where(collection_type: %i(volume periodical_issue)).find_each do |collection|
-    next unless collection.any_published_manifestations?
+  File.open(output_file, 'w') do |f|
+    f.write("{\n  \"mode\": #{JSON.generate(mode_label)},\n  \"collections\": [\n")
+    first = true
 
-    qualifying << serialize_collection(collection, url_helpers, [collection.id])
-    print "#{qualifying.size} " if (qualifying.size % 50).zero?
-    if !all_mode && qualifying.size >= limit
+    Collection.where(collection_type: %i(volume periodical_issue)).find_each do |collection|
+      next unless collection.any_published_manifestations?
+
+      serialized = serialize_collection(collection, url_helpers, [collection.id])
+      f.write(",\n") unless first
+      first = false
+      f.write(JSON.pretty_generate(serialized).split("\n").map { |l| "    #{l}" }.join("\n"))
+      count += 1
+      print "#{count} " if (count % 50).zero?
+
+      next if all_mode
+      next unless count >= limit
+
       puts "\nReached limit of #{limit}. Pass --all to export everything."
       break
     end
+
+    f.write("\n  ],\n  \"count\": #{count}\n}\n")
   end
 
-  output = {
-    mode: mode_label,
-    count: qualifying.size,
-    collections: qualifying
-  }
-
-  File.write(output_file, JSON.pretty_generate(output))
-  puts "Exported #{qualifying.size} collections to #{output_file}"
+  puts "Exported #{count} collections to #{output_file}"
 end

--- a/lib/tasks/export_catalog.rake
+++ b/lib/tasks/export_catalog.rake
@@ -9,7 +9,7 @@ module ExportCatalogHelpers
   include BybeUtils
 
   def approved_tag_names(taggable)
-    taggable.taggings.to_a.select { |t| t.approved? && t.tag.approved? }.map { |t| t.tag.name }
+    taggable.taggings.preload(:tag).select(&:approved?).select { |t| t.tag.approved? }.map { |t| t.tag.name }
   end
 
   def authorities_by_role(record)
@@ -83,7 +83,7 @@ task export_catalog: :environment do
   extend ExportCatalogHelpers
 
   all_mode = ARGV.include?('--all')
-  limit = 50
+  limit = ENV.fetch('EXPORT_CATALOG_LIMIT', '50').to_i
   output_file = ENV.fetch('EXPORT_CATALOG_OUTPUT', 'catalog_export.json')
   mode_label = all_mode ? 'all collections' : "first #{limit} qualifying collections"
 
@@ -92,26 +92,29 @@ task export_catalog: :environment do
   url_helpers = Rails.application.routes.url_helpers
   count = 0
 
-  File.open(output_file, 'w') do |f|
+  File.open(output_file, 'w:UTF-8') do |f|
     f.write("{\n  \"mode\": #{JSON.generate(mode_label)},\n  \"collections\": [\n")
     first = true
 
-    Collection.where(collection_type: %i(volume periodical_issue)).find_each do |collection|
-      next unless collection.any_published_manifestations?
+    Collection
+      .where(collection_type: %i(volume periodical_issue))
+      .preload({ taggings: :tag }, { involved_authorities: :authority })
+      .find_each do |collection|
+        next unless collection.any_published_manifestations?
 
-      serialized = serialize_collection(collection, url_helpers, [collection.id])
-      f.write(",\n") unless first
-      first = false
-      f.write(JSON.pretty_generate(serialized).split("\n").map { |l| "    #{l}" }.join("\n"))
-      count += 1
-      print "#{count} " if (count % 50).zero?
+        serialized = serialize_collection(collection, url_helpers, [collection.id])
+        f.write(",\n") unless first
+        first = false
+        f.write(JSON.pretty_generate(serialized).split("\n").map { |l| "    #{l}" }.join("\n"))
+        count += 1
+        print "#{count} " if (count % 50).zero?
 
-      next if all_mode
-      next unless count >= limit
+        next if all_mode
+        next unless count >= limit
 
-      puts "\nReached limit of #{limit}. Pass --all to export everything."
-      break
-    end
+        puts "\nReached limit of #{limit}. Pass --all to export everything."
+        break
+      end
 
     f.write("\n  ],\n  \"count\": #{count}\n}\n")
   end

--- a/lib/tasks/export_catalog.rake
+++ b/lib/tasks/export_catalog.rake
@@ -86,8 +86,9 @@ task export_catalog: :environment do
     next unless collection.any_published_manifestations?
 
     qualifying << serialize_collection(collection, url_helpers, [collection.id])
+    print "#{qualifying.size} " if (qualifying.size % 50).zero?
     if !all_mode && qualifying.size >= limit
-      puts "Reached limit of #{limit}. Pass --all to export everything."
+      puts "\nReached limit of #{limit}. Pass --all to export everything."
       break
     end
   end

--- a/spec/lib/tasks/export_catalog_rake_spec.rb
+++ b/spec/lib/tasks/export_catalog_rake_spec.rb
@@ -10,8 +10,10 @@ RSpec.describe 'export_catalog rake task' do # rubocop:disable RSpec/DescribeCla
     Rake::Task.define_task(:environment)
   end
 
+  let(:output_tempfile) { Tempfile.new(['catalog_export', '.json']) }
+  let(:output_file) { output_tempfile.path }
+
   let(:task) { Rake::Task['export_catalog'] }
-  let(:output_file) { Tempfile.new(['catalog_export', '.json']).path }
 
   before do
     task.reenable
@@ -21,7 +23,9 @@ RSpec.describe 'export_catalog rake task' do # rubocop:disable RSpec/DescribeCla
 
   after do
     ENV.delete('EXPORT_CATALOG_OUTPUT')
-    FileUtils.rm_f(output_file)
+    ENV.delete('EXPORT_CATALOG_LIMIT')
+    output_tempfile.close
+    output_tempfile.unlink
   end
 
   def parsed_output
@@ -109,17 +113,28 @@ RSpec.describe 'export_catalog rake task' do # rubocop:disable RSpec/DescribeCla
       create(:collection, collection_type: :volume, manifestations: [manifestation])
     end
     let!(:approved_tag) { create(:tag, status: :approved) }
-    let!(:pending_tag) { create(:tag, status: :approved) }
 
     before do
       create(:tagging, taggable: collection, tag: approved_tag, status: :approved)
-      create(:tagging, taggable: collection, tag: pending_tag, status: :pending)
     end
 
-    it 'exports only approved tags' do
+    it 'exports approved tags' do
       task.invoke
-      c = parsed_output['collections'].first
-      expect(c['tags']).to eq([approved_tag.name])
+      expect(parsed_output['collections'].first['tags']).to eq([approved_tag.name])
+    end
+
+    it 'excludes tags whose tagging is pending' do
+      pending_tagging_tag = create(:tag, status: :approved)
+      create(:tagging, taggable: collection, tag: pending_tagging_tag, status: :pending)
+      task.invoke
+      expect(parsed_output['collections'].first['tags']).not_to include(pending_tagging_tag.name)
+    end
+
+    it 'excludes tags where the tag itself is not approved even if the tagging is approved' do
+      pending_tag = create(:tag, status: :pending)
+      create(:tagging, taggable: collection, tag: pending_tag, status: :approved)
+      task.invoke
+      expect(parsed_output['collections'].first['tags']).not_to include(pending_tag.name)
     end
   end
 
@@ -157,6 +172,60 @@ RSpec.describe 'export_catalog rake task' do # rubocop:disable RSpec/DescribeCla
       task.invoke
       m = parsed_output['collections'].first['contents'].first
       expect(m['authorities']['author']).to eq(['Aaron Author', 'Zara Author'])
+    end
+  end
+
+  context 'with nested sub-collections' do
+    let!(:manifestation) { create(:manifestation, status: :published) }
+    let!(:sub_collection) do
+      create(:collection, collection_type: :volume, title: 'Sub Collection', manifestations: [manifestation])
+    end
+    let!(:parent_collection) do
+      create(:collection, collection_type: :volume, title: 'Parent Collection',
+                          included_collections: [sub_collection])
+    end
+
+    it 'includes the sub-collection in the parent contents tree' do
+      task.invoke
+      parent = parsed_output['collections'].find { |c| c['id'] == parent_collection.id }
+      expect(parent).not_to be_nil
+      nested = parent['contents'].find { |c| c['type'] == 'collection' }
+      expect(nested).to include('id' => sub_collection.id, 'title' => 'Sub Collection')
+    end
+
+    it 'includes the manifestation nested inside the sub-collection' do
+      task.invoke
+      parent = parsed_output['collections'].find { |c| c['id'] == parent_collection.id }
+      nested_col = parent['contents'].find { |c| c['type'] == 'collection' }
+      expect(nested_col['contents'].first).to include('id' => manifestation.id)
+    end
+  end
+
+  context 'with --all mode' do
+    before { ENV['EXPORT_CATALOG_LIMIT'] = '2' }
+
+    let!(:manifestations) { create_list(:manifestation, 3, status: :published) }
+    let!(:collections) do
+      manifestations.map do |m|
+        create(:collection, collection_type: :volume, manifestations: [m])
+      end
+    end
+
+    it 'uses "all collections" as the mode label' do
+      allow(ARGV).to receive(:include?).with('--all').and_return(true)
+      task.invoke
+      expect(parsed_output['mode']).to eq('all collections')
+    end
+
+    it 'exports all qualifying collections beyond the default limit' do
+      allow(ARGV).to receive(:include?).with('--all').and_return(true)
+      task.invoke
+      expect(parsed_output['count']).to eq(3)
+    end
+
+    it 'stops at the limit in default mode' do
+      task.invoke
+      expect(parsed_output['count']).to eq(2)
     end
   end
 end

--- a/spec/lib/tasks/export_catalog_rake_spec.rb
+++ b/spec/lib/tasks/export_catalog_rake_spec.rb
@@ -1,0 +1,162 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'rake'
+require 'tempfile'
+
+RSpec.describe 'export_catalog rake task' do # rubocop:disable RSpec/DescribeClass
+  before(:all) do
+    Rake.application.rake_require 'tasks/export_catalog'
+    Rake::Task.define_task(:environment)
+  end
+
+  let(:task) { Rake::Task['export_catalog'] }
+  let(:output_file) { Tempfile.new(['catalog_export', '.json']).path }
+
+  before do
+    task.reenable
+    ENV['EXPORT_CATALOG_OUTPUT'] = output_file
+    allow(ARGV).to receive(:include?).with('--all').and_return(false)
+  end
+
+  after do
+    ENV.delete('EXPORT_CATALOG_OUTPUT')
+    FileUtils.rm_f(output_file)
+  end
+
+  def parsed_output
+    JSON.parse(File.read(output_file))
+  end
+
+  context 'with a qualifying volume collection' do
+    let!(:author) { create(:authority) }
+    let!(:manifestation) do
+      create(:manifestation, author: author, status: :published, orig_lang: 'en')
+    end
+    let!(:collection) do
+      create(:collection,
+             collection_type: :volume,
+             title: 'Test Volume',
+             subtitle: 'A subtitle',
+             publisher_line: 'Publisher Co.',
+             alternate_titles: 'Alt Title One; Alt Title Two',
+             manifestations: [manifestation])
+    end
+
+    it 'writes valid JSON with the expected top-level structure' do
+      task.invoke
+      data = parsed_output
+      expect(data).to include('mode', 'collections', 'count')
+    end
+
+    it 'includes the collection with required fields' do
+      task.invoke
+      c = parsed_output['collections'].first
+      expect(c).to include('type' => 'collection', 'id' => collection.id, 'title' => 'Test Volume')
+      expect(c['url']).to match(%r{/collections/#{collection.id}})
+    end
+
+    it 'includes subtitle and publisher_line when present' do
+      task.invoke
+      c = parsed_output['collections'].first
+      expect(c['subtitle']).to eq('A subtitle')
+      expect(c['publisher_line']).to eq('Publisher Co.')
+    end
+
+    it 'splits alternate_titles on semicolon regardless of spacing' do
+      collection.update!(alternate_titles: 'One;Two ; Three')
+      task.invoke
+      c = parsed_output['collections'].first
+      expect(c['alternate_titles']).to eq(%w(One Two Three))
+    end
+
+    it 'serializes manifestation contents with id and url' do
+      task.invoke
+      m = parsed_output['collections'].first['contents'].first
+      expect(m).to include('type' => 'manifestation', 'id' => manifestation.id)
+      expect(m['url']).to match(%r{/read/#{manifestation.id}})
+    end
+
+    it 'includes original_language as Hebrew text when not Hebrew' do
+      task.invoke
+      m = parsed_output['collections'].first['contents'].first
+      expect(m['original_language']).to eq('אנגלית')
+    end
+
+    it 'omits original_language for Hebrew works' do
+      manifestation.expression.work.update!(orig_lang: 'he')
+      task.invoke
+      m = parsed_output['collections'].first['contents'].first
+      expect(m).not_to have_key('original_language')
+    end
+  end
+
+  context 'with a qualifying periodical_issue collection' do
+    let!(:manifestation) { create(:manifestation, status: :published) }
+    let!(:collection) do
+      create(:collection, collection_type: :periodical_issue, manifestations: [manifestation])
+    end
+
+    it 'includes periodical_issue collections' do
+      task.invoke
+      expect(parsed_output['collections'].map { |c| c['id'] }).to include(collection.id) # rubocop:disable Rails/Pluck
+    end
+  end
+
+  context 'with tag filtering' do
+    let!(:manifestation) { create(:manifestation, status: :published) }
+    let!(:collection) do
+      create(:collection, collection_type: :volume, manifestations: [manifestation])
+    end
+    let!(:approved_tag) { create(:tag, status: :approved) }
+    let!(:pending_tag) { create(:tag, status: :approved) }
+
+    before do
+      create(:tagging, taggable: collection, tag: approved_tag, status: :approved)
+      create(:tagging, taggable: collection, tag: pending_tag, status: :pending)
+    end
+
+    it 'exports only approved tags' do
+      task.invoke
+      c = parsed_output['collections'].first
+      expect(c['tags']).to eq([approved_tag.name])
+    end
+  end
+
+  context 'when filtering by collection type' do
+    let!(:manifestation) { create(:manifestation, status: :published) }
+
+    it 'excludes series collections' do
+      series = create(:collection, collection_type: :series, manifestations: [manifestation])
+      task.invoke
+      ids = parsed_output['collections'].map { |c| c['id'] } # rubocop:disable Rails/Pluck
+      expect(ids).not_to include(series.id)
+    end
+
+    it 'excludes collections with no published manifestations' do
+      empty_col = create(:collection, collection_type: :volume)
+      task.invoke
+      ids = parsed_output['collections'].map { |c| c['id'] } # rubocop:disable Rails/Pluck
+      expect(ids).not_to include(empty_col.id)
+    end
+  end
+
+  context 'with authority serialization' do
+    let!(:auth_z) { create(:authority, name: 'Zara Author') }
+    let!(:auth_a) { create(:authority, name: 'Aaron Author') }
+    let!(:manifestation) { create(:manifestation, status: :published, author: auth_z) }
+    let!(:collection) do
+      create(:collection, collection_type: :volume, manifestations: [manifestation])
+    end
+
+    before do
+      manifestation.expression.work.involved_authorities.create!(role: :author, authority: auth_a)
+    end
+
+    it 'sorts authority names within each role' do
+      task.invoke
+      m = parsed_output['collections'].first['contents'].first
+      expect(m['authorities']['author']).to eq(['Aaron Author', 'Zara Author'])
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Adds `lib/tasks/export_catalog.rake` with a new `export_catalog` rake task
- Exports all Collections of type `volume` or `periodical_issue` that contain at least one published Manifestation
- Produces a JSON file (`catalog_export.json`) with a full contents tree per collection

## What the output includes

Per qualifying Collection:
- ID, permanent URL, title, subtitle, alternate titles
- Authorities grouped by role
- Tag names
- Publication details (`publisher_line`)
- Recursive contents tree (CollectionItems of type Manifestation or Collection only)

Per Manifestation in the tree:
- Title, alternate titles, authorities by role, tags
- Original language (if not Hebrew)

## Usage

```bash
# Export first 50 qualifying collections (for testing)
bundle exec rake export_catalog

# Export entire catalog
bundle exec rake export_catalog -- --all
```

## Test plan
- [x] Ran `bundle exec rake export_catalog` — produced `catalog_export.json` with 50 collections
- [x] Verified JSON structure matches spec (all required fields present, optional fields omitted when empty)
- [x] Verified authority grouping by role, original language flagging, and alternate titles
- [x] RuboCop passes with no offenses

Closes by-nky