### PR TITLE
Fix missing redo-migrate button when lex_item is nil in draft/verifying state

### DIFF
--- a/app/views/lexicon/files/_file_row.html.haml
+++ b/app/views/lexicon/files/_file_row.html.haml
@@ -22,7 +22,7 @@
       -# for now we only show the migrate link for person entries (stage 1)
       = link_to t('lexicon.files.migrate.title'), migrate_lexicon_file_path(lf),
                 remote: true, method: :post, class: 'migrate-link'
-    - elsif (lex_entry.status_draft? || lex_entry.status_verifying?) && lf.entrytype_person?
+    - elsif (lex_entry.status_draft? || lex_entry.status_verifying?) && lex_entry.lex_item.nil? && lf.entrytype_person?
       -# lex_item is nil despite a post-migration status — allow re-running migration
       = link_to t('lexicon.files.redo_migrate.title'), redo_migration_lexicon_file_path(lf),
                 remote: true, method: :post, class: 'btn btn-sm btn-outline-warning ms-1',

--- a/app/views/lexicon/files/_file_row.html.haml
+++ b/app/views/lexicon/files/_file_row.html.haml
@@ -22,3 +22,8 @@
       -# for now we only show the migrate link for person entries (stage 1)
       = link_to t('lexicon.files.migrate.title'), migrate_lexicon_file_path(lf),
                 remote: true, method: :post, class: 'migrate-link'
+    - elsif (lex_entry.status_draft? || lex_entry.status_verifying?) && lf.entrytype_person?
+      -# lex_item is nil despite a post-migration status — allow re-running migration
+      = link_to t('lexicon.files.redo_migrate.title'), redo_migration_lexicon_file_path(lf),
+                remote: true, method: :post, class: 'btn btn-sm btn-outline-warning ms-1',
+                data: { confirm: t('lexicon.files.redo_migrate.confirm') }

--- a/spec/requests/lexicon/files_spec.rb
+++ b/spec/requests/lexicon/files_spec.rb
@@ -41,8 +41,9 @@ describe '/lexicon/files' do
       end
 
       it 'renders the redo_migration button so the entry is not stuck' do
+        expect(stuck_file.lex_entry.lex_item).to be_nil # entry_status: :raw factory trait guarantees nil lex_item
         call
-        expect(call).to eq(200)
+        expect(response).to have_http_status(:ok)
         expect(response.body).to include(redo_migration_lexicon_file_path(stuck_file))
       end
     end

--- a/spec/requests/lexicon/files_spec.rb
+++ b/spec/requests/lexicon/files_spec.rb
@@ -30,6 +30,23 @@ describe '/lexicon/files' do
       end
     end
 
+    context 'when entry has verifying status but no lex_item (stuck after NFS error)' do
+      let(:params) { { entry_statuses: ['verifying'] } }
+
+      let!(:stuck_file) do
+        file = create(:lex_file, :person, status: :classified, entry_status: :raw,
+                                          error_message: 'No such file or directory @ rb_sysopen - /lexicon/00044.php')
+        file.lex_entry.update_columns(status: LexEntry.statuses[:verifying])
+        file
+      end
+
+      it 'renders the redo_migration button so the entry is not stuck' do
+        call
+        expect(call).to eq(200)
+        expect(response.body).to include(redo_migration_lexicon_file_path(stuck_file))
+      end
+    end
+
     context 'when filtering applied' do
       context 'when filtering by title' do
         let!(:file1) do
@@ -257,7 +274,7 @@ describe '/lexicon/files' do
     end
 
     context 'when entry_status is not draft or verifying' do
-      let(:entry_status) { LexEntry.statuses.keys.find { |status| !%w(draft verifying).include?(status) } }
+      let(:entry_status) { LexEntry.statuses.keys.find { |status| %w(draft verifying).exclude?(status) } }
 
       it 'does not queue job and simply re-renders tr' do
         expect { call }.not_to(change { Lexicon::IngestFile.jobs.size })


### PR DESCRIPTION
## Summary

- In `/lex/files`, a person entry with `status: verifying` (or `draft`) and `lex_item: nil` showed no action buttons, making it impossible to re-run migration
- This can happen when an NFS share is temporarily unavailable during a redo-migration: `reset_ingestion!` destroys the `lex_item`, the queued job then fails, and if the rescue doesn't cleanly transition to `error` status, the entry is stuck
- Fixed by adding a fallback `elsif` in `_file_row.html.haml` that shows the redo-migrate button for person entries in `draft`/`verifying` state when `lex_item` is nil
- The `redo_migration` controller action already handles nil `lex_item` safely via `lex_item&.destroy!` in `reset_ingestion!` — no controller changes needed

## Test plan

- [x] New request spec: creates a person lex_file with `verifying` entry status and nil `lex_item`, asserts the index response includes the `redo_migration` path
- [x] All 14 existing tests in `spec/requests/lexicon/files_spec.rb` still pass
- [x] HAML-lint and RuboCop both clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)