### PR TITLE
Fix IngestPerson missing works when span wraps all page content

### DIFF
--- a/app/services/lexicon/ingest_person.rb
+++ b/app/services/lexicon/ingest_person.rb
@@ -28,7 +28,11 @@ module Lexicon
       end
 
       if heading_table.parent.name == 'span'
-        heading_table = heading_table.parent
+        span = heading_table.parent
+        # Only move up to the span level if content continues outside it.
+        # When the span has no next sibling, it wraps all page content, so we
+        # stay at the table level and iterate its siblings (which are inside the span).
+        heading_table = span if span.next_element.present?
       end
 
       next_elem = heading_table.next_element

--- a/spec/fixtures/files/lexicon/span_wraps_all.php
+++ b/spec/fixtures/files/lexicon/span_wraps_all.php
@@ -1,0 +1,36 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>סופר לדוגמה</title>
+</head>
+<!-- page header --><?php
+include "header.php";
+?><span dir="rtl">
+<body dir="rtl">
+
+<table border="0" width="100%" id="table5">
+  <tr>
+    <td><p align="center"><font size="5" color="#FF0000">סופר לדוגמה</font><font size="4" color="#FF0000"> (1950–2020)</font></p></td>
+    <td><p align="center"><font size="2" color="#FF0000">&lt;בהכנה&gt;</font></p></td>
+    <td><p align="center" dir="ltr"><font size="5" color="#FF0000">Example Author</font></p></td>
+  </tr>
+</table>
+<p class="margin" align="justify">
+ביוגרפיה קצרה של הסופר לדוגמה. הוא נולד בשנת 1950 וכתב ספרים רבים.
+</p>
+<p align="right" dir="rtl"><font size="4" color="#0000FF"><a name="Books">ספריו:</a></font></p>
+<ul style="MARGIN-TOP: 0in" type="circle">
+  <li>ספר ראשון : שירים (תל אביב : הוצאה לדוגמה, 1980)</li>
+  <li>ספר שני : פרוזה (תל אביב : הוצאה אחרת, 1990)</li>
+</ul>
+<p><font size="4" color="#0000FF"><a name="Bib.">על המחבר ויצירתו:</a></font></p>
+<p>לא נמצאו מקורות.</p>
+<font size="4" color="#0000FF"><a name="links">קישורים:</a></font>
+<ul style="MARGIN-TOP: 0in" type="circle">
+</ul>
+<!-- page footer --><?php
+include "footer.php";
+?>
+</span>
+</body>
+</html>

--- a/spec/services/lexicon/ingest_person_spec.rb
+++ b/spec/services/lexicon/ingest_person_spec.rb
@@ -73,6 +73,36 @@ describe Lexicon::IngestPerson do
     end
   end
 
+  context 'when span wraps all page content (no </span> before Books section)' do
+    # Regression test for 00633.php: when the <span dir="rtl"> before <body> is never closed
+    # before the Books section, Nokogiri parses everything inside the span. The original code
+    # jumped to the span's parent level and called next_element, finding nothing (span has no
+    # next sibling), resulting in 0 LexPersonWorks.
+    let!(:file) do
+      create(
+        :lex_file,
+        {
+          entrytype: :person,
+          status: :classified,
+          title: 'Example Author',
+          fname: 'span_wraps_all.php',
+          full_path: Rails.root.join('spec/fixtures/files/lexicon/span_wraps_all.php')
+        }
+      )
+    end
+
+    it 'parses works correctly even when span wraps all content' do
+      expect { call }.to change(LexPerson, :count).by(1)
+      expect(file.reload).to be_status_ingested
+
+      person = file.lex_entry.lex_item
+      expect(person).to be_an_instance_of(LexPerson)
+      expect(person.works.count).to eq(2)
+      expect(person.works.map(&:title)).to include('ספר ראשון : שירים', 'ספר שני : פרוזה')
+      expect(person.works.all?(&:work_type_original?)).to be true
+    end
+  end
+
   context 'when a link has href as its only attribute (no target="_blank")' do
     let!(:file) do
       create(


### PR DESCRIPTION
## Summary

- **Bug**: Legacy file `00633.php` (and similar files) resulted in 0 `LexPersonWorks` after migration.
- **Root cause**: In some PHP files, `<span dir="rtl">` appears before `<body>` and is never closed before the Books section, so Nokogiri parses all page content as children of that span. The existing code jumped to the span's parent level and called `next_element` — but the span had no siblings, so nothing was found and `ExtractPersonWorks` was never called.
- **Fix**: Only move up to the span level when the span has a next sibling (i.e., content continues outside it). When the span has no next sibling, all content is inside it, so we stay at the heading table level and iterate its siblings normally — which correctly reaches the Books header.
- **Regression test**: Added a fixture (`span_wraps_all.php`) that reproduces the unclosed-span structure and a spec that verifies 2 works are correctly extracted.

## Contrast between file patterns

| File | Span structure | Behavior |
|------|---------------|----------|
| `00118.php` | `<span>` wraps only the heading table, closed before Books | `span.next_element` finds Books header ✓ |
| `00024.php` | same | ✓ |
| `00633.php` | `<span>` wraps **everything** (never closed), Books inside span | `span.next_element` is `nil` → 0 works ✗ → **fixed** ✓ |

## Test plan

- [x] New spec `ingest_person_spec.rb` — "when span wraps all page content" — passes
- [x] All 7 `ingest_person_spec.rb` examples pass
- [x] RuboCop clean on changed files
- [ ] Full suite (running)

🤖 Generated with [Claude Code](https://claude.com/claude-code)