### PR TITLE
Add uncollected_texts to catalog export

### DIFF
--- a/lib/tasks/export_catalog.rake
+++ b/lib/tasks/export_catalog.rake
@@ -90,7 +90,11 @@ task export_catalog: :environment do
   all_mode = ARGV.include?('--all')
   limit = ENV.fetch('EXPORT_CATALOG_LIMIT', '50').to_i
   output_file = ENV.fetch('EXPORT_CATALOG_OUTPUT', 'catalog_export.json')
-  mode_label = all_mode ? 'all collections' : "first #{limit} qualifying collections"
+  mode_label = if all_mode
+                 'all collections and uncollected texts'
+               else
+                 "first #{limit} qualifying collections and #{limit} uncollected texts"
+               end
 
   puts "Mode: #{mode_label}"
 
@@ -129,7 +133,9 @@ task export_catalog: :environment do
                            .joins(:collection)
                            .where(collections: { collection_type: Collection.collection_types[:uncollected] },
                                   item_type: 'Manifestation')
+                           .where.not(item_id: nil)
                            .select(:item_id)
+                           .distinct
 
     Manifestation
       .where(id: uncollected_item_ids, status: :published)

--- a/lib/tasks/export_catalog.rake
+++ b/lib/tasks/export_catalog.rake
@@ -27,7 +27,7 @@ module ExportCatalogHelpers
     raw.split(';').map(&:strip).compact_blank
   end
 
-  def serialize_manifestation(manifestation, url_helpers)
+  def serialize_manifestation(manifestation, url_helpers, edition_details: false)
     lang = manifestation.expression.work.orig_lang
     entry = {
       type: 'manifestation',
@@ -40,6 +40,11 @@ module ExportCatalogHelpers
     alts = split_alternate_titles(manifestation.alternate_titles)
     entry[:alternate_titles] = alts unless alts.empty?
     entry[:original_language] = textify_lang(lang) unless lang.blank? || lang == 'he'
+    if edition_details
+      expr = manifestation.expression
+      entry[:source_edition] = expr.source_edition if expr.source_edition.present?
+      entry[:date] = expr.date if expr.date.present?
+    end
     entry
   end
 
@@ -91,6 +96,7 @@ task export_catalog: :environment do
 
   url_helpers = Rails.application.routes.url_helpers
   count = 0
+  ucount = 0
 
   File.open(output_file, 'w:UTF-8') do |f|
     f.write("{\n  \"mode\": #{JSON.generate(mode_label)},\n  \"collections\": [\n")
@@ -116,8 +122,36 @@ task export_catalog: :environment do
         break
       end
 
-    f.write("\n  ],\n  \"count\": #{count}\n}\n")
+    f.write("\n  ],\n  \"count\": #{count},\n  \"uncollected_texts\": [\n")
+    ufirst = true
+
+    uncollected_item_ids = CollectionItem
+                           .joins(:collection)
+                           .where(collections: { collection_type: Collection.collection_types[:uncollected] },
+                                  item_type: 'Manifestation')
+                           .select(:item_id)
+
+    Manifestation
+      .where(id: uncollected_item_ids, status: :published)
+      .preload(expression: [{ involved_authorities: :authority }, { work: { involved_authorities: :authority } }],
+               taggings: :tag)
+      .find_each do |manifestation|
+        serialized = serialize_manifestation(manifestation, url_helpers, edition_details: true)
+        f.write(",\n") unless ufirst
+        ufirst = false
+        f.write(JSON.pretty_generate(serialized).split("\n").map { |l| "    #{l}" }.join("\n"))
+        ucount += 1
+        print "u#{ucount} " if (ucount % 50).zero?
+
+        next if all_mode
+        next unless ucount >= limit
+
+        puts "\nReached uncollected limit of #{limit}. Pass --all to export everything."
+        break
+      end
+
+    f.write("\n  ],\n  \"uncollected_count\": #{ucount}\n}\n")
   end
 
-  puts "Exported #{count} collections to #{output_file}"
+  puts "Exported #{count} collections and #{ucount} uncollected texts to #{output_file}"
 end

--- a/spec/lib/tasks/export_catalog_rake_spec.rb
+++ b/spec/lib/tasks/export_catalog_rake_spec.rb
@@ -228,4 +228,88 @@ RSpec.describe 'export_catalog rake task' do # rubocop:disable RSpec/DescribeCla
       expect(parsed_output['count']).to eq(2)
     end
   end
+
+  context 'with uncollected texts' do
+    let!(:uncollected_col) { create(:collection, :uncollected) }
+    let!(:published_m) { create(:manifestation, status: :published, orig_lang: 'fr') }
+    let!(:unpublished_m) { create(:manifestation, status: :unpublished) }
+
+    before do
+      uncollected_col.append_item(published_m)
+      uncollected_col.append_item(unpublished_m)
+    end
+
+    it 'includes uncollected_texts and uncollected_count in the output' do
+      task.invoke
+      data = parsed_output
+      expect(data).to include('uncollected_texts', 'uncollected_count')
+    end
+
+    it 'exports published manifestations from uncollected collections' do
+      task.invoke
+      ids = parsed_output['uncollected_texts'].map { |m| m['id'] } # rubocop:disable Rails/Pluck
+      expect(ids).to include(published_m.id)
+    end
+
+    it 'excludes unpublished manifestations from uncollected collections' do
+      task.invoke
+      ids = parsed_output['uncollected_texts'].map { |m| m['id'] } # rubocop:disable Rails/Pluck
+      expect(ids).not_to include(unpublished_m.id)
+    end
+
+    it 'serializes uncollected manifestations with the standard manifestation fields' do
+      task.invoke
+      m = parsed_output['uncollected_texts'].find { |x| x['id'] == published_m.id }
+      expect(m).to include('type' => 'manifestation')
+      expect(m.keys).to include('id', 'url', 'title', 'authorities', 'tags')
+      expect(m['url']).to match(%r{/read/#{published_m.id}})
+      expect(m['original_language']).to eq('צרפתית')
+    end
+
+    it 'includes source_edition and date for uncollected manifestations when present' do
+      published_m.expression.update!(source_edition: 'First Ed.', date: '1920')
+      task.invoke
+      m = parsed_output['uncollected_texts'].find { |x| x['id'] == published_m.id }
+      expect(m['source_edition']).to eq('First Ed.')
+      expect(m['date']).to eq('1920')
+    end
+
+    it 'does not include source_edition and date for collected manifestations' do
+      m_in_vol = create(:manifestation, status: :published)
+      m_in_vol.expression.update!(source_edition: 'First Ed.', date: '1920')
+      create(:collection, collection_type: :volume, manifestations: [m_in_vol])
+      task.invoke
+      collected = parsed_output['collections'].flat_map { |c| c['contents'] }
+                                              .find { |x| x['id'] == m_in_vol.id }
+      expect(collected).not_to have_key('source_edition')
+      expect(collected).not_to have_key('date')
+    end
+
+    it 'does not include the uncollected collection itself in collections' do
+      task.invoke
+      ids = parsed_output['collections'].map { |c| c['id'] } # rubocop:disable Rails/Pluck
+      expect(ids).not_to include(uncollected_col.id)
+    end
+  end
+
+  context 'with uncollected limit' do
+    let!(:uncollected_col) { create(:collection, :uncollected) }
+    let!(:manifestations) { create_list(:manifestation, 3, status: :published) }
+
+    before do
+      ENV['EXPORT_CATALOG_LIMIT'] = '2'
+      manifestations.each { |m| uncollected_col.append_item(m) }
+    end
+
+    it 'stops at the limit in default mode' do
+      task.invoke
+      expect(parsed_output['uncollected_count']).to eq(2)
+    end
+
+    it 'exports all uncollected texts in --all mode' do
+      allow(ARGV).to receive(:include?).with('--all').and_return(true)
+      task.invoke
+      expect(parsed_output['uncollected_count']).to eq(3)
+    end
+  end
 end

--- a/spec/lib/tasks/export_catalog_rake_spec.rb
+++ b/spec/lib/tasks/export_catalog_rake_spec.rb
@@ -211,10 +211,10 @@ RSpec.describe 'export_catalog rake task' do # rubocop:disable RSpec/DescribeCla
       end
     end
 
-    it 'uses "all collections" as the mode label' do
+    it 'uses "all collections and uncollected texts" as the mode label' do
       allow(ARGV).to receive(:include?).with('--all').and_return(true)
       task.invoke
-      expect(parsed_output['mode']).to eq('all collections')
+      expect(parsed_output['mode']).to eq('all collections and uncollected texts')
     end
 
     it 'exports all qualifying collections beyond the default limit' do


### PR DESCRIPTION
## Summary

- Adds a `uncollected_texts` flat array to the JSON export, containing all published Manifestations from `uncollected`-type Collections
- Adds `uncollected_count` alongside it
- Uncollected manifestations include `source_edition` and `date` from their Expression (not present for collected manifestations, since those details can be inferred from the parent Collection)
- Same limit / `--all` controls apply; progress prints `u50 u100 ...` separately from the collections counter

## Test plan
- [x] 28-example spec covers: published/unpublished filter, standard fields, `source_edition`/`date` present only for uncollected, limit in default mode, `--all` bypasses limit
- [x] RuboCop passes on both files