### PR TITLE
Extend authority name matching to check other_designation aliases

### DIFF
--- a/app/services/lexicon/associate_authority.rb
+++ b/app/services/lexicon/associate_authority.rb
@@ -108,17 +108,20 @@ module Lexicon
       name = entry_title.presence || lex_person.entry&.title
       return nil if name.blank?
 
-      by_name        = Authority.where(name: name).to_a
+      by_name = Authority.where(name: name).to_a
+      return nil if by_name.size > 1
+
       by_designation = authorities_by_designation(name)
       matches        = (by_name + by_designation).uniq
       matches.one? ? matches.first : nil
     end
 
+    # Scans authorities with non-blank other_designation in Ruby to avoid
+    # an unindexable leading-wildcard LIKE. The authority table is small
+    # (~thousands of rows) so loading qualifying rows is inexpensive.
     def authorities_by_designation(name)
-      escaped    = ActiveRecord::Base.sanitize_sql_like(name)
-      candidates = Authority.where('other_designation LIKE ?', "%#{escaped}%")
-      candidates.select do |auth|
-        auth.other_designation.to_s.split(';').map(&:strip).include?(name)
+      Authority.where.not(other_designation: [nil, '']).select do |auth|
+        auth.other_designation.split(';').map(&:strip).include?(name)
       end
     end
   end

--- a/app/services/lexicon/associate_authority.rb
+++ b/app/services/lexicon/associate_authority.rb
@@ -108,8 +108,18 @@ module Lexicon
       name = entry_title.presence || lex_person.entry&.title
       return nil if name.blank?
 
-      authorities = Authority.where(name: name)
-      authorities.one? ? authorities.first : nil
+      by_name        = Authority.where(name: name).to_a
+      by_designation = authorities_by_designation(name)
+      matches        = (by_name + by_designation).uniq
+      matches.one? ? matches.first : nil
+    end
+
+    def authorities_by_designation(name)
+      escaped    = ActiveRecord::Base.sanitize_sql_like(name)
+      candidates = Authority.where('other_designation LIKE ?', "%#{escaped}%")
+      candidates.select do |auth|
+        auth.other_designation.to_s.split(';').map(&:strip).include?(name)
+      end
     end
   end
 end

--- a/spec/services/lexicon/associate_authority_spec.rb
+++ b/spec/services/lexicon/associate_authority_spec.rb
@@ -214,6 +214,14 @@ describe Lexicon::AssociateAuthority do
     it_behaves_like 'associates authority'
   end
 
+  context 'when the alias has extra whitespace around the semicolon separator' do
+    let(:expected_authority) { create(:authority, other_designation: "Other Alias ;  #{entry_title}  ; Yet Another") }
+
+    before { expected_authority }
+
+    it_behaves_like 'associates authority'
+  end
+
   context 'when multiple Authorities share the same other_designation alias' do
     before { create_list(:authority, 2, other_designation: entry_title) }
 

--- a/spec/services/lexicon/associate_authority_spec.rb
+++ b/spec/services/lexicon/associate_authority_spec.rb
@@ -206,6 +206,29 @@ describe Lexicon::AssociateAuthority do
     it_behaves_like 'does not associate authority'
   end
 
+  context 'when exactly one Authority has the entry title as an other_designation alias' do
+    let(:expected_authority) { create(:authority, other_designation: "#{entry_title}; Other Alias") }
+
+    before { expected_authority }
+
+    it_behaves_like 'associates authority'
+  end
+
+  context 'when multiple Authorities share the same other_designation alias' do
+    before { create_list(:authority, 2, other_designation: entry_title) }
+
+    it_behaves_like 'does not associate authority'
+  end
+
+  context 'when one Authority matches by name and another matches the same title by other_designation' do
+    before do
+      create(:authority, name: entry_title)
+      create(:authority, other_designation: entry_title)
+    end
+
+    it_behaves_like 'does not associate authority'
+  end
+
   context 'when both a benyehuda.org link and a name match exist' do
     let(:authority_by_link) { create(:authority) }
     let(:html_body) do


### PR DESCRIPTION
## Summary

- `AssociateAuthority#find_by_name` now also searches the `other_designation` column (semicolon-separated aliases) in addition to the primary `name` field.
- Uses a `LIKE` pre-filter to avoid a full table scan, then confirms precisely in Ruby by splitting on `';'` and stripping whitespace.
- The combined pool of name-matches and alias-matches is deduplicated before applying the single-match guard — so ambiguous cases (e.g. one authority matches by name, another by alias for the same title) correctly produce no link.
- Backfilled LexEntry 4998 (שמעון אדף → Authority 3890), whose primary authority name uses niqqud (`שמעון אָדָף`) while the `other_designation` alias matches the plain form used in the lexicon entry.

## Test plan

- [x] New test: entry title matches `other_designation` alias in exactly one authority → associates
- [x] New test: multiple authorities share the same alias → no match
- [x] New test: one authority matches by name, another matches the same title by alias → no match (ambiguous)
- [x] `bundle exec rspec spec/services/lexicon/associate_authority_spec.rb` — 19 examples, 0 failures