### PR TITLE
Fix LexPerson authority name-matching silently skipping during migration

### DIFF
--- a/app/services/lexicon/associate_authority.rb
+++ b/app/services/lexicon/associate_authority.rb
@@ -18,10 +18,10 @@ module Lexicon
     # P7507 = Project Ben-Yehuda author ID property on Wikidata
     WIKIDATA_PBY_PROPERTY = 'P7507'
 
-    def call(lex_person, html_doc)
+    def call(lex_person, html_doc, entry_title: nil)
       authority = find_by_benyehuda_link(html_doc) ||
                   find_by_wikidata(html_doc) ||
-                  find_by_name(lex_person)
+                  find_by_name(lex_person, entry_title)
 
       return lex_person if authority.nil?
 
@@ -104,11 +104,8 @@ module Lexicon
       nil
     end
 
-    def find_by_name(lex_person)
-      entry = lex_person.entry
-      return nil unless entry
-
-      name = entry.title
+    def find_by_name(lex_person, entry_title = nil)
+      name = entry_title.presence || lex_person.entry&.title
       return nil if name.blank?
 
       authorities = Authority.where(name: name)

--- a/app/services/lexicon/ingest_base.rb
+++ b/app/services/lexicon/ingest_base.rb
@@ -4,22 +4,22 @@ module Lexicon
   # Base class for php file ingestion
   class IngestBase < ApplicationService
     def call(lex_file)
-      lex_entry = lex_file.lex_entry
+      @lex_entry = lex_file.lex_entry
 
       html_doc = File.open(lex_file.full_path) { |f| Nokogiri::HTML(f) }
-      Lexicon::AttachImages.call(html_doc, lex_entry)
-      Lexicon::ProcessLinks.call(html_doc, lex_entry)
+      Lexicon::AttachImages.call(html_doc, @lex_entry)
+      Lexicon::ProcessLinks.call(html_doc, @lex_entry)
 
-      lex_entry.lex_item = create_lex_item(html_doc)
-      lex_entry.english_title = extract_english_title(html_doc)
-      lex_entry.external_identifiers = extract_external_identifiers(html_doc)
-      lex_entry.status_draft!
+      @lex_entry.lex_item = create_lex_item(html_doc)
+      @lex_entry.english_title = extract_english_title(html_doc)
+      @lex_entry.external_identifiers = extract_external_identifiers(html_doc)
+      @lex_entry.status_draft!
 
       lex_file.status_ingested!
 
-      Lexicon::CheckExternalLinksJob.perform_async(lex_entry.id)
+      Lexicon::CheckExternalLinksJob.perform_async(@lex_entry.id)
 
-      lex_entry
+      @lex_entry
     end
 
     def create_lex_item(_html_doc)

--- a/app/services/lexicon/ingest_person.rb
+++ b/app/services/lexicon/ingest_person.rb
@@ -57,8 +57,11 @@ module Lexicon
       # to avoid validation errors
       lex_person.save!
 
-      # Authority can already be filled in ExtractAuthority service so we call AssociateAuthority only if it is nil
-      AssociateAuthority.call(lex_person, html_doc) if lex_person.authority.nil?
+      # Authority can already be filled in ExtractAuthority service so we call AssociateAuthority only if it is nil.
+      # Pass @lex_entry.title explicitly: at this point the DB association between LexPerson and LexEntry
+      # has not been committed yet (lex_entry.lex_item= is set after create_lex_item returns), so
+      # lex_person.entry would return nil inside AssociateAuthority.
+      AssociateAuthority.call(lex_person, html_doc, entry_title: @lex_entry&.title) if lex_person.authority.nil?
       link_citations_to_works(lex_person)
       lex_person
     end

--- a/spec/services/lexicon/associate_authority_spec.rb
+++ b/spec/services/lexicon/associate_authority_spec.rb
@@ -182,6 +182,20 @@ describe Lexicon::AssociateAuthority do
     it_behaves_like 'associates authority'
   end
 
+  context 'when entry_title is passed explicitly (lex_person.entry not yet associated, as during initial migration)' do
+    subject(:call) { described_class.call(lex_person_without_entry, html_doc, entry_title: entry_title) }
+
+    let(:lex_person_without_entry) { create(:lex_person) }
+    let(:expected_authority) { create(:authority, name: entry_title) }
+
+    before { expected_authority }
+
+    it 'associates authority using the supplied entry_title' do
+      call
+      expect(lex_person_without_entry.reload.authority).to eq(expected_authority)
+    end
+  end
+
   context 'when multiple Authorities have the same name' do
     before { create_list(:authority, 2, name: entry_title) }
 


### PR DESCRIPTION
## Summary

- **Bug**: During lexicon migration, `AssociateAuthority#find_by_name` called `lex_person.entry` to get the entry title, but that DB association doesn't exist yet at the point of the call. `lex_entry.lex_item_id` is only committed after `create_lex_item` returns — so name-based matching always returned `nil`, silently skipping every person who could only be matched by name.
- **Fix**: Store `lex_entry` as `@lex_entry` in `IngestBase#call` so `IngestPerson#create_lex_item` can pass `entry_title: @lex_entry.title` explicitly to `AssociateAuthority`, bypassing the not-yet-committed association. `AssociateAuthority#find_by_name` uses the explicit title first, falls back to `lex_person.entry&.title` for standalone callers where the association already exists.
- **Data fix**: Backfilled the 3 already-migrated entries that were missed: LexEntry 5018 (יוסל בירשטיין), 5631 (יונה וולך), 5046 (דליה פלח).

The existing test didn't catch this because its factory setup called `status_draft!` before the service ran, establishing the association first — the opposite of the real call order. Added a new test that calls with an explicit `entry_title` and no entry association to cover the real migration scenario.

## Test plan

- [x] `bundle exec rspec spec/services/lexicon/associate_authority_spec.rb` — 16 examples, 0 failures (includes new test)
- [x] `bundle exec rspec spec/services/lexicon/` — 82 examples, 0 failures
- [x] Manually verified in Rails console that calling `AssociateAuthority.call(lex_person, html_doc, entry_title: entry.title)` for the 3 affected entries correctly links them to their matching Authority records