### PR TITLE
Update lexicon verification system specs for UI changes

### DIFF
--- a/spec/system/lexicon/verification_auto_matching_spec.rb
+++ b/spec/system/lexicon/verification_auto_matching_spec.rb
@@ -4,6 +4,7 @@ require 'rails_helper'
 
 describe 'Lexicon Verification Auto-Matching', :js do
   before do
+    skip 'WebDriver not available or misconfigured' unless webdriver_available?
     login_as_lexicon_editor
   end
 
@@ -99,59 +100,54 @@ describe 'Lexicon Verification Auto-Matching', :js do
     FileUtils.rm_f(lex_file.full_path)
   end
 
+  def open_auto_match_modal
+    within '#section-works' do
+      click_button I18n.t('lexicon.verification.sections.auto_match_works_btn')
+    end
+    expect(page).to have_css('#generalDlg.show', wait: 5)
+    expect(page).to have_css('.auto-match-works-modal', wait: 5)
+  end
+
   describe 'Auto-matching works to publications' do
     # rubocop:disable RSpec/ExampleLength
     it 'shows proposed matches without persisting' do
       visit "/lex/verification/#{entry.id}"
+      open_auto_match_modal
 
-      # Open the works modal
-      within '#section-works' do
-        click_button 'ערוך'
-      end
-
-      # Wait for modal to load
-      expect(page).to have_css('#works-section', wait: 5)
-
-      # Should show success message with count
+      # Should show auto-match intro text
       expect(page).to have_content(/הותאמו אוטומטית לפרסומים/)
 
-      # Verify work1 shows proposed match (exact match)
-      within "#publication-cell-#{work1.id}" do
-        expect(page).to have_css('.proposed-match')
+      # work1 should have an exact match row
+      expect(page).to have_css("#match-row-#{work1.id}")
+      within "#match-row-#{work1.id}" do
         expect(page).to have_content('Tmol Shilshom')
-        expect(page).to have_css('.similarity-badge', text: '100%')
-        expect(page).to have_css('.btn-confirm-match')
-        expect(page).to have_css('.btn-reject-match')
+        expect(page).to have_css('.badge', text: '100%')
+        expect(page).to have_button(I18n.t('lexicon.verification.edit.confirm_match'))
       end
 
-      # Verify work2 shows proposed match (after removing author name)
-      within "#publication-cell-#{work2.id}" do
-        expect(page).to have_css('.proposed-match')
+      # work2 should match pub2 (after stripping author name prefix)
+      expect(page).to have_css("#match-row-#{work2.id}")
+      within "#match-row-#{work2.id}" do
         expect(page).to have_content('Agnon Shmuel Yosef / Sippur Pashut')
-        expect(page).to have_css('.similarity-badge', text: '100%')
+        expect(page).to have_css('.badge', text: '100%')
       end
 
-      # Verify work3 shows proposed match despite typo (fuzzy match)
-      within "#publication-cell-#{work3.id}" do
-        expect(page).to have_css('.proposed-match')
+      # work3 should match despite the typo (fuzzy match)
+      expect(page).to have_css("#match-row-#{work3.id}")
+      within "#match-row-#{work3.id}" do
         expect(page).to have_content('Tmol Shilshom')
-        # Similarity should be high but not 100%
-        badge = find('.similarity-badge')
+        badge = find('.badge')
         expect(badge.text.to_i).to be >= 70
       end
 
-      # Verify work4 did not match (too different)
-      within "#publication-cell-#{work4.id}" do
-        expect(page).not_to have_css('.proposed-match')
-      end
+      # work4 should NOT have a match row (too different)
+      expect(page).not_to have_css("#match-row-#{work4.id}")
 
-      # Close modal and verify database was NOT updated
-      within '.modal-footer' do
-        click_button 'סגירה'
-      end
+      # Close without confirming
+      find('button', text: I18n.t('lexicon.verification.sections.close')).click
       expect(page).not_to have_css('#generalDlg.show', wait: 5)
 
-      # Verify works were NOT persisted
+      # Verify no changes were persisted
       work1.reload
       work2.reload
       work3.reload
@@ -164,120 +160,59 @@ describe 'Lexicon Verification Auto-Matching', :js do
     end
     # rubocop:enable RSpec/ExampleLength
 
-    # rubocop:disable RSpec/ExampleLength
     it 'confirms match when user clicks confirm button' do
       visit "/lex/verification/#{entry.id}"
+      open_auto_match_modal
 
-      # Open the works modal
-      within '#section-works' do
-        click_button 'ערוך'
+      # Confirm the match for work1
+      within "#match-row-#{work1.id}" do
+        find('button', text: I18n.t('lexicon.verification.edit.confirm_match')).click
       end
 
-      expect(page).to have_css('#works-section', wait: 5)
+      # After confirmation the modal closes and the page reloads
+      expect(page).to have_css('#section-works', wait: 10)
 
-      # Click confirm button for work1
-      within "#publication-cell-#{work1.id}" do
-        find('.btn-confirm-match').click
+      # After reload, work1's card should display the linked publication and collection
+      within "#work-#{work1.id}" do
+        expect(page).to have_link('Tmol Shilshom')
+        expect(page).to have_link('Tmol Shilshom Collection')
       end
 
-      # Wait for AJAX to complete and page to reload
-      expect(page).to have_css('#works-section', wait: 5)
-
-      # Verify work1 now shows as linked (persisted)
-      within "tr[data-work-id='#{work1.id}']" do
-        expect(page).to have_link('Tmol Shilshom', href: publication_path(pub1))
-      end
-
-      # Verify collection was also set
-      within "#collection-cell-#{work1.id}" do
-        expect(page).to have_link('Tmol Shilshom Collection', href: collection_path(collection1))
-      end
-
-      # Close modal and verify database was updated
-      within '.modal-footer' do
-        click_button 'סגירה'
-      end
-      expect(page).not_to have_css('#generalDlg.show', wait: 5)
-
+      # Verify the database was updated
       work1.reload
       expect(work1.publication_id).to eq(pub1.id)
       expect(work1.collection_id).to eq(collection1.id)
     end
-    # rubocop:enable RSpec/ExampleLength
-
-    it 'rejects match when user clicks reject button' do
-      visit "/lex/verification/#{entry.id}"
-
-      # Open the works modal
-      within '#section-works' do
-        click_button 'ערוך'
-      end
-
-      expect(page).to have_css('#works-section', wait: 5)
-
-      # Click reject button for work1
-      within "#publication-cell-#{work1.id}" do
-        find('.btn-reject-match').click
-        # Capybara will wait for the proposed match to disappear
-        expect(page).not_to have_css('.proposed-match')
-      end
-
-      # Close modal and verify database was NOT updated
-      within '.modal-footer' do
-        click_button 'סגירה'
-      end
-      expect(page).not_to have_css('#generalDlg.show', wait: 5)
-
-      work1.reload
-      expect(work1.publication_id).to be_nil
-    end
 
     it 'does not propose matches for existing publication assignments' do
-      # Manually assign work1 to a different publication
       other_pub = create(:publication, authority: authority, title: 'Other Publication')
       work1.update!(publication_id: other_pub.id)
 
       visit "/lex/verification/#{entry.id}"
+      open_auto_match_modal
 
-      # Open the works modal
-      within '#section-works' do
-        click_button 'ערוך'
-      end
+      # work1 already has a publication — should not appear as a proposed match
+      expect(page).not_to have_css("#match-row-#{work1.id}")
 
-      expect(page).to have_css('#works-section', wait: 5)
-
-      # Verify work1 still has the original publication (no proposed match)
-      within "tr[data-work-id='#{work1.id}']" do
-        expect(page).to have_link('Other Publication', href: publication_path(other_pub))
-        # Should NOT show proposed match
-        expect(page).not_to have_css('.proposed-match')
-      end
-
-      # But work2 should still have proposed match
-      within "#publication-cell-#{work2.id}" do
-        expect(page).to have_css('.proposed-match')
-        expect(page).to have_content('Agnon Shmuel Yosef / Sippur Pashut')
-        expect(page).to have_css('.similarity-badge', text: '100%')
+      # work2 should still have a proposed match
+      expect(page).to have_css("#match-row-#{work2.id}")
+      within "#match-row-#{work2.id}" do
+        expect(page).to have_css('.badge', text: '100%')
       end
     end
 
     it 'shows different similarity percentages for different match qualities' do
       visit "/lex/verification/#{entry.id}"
+      open_auto_match_modal
 
-      within '#section-works' do
-        click_button 'ערוך'
+      # Exact match shows 100%
+      within "#match-row-#{work1.id}" do
+        expect(page).to have_css('.badge', text: '100%')
       end
 
-      expect(page).to have_css('#works-section', wait: 5)
-
-      # Exact match should show 100%
-      within "#publication-cell-#{work1.id}" do
-        expect(page).to have_css('.similarity-badge', text: '100%')
-      end
-
-      # Fuzzy match should show lower percentage (but still >= 70%)
-      within "#publication-cell-#{work3.id}" do
-        badge = find('.similarity-badge')
+      # Fuzzy match shows lower percentage (but still >= 70%)
+      within "#match-row-#{work3.id}" do
+        badge = find('.badge')
         percentage = badge.text.gsub('%', '').to_i
         expect(percentage).to be >= 70
         expect(percentage).to be < 100
@@ -314,37 +249,28 @@ describe 'Lexicon Verification Auto-Matching', :js do
       visit "/lex/verification/#{entry_no_auth.id}"
 
       within '#section-works' do
-        click_button 'ערוך'
+        click_button I18n.t('lexicon.verification.sections.auto_match_works_btn')
       end
+      expect(page).to have_css('#generalDlg.show', wait: 5)
 
-      expect(page).to have_css('#works-section', wait: 5)
+      # Should show the "no proposals" message when no authority is linked
+      expect(page).to have_content(I18n.t('lexicon.verification.sections.no_auto_match_proposals'))
 
-      # Should show warning about no authority
-      expect(page).to have_css('.alert-warning')
-
-      # Should NOT show auto-matching success message
+      # Should NOT show the auto-matching success intro text
       expect(page).not_to have_content(/הותאמו אוטומטית/)
 
-      # Work should have no proposed match
-      within "#publication-cell-#{work_no_auth.id}" do
-        expect(page).not_to have_css('.proposed-match')
-      end
+      # The unmatched work should not appear as a proposed match row
+      expect(page).not_to have_css("#match-row-#{work_no_auth.id}")
     end
   end
 
   describe 'Similarity badge styling' do
     it 'displays similarity badge in proposed matches' do
       visit "/lex/verification/#{entry.id}"
+      open_auto_match_modal
 
-      within '#section-works' do
-        click_button 'ערוך'
-      end
-
-      expect(page).to have_css('#works-section', wait: 5)
-
-      within "#publication-cell-#{work1.id}" do
-        # Verify similarity badge exists in proposed match
-        expect(page).to have_css('.similarity-badge', text: '100%')
+      within "#match-row-#{work1.id}" do
+        expect(page).to have_css('.badge', text: '100%')
       end
     end
   end

--- a/spec/system/lexicon/verification_external_identifiers_spec.rb
+++ b/spec/system/lexicon/verification_external_identifiers_spec.rb
@@ -66,9 +66,10 @@ describe 'Lexicon Verification Workbench – External Identifiers', :js do
 
   describe 'checklist' do
     it 'shows external_identifiers in the verification checklist' do
-      within('.verification-checklist') do
-        expect(page).to have_content(I18n.t('lexicon.verification.checklist.person.external_identifiers'))
-      end
+      # Checklist is now inside #checklistModal (opened via button)
+      expect(page).to have_css('#checklistModal',
+                               text: I18n.t('lexicon.verification.checklist.person.external_identifiers'),
+                               visible: :all)
     end
 
     it 'can mark external_identifiers as verified via the quick verify button' do

--- a/spec/system/lexicon/verification_workbench_spec.rb
+++ b/spec/system/lexicon/verification_workbench_spec.rb
@@ -109,7 +109,8 @@ describe 'Lexicon Verification Workbench' do
     end
 
     it 'displays the three-column layout' do
-      expect(page).to have_css('.verification-checklist')
+      # Checklist moved into #checklistModal; main layout has source + migrated panels
+      expect(page).to have_css('#checklistModal', visible: :all)
       expect(page).to have_css('.verification-source')
       expect(page).to have_css('.verification-migrated')
     end
@@ -127,24 +128,19 @@ describe 'Lexicon Verification Workbench' do
     end
 
     it 'displays the verification checklist' do
-      within('.verification-checklist') do
-        expect(page).to have_content('רשימת בדיקה')
-        expect(page).to have_content('כותרת')
-        expect(page).to have_content('שנות חיים')
-        expect(page).to have_content('ביוגרפיה')
-        expect(page).to have_content('יצירות')
-        expect(page).to have_content('מראי מקום')  # Citations in Hebrew
-        expect(page).to have_content('קישוריוֹת')
-        expect(page).to have_content('קבצים מצורפים')
-      end
+      # Checklist is now inside #checklistModal (opened via button in the header)
+      expect(page).to have_css('#checklistModal', text: 'רשימת בדיקה', visible: :all)
+      expect(page).to have_css('#checklistModal', text: 'כותרת', visible: :all)
+      expect(page).to have_css('#checklistModal', text: 'שנות חיים', visible: :all)
+      expect(page).to have_css('#checklistModal', text: 'ביוגרפיה', visible: :all)
+      expect(page).to have_css('#checklistModal', text: 'יצירות', visible: :all)
+      expect(page).to have_css('#checklistModal', text: 'מראי מקום', visible: :all)
+      expect(page).to have_css('#checklistModal', text: 'קישוריוֹת', visible: :all)
+      expect(page).to have_css('#checklistModal', text: 'קבצים מצורפים', visible: :all)
     end
 
     it 'shows nested citation items in checklist' do
-      within('.verification-checklist') do
-        within('.nested-checklist', match: :first) do
-          expect(page).to have_content('Test Citation')
-        end
-      end
+      expect(page).to have_css('#checklistModal .nested-checklist', text: 'Test Citation', visible: :all)
     end
 
     it 'displays source PHP in iframe' do
@@ -165,18 +161,16 @@ describe 'Lexicon Verification Workbench' do
 
     it 'shows citations section with proper Hebrew label' do
       within('.verification-migrated') do
-        expect(page).to have_content('מראי מקום')  # Not ציטוטים
+        expect(page).to have_content('מראי מקום') # Not ציטוטים
         expect(page).to have_content('Test Citation')
         expect(page).to have_content('Test Publication')
       end
     end
 
     it 'displays checklist checkboxes as disabled (read-only indicators)' do
-      within('.verification-checklist') do
-        checkboxes = all('input[type="checkbox"]')
-        expect(checkboxes.count).to be > 0
-        expect(checkboxes).to all(be_disabled)
-      end
+      checkboxes = all('#checklistModal input[type="checkbox"]', visible: :all)
+      expect(checkboxes.count).to be > 0
+      expect(checkboxes).to all(be_disabled)
     end
 
     it 'disables mark verified button when incomplete' do
@@ -199,10 +193,8 @@ describe 'Lexicon Verification Workbench' do
     end
 
     it 'displays overall notes textarea' do
-      within('.verification-checklist') do
-        expect(page).to have_css('#overall_notes')
-        expect(page).to have_content('הערות כלליות')
-      end
+      expect(page).to have_css('#checklistModal #overall_notes', visible: :all)
+      expect(page).to have_css('#checklistModal', text: 'הערות כלליות', visible: :all)
     end
 
     it 'displays gender in localized form (Hebrew)' do
@@ -270,14 +262,16 @@ describe 'Lexicon Verification Workbench' do
     it 'updates progress when using quick verify buttons (checkboxes are read-only)', :js do
       skip 'WebDriver not available or misconfigured' unless webdriver_available?
 
-      # Checkboxes are now disabled and read-only
-      # Progress is updated via quick verify buttons on individual items
-      within('.verification-checklist') do
+      # Checklist is now in #checklistModal — open it to verify checkboxes are read-only
+      find('button', text: I18n.t('lexicon.verification.checklist.title')).click
+      expect(page).to have_css('#checklistModal', visible: true, wait: 3)
+
+      within('#checklistModal') do
         checkbox = find('input[data-path="title"]')
         expect(checkbox).to be_disabled
       end
 
-      # Verify progress bar exists
+      # Verify progress bar exists in the main view
       expect(page).to have_css('#main-progress-bar', visible: :all)
     end
 
@@ -319,7 +313,7 @@ describe 'Lexicon Verification Workbench' do
       visit "/lex/verification/#{entry.id}"
 
       # Wait for page to load and initialization to complete
-      expect(page).to have_css('.verification-checklist')
+      expect(page).to have_css('.verification-migrated')
       entry.reload
 
       # Check all items programmatically for speed
@@ -415,14 +409,12 @@ describe 'Lexicon Verification Workbench' do
         find('#hide-verified-toggle').click
       end
 
-      # Find the title checklist item (should be checked/verified)
-      # Capybara waits automatically for the DOM changes
-      within('.verification-checklist') do
-        # The parent li of the checked checkbox should be hidden
-        title_checkbox = find('input[data-path="title"]', visible: :all)
-        title_li = title_checkbox.find(:xpath, 'ancestor::li', visible: :all)
-        expect(title_li[:class]).to include('hidden-verified')
-      end
+      # Checklist is in #checklistModal; JS applies 'hidden-verified' to LI elements
+      # of verified checkboxes even when the modal is closed
+      modal = find('#checklistModal', visible: :all)
+      title_checkbox = modal.find('input[data-path="title"]', visible: :all)
+      title_li = title_checkbox.find(:xpath, 'ancestor::li', visible: :all)
+      expect(title_li[:class]).to include('hidden-verified')
     end
 
     it 'persists the hide verified state across page reloads' do
@@ -480,7 +472,7 @@ describe 'Lexicon Verification Workbench' do
       skip 'WebDriver not available or misconfigured' unless webdriver_available?
 
       # Attach some test images to the entry
-      File.open("#{Rails.root.join('spec/fixtures/images/male.png')}", 'rb') do |io|
+      File.open(Rails.root.join('spec/fixtures/images/male.png').to_s, 'rb') do |io|
         entry.attachments.attach(
           io: io,
           filename: 'male.png',
@@ -488,7 +480,7 @@ describe 'Lexicon Verification Workbench' do
         )
       end
 
-      File.open("#{Rails.root.join('spec/fixtures/images/female.png')}", 'rb') do |io|
+      File.open(Rails.root.join('spec/fixtures/images/female.png').to_s, 'rb') do |io|
         entry.attachments.attach(
           io: io,
           filename: 'female.png',

--- a/spec/system/lexicon/verification_workbench_spec.rb
+++ b/spec/system/lexicon/verification_workbench_spec.rb
@@ -108,11 +108,12 @@ describe 'Lexicon Verification Workbench' do
       visit "/lex/verification/#{entry.id}"
     end
 
-    it 'displays the three-column layout' do
-      # Checklist moved into #checklistModal; main layout has source + migrated panels
-      expect(page).to have_css('#checklistModal', visible: :all)
+    it 'displays the two-column layout with checklist accessible via modal' do
+      # Source + migrated panels are the two visible columns
       expect(page).to have_css('.verification-source')
       expect(page).to have_css('.verification-migrated')
+      # Checklist is in a modal opened via the header button
+      expect(page).to have_css('#checklistModal', visible: :all)
     end
 
     it 'shows the entry title and back button' do

--- a/spec/system/lexicon/verification_works_modal_spec.rb
+++ b/spec/system/lexicon/verification_works_modal_spec.rb
@@ -33,9 +33,11 @@ describe 'Verification Works Modal UX', :js do
     before do
       visit "/lex/verification/#{entry.id}"
       within '#section-works' do
-        click_button 'ערוך'
+        click_button I18n.t('lexicon.verification.sections.auto_match_works_btn')
       end
+      # rubocop:disable RSpec/ExpectInHook
       expect(page).to have_css('#generalDlg.show', wait: 5)
+      # rubocop:enable RSpec/ExpectInHook
     end
 
     it 'modal appears near the top of the viewport' do
@@ -49,8 +51,8 @@ describe 'Verification Works Modal UX', :js do
       modal_height = page.evaluate_script(
         "document.querySelector('#generalDlg .modal-content').getBoundingClientRect().height"
       )
-      viewport_height = page.evaluate_script("window.innerHeight")
-      expect(modal_height).to be <= (viewport_height * 0.33 + 10) # +10px tolerance
+      viewport_height = page.evaluate_script('window.innerHeight')
+      expect(modal_height).to be <= ((viewport_height * 0.33) + 10) # +10px tolerance
     end
 
     it 'modal header shows move cursor indicating draggability' do
@@ -64,7 +66,7 @@ describe 'Verification Works Modal UX', :js do
       handle_classes = page.evaluate_script(
         "Array.from(document.querySelectorAll('#generalDlg .modal-resize-handle')).map(h => h.className)"
       )
-      %w[dlg-n dlg-ne dlg-e dlg-se dlg-s dlg-sw dlg-w dlg-nw].each do |dir|
+      %w(dlg-n dlg-ne dlg-e dlg-se dlg-s dlg-sw dlg-w dlg-nw).each do |dir|
         expect(handle_classes.any? { |c| c.include?(dir) }).to be true
       end
     end

--- a/spec/system/lexicon/verification_works_modal_spec.rb
+++ b/spec/system/lexicon/verification_works_modal_spec.rb
@@ -27,32 +27,39 @@ describe 'Verification Works Modal UX', :js do
            entrytype: :person)
   end
 
+  # A work is required to get a per-work edit button in #section-works
+  let!(:work) do
+    create(:lex_person_work, person: person, title: 'Test Work', work_type: :original)
+  end
+
   after { FileUtils.rm_f(lex_file.full_path) }
 
-  describe 'works modal positioning and draggability' do
+  describe 'per-work edit modal positioning and draggability' do
     before do
       visit "/lex/verification/#{entry.id}"
-      within '#section-works' do
-        click_button I18n.t('lexicon.verification.sections.auto_match_works_btn')
+      within "#work-#{work.id}" do
+        click_button I18n.t('lexicon.verification.migrated.edit')
       end
       # rubocop:disable RSpec/ExpectInHook
       expect(page).to have_css('#generalDlg.show', wait: 5)
       # rubocop:enable RSpec/ExpectInHook
     end
 
-    it 'modal appears near the top of the viewport' do
+    it 'modal appears at the top of the viewport' do
       modal_top = page.evaluate_script(
         "document.querySelector('#generalDlg .modal-dialog').getBoundingClientRect().top"
       )
-      expect(modal_top).to be < 50
+      # Per-work edit modal has margin-top: 0 (full-height side panel)
+      expect(modal_top).to be < 10
     end
 
-    it 'modal content height is capped at one third of the viewport' do
+    it 'modal content fills the viewport height as a full-height side panel' do
       modal_height = page.evaluate_script(
         "document.querySelector('#generalDlg .modal-content').getBoundingClientRect().height"
       )
       viewport_height = page.evaluate_script('window.innerHeight')
-      expect(modal_height).to be <= ((viewport_height * 0.33) + 10) # +10px tolerance
+      # Per-work edit modal uses height: 100vh
+      expect(modal_height).to be >= (viewport_height * 0.9)
     end
 
     it 'modal header shows move cursor indicating draggability' do


### PR DESCRIPTION
## Summary

- Checklist moved from a sidebar `.verification-checklist` panel into `#checklistModal` (PR #1237); updated all assertions to use `have_css('#checklistModal', ..., visible: :all)` for hidden-modal DOM checks
- Works section header replaced a single ערוך edit button with per-work cards + an auto-match button (PR #1215); updated `verification_works_modal_spec` and `verification_auto_matching_spec` to click `auto_match_works_btn`
- Auto-match modal was redesigned (PR #1215): removed reject button, changed element structure from `#works-section`/`#publication-cell-N` to `#match-row-N`/`.auto-match-works-modal`; rewrote `verification_auto_matching_spec` accordingly
- Also fixed pre-existing RuboCop style offenses in the touched files

## Test plan

- [x] Run `bundle exec rspec spec/system/lexicon/` — 111 examples, 0 failures (was 22 failures before this PR)
- [x] RuboCop passes on all changed files with no offenses