### PR TITLE
Replace literal strings in lexicon views with I18n.t calls

### DIFF
--- a/app/views/lex_issues/_form.html.haml
+++ b/app/views/lex_issues/_form.html.haml
@@ -1,7 +1,7 @@
 = form_for @lex_issue do |f|
   - if @lex_issue.errors.any?
     #error_explanation
-      %h2= "#{pluralize(@lex_issue.errors.count, "error")} prohibited this lex_issue from being saved:"
+      %h2= t('.errors_header', count: @lex_issue.errors.count)
       %ul
         - @lex_issue.errors.full_messages.each do |message|
           %li= message
@@ -25,4 +25,4 @@
     = f.label :lex_publication
     = f.text_field :lex_publication
   .actions
-    = f.submit 'Save'
+    = f.submit t(:save)

--- a/app/views/lex_issues/edit.html.haml
+++ b/app/views/lex_issues/edit.html.haml
@@ -1,7 +1,7 @@
-%h1 Editing lex_issue
+%h1= t('.title')
 
 = render 'form'
 
-= link_to 'Show', @lex_issue
+= link_to t(:show), @lex_issue
 \|
-= link_to 'Back', lex_issues_path
+= link_to t(:back), lex_issues_path

--- a/app/views/lex_issues/index.html.haml
+++ b/app/views/lex_issues/index.html.haml
@@ -1,14 +1,14 @@
-%h1 Listing lex_issues
+%h1= t('.title')
 
 %table
   %thead
     %tr
-      %th Subtitle
-      %th Volume
-      %th Issue
-      %th Seq num
-      %th Toc
-      %th Lex publication
+      %th= LexIssue.human_attribute_name(:subtitle)
+      %th= LexIssue.human_attribute_name(:volume)
+      %th= LexIssue.human_attribute_name(:issue)
+      %th= LexIssue.human_attribute_name(:seq_num)
+      %th= LexIssue.human_attribute_name(:toc)
+      %th= LexIssue.human_attribute_name(:lex_publication)
       %th
       %th
       %th
@@ -22,10 +22,10 @@
         %td= lex_issue.seq_num
         %td= lex_issue.toc
         %td= lex_issue.lex_publication
-        %td= link_to 'Show', lex_issue
-        %td= link_to 'Edit', edit_lex_issue_path(lex_issue)
-        %td= link_to 'Destroy', lex_issue, method: :delete, data: { confirm: 'Are you sure?' }
+        %td= link_to t(:show), lex_issue
+        %td= link_to t(:edit), edit_lex_issue_path(lex_issue)
+        %td= link_to t(:destroy), lex_issue, method: :delete, data: { confirm: t(:are_you_sure) }
 
 %br
 
-= link_to 'New Lex issue', new_lex_issue_path
+= link_to t('.new'), new_lex_issue_path

--- a/app/views/lex_issues/new.html.haml
+++ b/app/views/lex_issues/new.html.haml
@@ -1,5 +1,5 @@
-%h1 New lex_issue
+%h1= t('.title')
 
 = render 'form'
 
-= link_to 'Back', lex_issues_path
+= link_to t(:back), lex_issues_path

--- a/app/views/lex_issues/show.html.haml
+++ b/app/views/lex_issues/show.html.haml
@@ -1,24 +1,24 @@
 %p#notice= notice
 
 %p
-  %b Subtitle:
+  %b #{LexIssue.human_attribute_name(:subtitle)}:
   = @lex_issue.subtitle
 %p
-  %b Volume:
+  %b #{LexIssue.human_attribute_name(:volume)}:
   = @lex_issue.volume
 %p
-  %b Issue:
+  %b #{LexIssue.human_attribute_name(:issue)}:
   = @lex_issue.issue
 %p
-  %b Seq num:
+  %b #{LexIssue.human_attribute_name(:seq_num)}:
   = @lex_issue.seq_num
 %p
-  %b Toc:
+  %b #{LexIssue.human_attribute_name(:toc)}:
   = @lex_issue.toc
 %p
-  %b Lex publication:
+  %b #{LexIssue.human_attribute_name(:lex_publication)}:
   = @lex_issue.lex_publication
 
-= link_to 'Edit', edit_lex_issue_path(@lex_issue)
+= link_to t(:edit), edit_lex_issue_path(@lex_issue)
 \|
-= link_to 'Back', lex_issues_path
+= link_to t(:back), lex_issues_path

--- a/app/views/lexicon/citations/edit.html.haml
+++ b/app/views/lexicon/citations/edit.html.haml
@@ -1,2 +1,2 @@
-%h1 Editing lex_citation
+%h1= t('.title')
 = render 'form'

--- a/app/views/lexicon/citations/show.html.haml
+++ b/app/views/lexicon/citations/show.html.haml
@@ -1,27 +1,27 @@
 %p#notice= notice
 
 %p
-  %b Title:
+  %b #{LexCitation.human_attribute_name(:title)}:
   = @lex_citation.title
 %p
-  %b From publication:
+  %b #{LexCitation.human_attribute_name(:from_publication)}:
   = @lex_citation.from_publication
 %p
-  %b Authors:
+  %b #{LexCitation.human_attribute_name(:authors)}:
   = @lex_citation.authors
 %p
-  %b Pages:
+  %b #{LexCitation.human_attribute_name(:pages)}:
   = @lex_citation.pages
 %p
-  %b Link:
+  %b #{LexCitation.human_attribute_name(:link)}:
   = @lex_citation.link
 %p
-  %b Item:
+  %b #{LexCitation.human_attribute_name(:item)}:
   = @lex_citation.item
 %p
-  %b Manifestation:
+  %b #{LexCitation.human_attribute_name(:manifestation)}:
   = @lex_citation.manifestation
 
-= link_to 'Edit', edit_lex_citation_path(@lex_citation)
+= link_to t(:edit), edit_lex_citation_path(@lex_citation)
 \|
-= link_to 'Back', lex_citations_path
+= link_to t(:back), lex_citations_path

--- a/app/views/lexicon/entries/index.html.haml
+++ b/app/views/lexicon/entries/index.html.haml
@@ -19,9 +19,9 @@
 %table.table
   %thead
     %tr
-      %th Title
-      %th Status
-      %th Type
+      %th= t(:title)
+      %th= t(:status)
+      %th= t(:type)
       %th
       %th
       %th

--- a/app/views/lexicon/links/edit.html.haml
+++ b/app/views/lexicon/links/edit.html.haml
@@ -1,3 +1,3 @@
-%h1 Editing lex_link
+%h1= t('.title')
 
 = render 'form'

--- a/app/views/lexicon/people/new.html.haml
+++ b/app/views/lexicon/people/new.html.haml
@@ -1,3 +1,3 @@
-%h1 New #{LexPerson.model_name.human}
+%h1= t('.title', model: LexPerson.model_name.human)
 
 = render 'form'

--- a/app/views/lexicon/people/new.html.haml
+++ b/app/views/lexicon/people/new.html.haml
@@ -1,3 +1,3 @@
-%h1 New lex_person
+%h1 New #{LexPerson.model_name.human}
 
 = render 'form'

--- a/app/views/lexicon/publications/new.html.haml
+++ b/app/views/lexicon/publications/new.html.haml
@@ -1,3 +1,3 @@
-%h1 New lex_publication
+%h1 New #{LexPublication.model_name.human}
 
 = render 'form'

--- a/app/views/lexicon/publications/new.html.haml
+++ b/app/views/lexicon/publications/new.html.haml
@@ -1,3 +1,3 @@
-%h1 New #{LexPublication.model_name.human}
+%h1= t('helpers.submit.create', model: LexPublication.model_name.human)
 
 = render 'form'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3247,3 +3247,20 @@ en:
         drag_to_reorder: Drag to reorder
         reordering_failed: Reordering failed
         no_subject: General
+      edit:
+        title: Edit Citation
+    links:
+      edit:
+        title: Edit Link
+  lex_issues:
+    index:
+      title: Lex Issues
+      new: New Lex Issue
+    new:
+      title: New Lex Issue
+    edit:
+      title: Edit Lex Issue
+    form:
+      errors_header:
+        one: "1 error prevented this lex issue from being saved"
+        other: "%{count} errors prevented this lex issue from being saved"

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -2499,3 +2499,21 @@ he:
         drag_to_reorder: גרור לשינוי סדר
         reordering_failed: שינוי הסדר נכשל
         no_subject: כללי
+      edit:
+        title: עריכת מראה מקום
+    links:
+      edit:
+        title: עריכת קישור
+  lex_issues:
+    index:
+      title: גיליונות
+      new: גיליון חדש
+    new:
+      title: גיליון חדש
+    edit:
+      title: עריכת גיליון
+    form:
+      errors_header:
+        one: "שגיאה אחת מנעה שמירת גיליון זה"
+        other: "%{count} שגיאות מנעו שמירת גיליון זה"
+  type: סוג


### PR DESCRIPTION
## Summary

- Replaced hardcoded English strings in `lex_issues` scaffold views (edit, new, index, show, form) with `t()` calls
- Replaced literal headings in `lexicon/citations/edit`, `lexicon/links/edit`, `lexicon/people/new`, `lexicon/publications/new` with `t()` / `model_name.human`
- Replaced bare `%b Label:` attribute headers in `lexicon/citations/show` and `lex_issues/show` with `Model.human_attribute_name(:attr)` (locale-driven)
- Replaced literal `'Show'`, `'Edit'`, `'Back'`, `'Destroy'`, `'Are you sure?'`, `'Save'` strings with existing global keys (`t(:show)`, `t(:edit)`, etc.)
- Replaced literal `%th Title`, `%th Status`, `%th Type` table headers in `lexicon/entries/index` with `t(:title)`, `t(:status)`, `t(:type)`
- Added new I18n keys to `en.yml` and `he.yml`: `lex_issues.*` section, `lexicon.citations.edit.title`, `lexicon.links.edit.title`, and `type` (he.yml top-level)

## Test plan

- [ ] Browse to `/lex/issues` (index), `/lex/issues/new`, `/lex/issues/:id/edit`, `/lex/issues/:id` (show) — verify labels appear correctly in both locales
- [ ] Browse to `/lex/entries` (admin index) — verify Title/Status/Type column headers render correctly
- [ ] Browse to a lexicon entry edit page and confirm Citations/Links edit modal titles display correctly
- [ ] Run `bundle exec rspec` to confirm no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)