### PR TITLE
Add title_links to LexPersonWork and make work-type headings prominent

### DIFF
--- a/app/assets/javascripts/lexicon_backend.js
+++ b/app/assets/javascripts/lexicon_backend.js
@@ -70,6 +70,10 @@ function openModal(path, onSuccess = null) {
 function setupModalContent(content) {
     $('#generalDlgBody').html(content);
 
+    $('#generalDlgBody [data-ajax-url]').each(function() {
+        $(this).load($(this).data('ajax-url'));
+    });
+
     // Extracting title from content
 	var title = '';
 	var h1 = $('#generalDlgBody').find('h1').first();

--- a/app/assets/stylesheets/verification.scss
+++ b/app/assets/stylesheets/verification.scss
@@ -296,6 +296,13 @@
   }
 }
 
+.work-type-heading {
+  font-weight: 600;
+  border-bottom: 2px solid #6c757d;
+  padding-bottom: 0.25rem;
+  color: #495057;
+}
+
 .citation-card, .link-card, .work-card {
   padding: 1rem;
   margin-bottom: 1rem;

--- a/app/controllers/lexicon/person_works_controller.rb
+++ b/app/controllers/lexicon/person_works_controller.rb
@@ -55,14 +55,17 @@ module Lexicon
       @work.destroy!
     end
 
-    def title_links; end
+    def title_links
+      entry_ids = Array(@work.title_links).filter_map { |l| l['entry_id'] }
+      @title_link_entries = LexEntry.where(id: entry_ids).index_by(&:id)
+    end
 
     def add_title_link
       text = params[:text].to_s.strip
       entry_id = params[:entry_id].to_i
       entry = LexEntry.find_by(id: entry_id)
 
-      if text.blank? || entry.nil?
+      if text.blank? || entry.nil? || !entry.lex_file&.entrytype_person?
         head :unprocessable_content
         return
       end
@@ -77,6 +80,11 @@ module Lexicon
     end
 
     def remove_title_link
+      if params[:index].blank?
+        head :unprocessable_content
+        return
+      end
+
       index = params[:index].to_i
       links = Array(@work.title_links)
       links.delete_at(index) if index >= 0 && index < links.size

--- a/app/controllers/lexicon/person_works_controller.rb
+++ b/app/controllers/lexicon/person_works_controller.rb
@@ -6,7 +6,7 @@ module Lexicon
     before_action do
       require_editor('edit_lexicon')
     end
-    before_action :set_work, only: %i(edit update destroy reorder)
+    before_action :set_work, only: %i(edit update destroy reorder title_links add_title_link remove_title_link)
     before_action :set_person, only: %i(new create index)
     after_action :sync_verification_checklist, only: %i(create update destroy reorder)
 
@@ -53,6 +53,35 @@ module Lexicon
 
     def destroy
       @work.destroy!
+    end
+
+    def title_links; end
+
+    def add_title_link
+      text = params[:text].to_s.strip
+      entry_id = params[:entry_id].to_i
+      entry = LexEntry.find_by(id: entry_id)
+
+      if text.blank? || entry.nil?
+        head :unprocessable_content
+        return
+      end
+
+      links = Array(@work.title_links)
+      unless links.any? { |l| l['text'] == text }
+        links << { 'text' => text, 'entry_id' => entry_id }
+        @work.update!(title_links: links)
+      end
+
+      head :ok
+    end
+
+    def remove_title_link
+      index = params[:index].to_i
+      links = Array(@work.title_links)
+      links.delete_at(index) if index >= 0 && index < links.size
+      @work.update!(title_links: links.presence)
+      head :ok
     end
 
     def reorder

--- a/app/controllers/lexicon/person_works_controller.rb
+++ b/app/controllers/lexicon/person_works_controller.rb
@@ -60,12 +60,16 @@ module Lexicon
       @title_link_entries = LexEntry.where(id: entry_ids).index_by(&:id)
     end
 
+    def person_entry_for_title_link?(entry)
+      entry&.lex_file&.entrytype_person? || entry&.lex_item_type == 'LexPerson'
+    end
+
     def add_title_link
       text = params[:text].to_s.strip
       entry_id = params[:entry_id].to_i
       entry = LexEntry.find_by(id: entry_id)
 
-      if text.blank? || entry.nil? || !entry.lex_file&.entrytype_person?
+      if text.blank? || entry.nil? || !person_entry_for_title_link?(entry)
         head :unprocessable_content
         return
       end

--- a/app/helpers/lexicon_helper.rb
+++ b/app/helpers/lexicon_helper.rb
@@ -44,7 +44,7 @@ module LexiconHelper
     if work.lex_publication.present?
       entry = work.lex_publication.entry
       link_to(entry.title, lexicon_entry_path(entry))
-    elsif work.title_links.present?
+    elsif work.title_links.is_a?(Array) && work.title_links.present?
       html = ERB::Util.html_escape(work.title)
       work.title_links.each do |tl|
         entry = LexEntry.find_by(id: tl['entry_id'])

--- a/app/helpers/lexicon_helper.rb
+++ b/app/helpers/lexicon_helper.rb
@@ -45,22 +45,23 @@ module LexiconHelper
       entry = work.lex_publication.entry
       link_to(entry.title, lexicon_entry_path(entry))
     elsif work.title_links.present?
-      html = work.title.dup
+      html = ERB::Util.html_escape(work.title)
       work.title_links.each do |tl|
         entry = LexEntry.find_by(id: tl['entry_id'])
         next unless entry
 
+        escaped_text = ERB::Util.html_escape(tl['text'])
         # Block form of sub avoids interpreting & or \1 in the replacement string
-        html = html.sub(tl['text']) { link_to(tl['text'], lexicon_entry_path(entry)) }
+        html = html.sub(escaped_text) { link_to(tl['text'], lexicon_entry_path(entry)) }
       end
-      html
+      html.html_safe
     else
       work.title
     end
   end
 
   def render_person_work(work)
-    result = render_person_work_title(work)
+    result = String.new(render_person_work_title(work))
 
     result += " (#{work.publication_place} : #{work.publisher}, #{work.publication_date})"
 

--- a/app/helpers/lexicon_helper.rb
+++ b/app/helpers/lexicon_helper.rb
@@ -35,12 +35,32 @@ module LexiconHelper
     LexLinkedPerson.human_enum_name(:link_type, linked_person.link_type) + ' ' + name
   end
 
+  # Renders a work title, applying hyperlinks from title_links if present.
+  # When the work has a lex_publication, the whole title links to that publication and
+  # title_links are not applied (nested anchors are invalid HTML).
+  # Returns a plain String (possibly containing HTML) so that render_person_work can
+  # safely concatenate further HTML before calling raw() at the end.
+  def render_person_work_title(work)
+    if work.lex_publication.present?
+      entry = work.lex_publication.entry
+      link_to(entry.title, lexicon_entry_path(entry))
+    elsif work.title_links.present?
+      html = work.title.dup
+      work.title_links.each do |tl|
+        entry = LexEntry.find_by(id: tl['entry_id'])
+        next unless entry
+
+        # Block form of sub avoids interpreting & or \1 in the replacement string
+        html = html.sub(tl['text']) { link_to(tl['text'], lexicon_entry_path(entry)) }
+      end
+      html
+    else
+      work.title
+    end
+  end
+
   def render_person_work(work)
-    result = if work.lex_publication.present?
-               link_to(work.lex_publication.title, lexicon_entry_path(work.lex_publication.entry))
-             else
-               work.title
-             end
+    result = render_person_work_title(work)
 
     result += " (#{work.publication_place} : #{work.publisher}, #{work.publication_date})"
 

--- a/app/services/lexicon/ingest_person.rb
+++ b/app/services/lexicon/ingest_person.rb
@@ -27,19 +27,34 @@ module Lexicon
         lex_person.deathdate = match[2]
       end
 
-      if heading_table.parent.name == 'span'
-        span = heading_table.parent
-        # Only move up to the span level if content continues outside it.
-        # When the span has no next sibling, it wraps all page content, so we
-        # stay at the table level and iterate its siblings (which are inside the span).
-        heading_table = span if span.next_element.present?
+      # Bio content may be inside a wrapping span (as siblings of the heading table),
+      # or outside the span (as siblings of the span itself). We first iterate table
+      # siblings; if exhausted, we fall through to span siblings to find remaining bio
+      # and the works header.
+      next_elem = heading_table.next_element
+      at_span_level = false
+
+      # When the table has no siblings inside its wrapping span, jump directly
+      # to the span's siblings where bio content lives.
+      if next_elem.nil? && heading_table.parent.name == 'span'
+        next_elem = heading_table.parent.next_element
+        at_span_level = true
       end
 
-      next_elem = heading_table.next_element
       bio = []
       while next_elem.present? && !header?(next_elem, WORKS_HEADER)
         bio << next_elem.to_html
         next_elem = next_elem.next_element
+      end
+
+      # Bio was inside the wrapping span but the works header is outside it.
+      # Continue from span siblings to find the works header.
+      if next_elem.nil? && !at_span_level && heading_table.parent.name == 'span'
+        next_elem = heading_table.parent.next_element
+        while next_elem.present? && !header?(next_elem, WORKS_HEADER)
+          bio << next_elem.to_html
+          next_elem = next_elem.next_element
+        end
       end
 
       lex_person.bio = HtmlToMarkdown.call(bio.join("\n"))

--- a/app/services/lexicon/lex_person_content.rb
+++ b/app/services/lexicon/lex_person_content.rb
@@ -16,7 +16,7 @@ module Lexicon
 
     def person_works_text(lex_person)
       lex_person.works.map do |work|
-        title = work.lex_publication&.title || work.title
+        title = work.lex_publication&.entry&.title || work.title
 
         result = "#{title} (#{work.publication_place} : #{work.publisher}, #{work.publication_date})"
         if work.comment.present?

--- a/app/services/lexicon/parse_person_work.rb
+++ b/app/services/lexicon/parse_person_work.rb
@@ -39,13 +39,13 @@ module Lexicon
       if !last_open_paren || !last_close_paren || last_open_paren >= last_close_paren
         # no valid parenthesis found, return title only
         result.title = line
-        result.title_links = extract_title_links(element, line)
+        result.title_links = extract_title_links(element, line) if result.respond_to?(:title_links=)
         return result
       end
 
       # Extract title (everything before last '(')
       result.title = line[0...last_open_paren].strip
-      result.title_links = extract_title_links(element, result.title)
+      result.title_links = extract_title_links(element, result.title) if result.respond_to?(:title_links=)
 
       # Extract inner content
       inner = line[(last_open_paren + 1)...last_close_paren].strip

--- a/app/services/lexicon/parse_person_work.rb
+++ b/app/services/lexicon/parse_person_work.rb
@@ -14,7 +14,6 @@ module Lexicon
     }.freeze
     # rubocop:enable Style/WordArray
 
-
     # @param element [Nokogiri::XML::Element] element containing the work information, typically a list item
     def call(element)
       line = element.text&.squish
@@ -40,11 +39,13 @@ module Lexicon
       if !last_open_paren || !last_close_paren || last_open_paren >= last_close_paren
         # no valid parenthesis found, return title only
         result.title = line
+        result.title_links = extract_title_links(element, line)
         return result
       end
 
       # Extract title (everything before last '(')
       result.title = line[0...last_open_paren].strip
+      result.title_links = extract_title_links(element, result.title)
 
       # Extract inner content
       inner = line[(last_open_paren + 1)...last_close_paren].strip
@@ -118,6 +119,35 @@ module Lexicon
       return nil if name.blank?
 
       return LexLinkedPerson.new(name: name, link_type: link_type, person_entry: find_person_entry(name, element))
+    end
+
+    # Scans the HTML element for <a> tags whose text appears in the title portion (not in comment brackets)
+    # and that link to person LexEntries. Returns an array of {text:, entry_id:} hashes.
+    def extract_title_links(element, title_text)
+      links = []
+      # Comments in angle brackets are stripped from the line before the title is extracted,
+      # and comment nodes in HTML are typically inside <font size="2"> wrappers.
+      # We skip any anchor that is a descendant of such a comment wrapper.
+      comment_hrefs = Set.new(element.css('font[size="2"] a').pluck('href'))
+
+      element.css('a').each do |anchor|
+        href = anchor['href']
+        next unless href&.start_with?(lexicon_entries_path + '/')
+        # skip anchors that belong to comment sections
+        next if comment_hrefs.include?(href)
+
+        link_text = anchor.text.squish
+        # Only include if the link text actually appears in the title (not in publication details)
+        next unless title_text.include?(link_text)
+
+        entry_id = href.delete_prefix(lexicon_entries_path + '/').to_i
+        entry = LexEntry.find_by(id: entry_id)
+        next unless entry&.lex_file&.entrytype_person?
+
+        links << { 'text' => link_text, 'entry_id' => entry_id }
+      end
+
+      links.presence
     end
 
     # It is kind-of difficult to parse Html document as-is, so we initially parse plain text of the comment

--- a/app/views/lexicon/person_works/_form.html.haml
+++ b/app/views/lexicon/person_works/_form.html.haml
@@ -1,3 +1,4 @@
+-# haml-lint:disable ViewLength
 :ruby
   path = @work.new_record? ? lexicon_person_works_path(@person) : lexicon_work_path(@work)
   authority = @person.authority
@@ -45,11 +46,44 @@
   %h4= t('.associated_people')
   .border.rounded.p-2#linked-people-list
 
+  %hr
+  %h4= t('lexicon.person_works.title_links.section_heading')
+  .border.rounded.p-2#title-links-list
+
   :javascript
     function reloadLinkedPeople() {
       $('#linked-people-list').load(`/lex/works/#{@work.id}/linked_people`);
     }
     reloadLinkedPeople();
+
+    function reloadTitleLinks() {
+      $('#title-links-list').load(`/lex/works/#{@work.id}/title_links`);
+    }
+    reloadTitleLinks();
+
+    function addTitleLink(workId) {
+      var text = $('#title_link_text').val();
+      var entryId = $('#title_link_entry_id').val();
+      if (!text || !entryId) { return; }
+      $.ajax({
+        url: '/lex/works/' + workId + '/add_title_link',
+        method: 'POST',
+        headers: { 'X-CSRF-Token': $('meta[name="csrf-token"]').attr('content') },
+        data: { text: text, entry_id: entryId },
+        success: reloadTitleLinks
+      });
+    }
+
+    function removeTitleLink(workId, index) {
+      if (!confirm('#{j(t(:are_you_sure))}')) { return; }
+      $.ajax({
+        url: '/lex/works/' + workId + '/remove_title_link',
+        method: 'DELETE',
+        headers: { 'X-CSRF-Token': $('meta[name="csrf-token"]').attr('content') },
+        data: { index: index },
+        success: reloadTitleLinks
+      });
+    }
 
 :javascript
   (function() {

--- a/app/views/lexicon/person_works/_form.html.haml
+++ b/app/views/lexicon/person_works/_form.html.haml
@@ -44,22 +44,20 @@
 - unless @work.new_record?
   %hr
   %h4= t('.associated_people')
-  .border.rounded.p-2#linked-people-list
+  .border.rounded.p-2#linked-people-list{ data: { ajax_url: lexicon_work_linked_people_path(@work) } }
 
   %hr
   %h4= t('lexicon.person_works.title_links.section_heading')
-  .border.rounded.p-2#title-links-list
+  .border.rounded.p-2#title-links-list{ data: { ajax_url: title_links_lexicon_work_path(@work) } }
 
   :javascript
     function reloadLinkedPeople() {
-      $('#linked-people-list').load(`/lex/works/#{@work.id}/linked_people`);
+      $('#linked-people-list').load('#{lexicon_work_linked_people_path(@work)}');
     }
-    reloadLinkedPeople();
 
     function reloadTitleLinks() {
-      $('#title-links-list').load(`/lex/works/#{@work.id}/title_links`);
+      $('#title-links-list').load('#{title_links_lexicon_work_path(@work)}');
     }
-    reloadTitleLinks();
 
     function addTitleLink(workId) {
       var text = $('#title_link_text').val();

--- a/app/views/lexicon/person_works/title_links.html.haml
+++ b/app/views/lexicon/person_works/title_links.html.haml
@@ -1,6 +1,6 @@
 -# haml-lint:disable LineLength
 %ul.title-links-list.list-unstyled.mb-2
-  - (@work.title_links || []).each_with_index do |link, idx|
+  - Array(@work.title_links).each_with_index do |link, idx|
     - entry = @title_link_entries[link['entry_id']]
     %li.d-flex.align-items-center.gap-2.mb-1
       %span.badge.bg-light.text-dark.border= link['text']

--- a/app/views/lexicon/person_works/title_links.html.haml
+++ b/app/views/lexicon/person_works/title_links.html.haml
@@ -1,0 +1,38 @@
+-# haml-lint:disable LineLength
+%ul.title-links-list.list-unstyled.mb-2
+  - (@work.title_links || []).each_with_index do |link, idx|
+    - entry = LexEntry.find_by(id: link['entry_id'])
+    %li.d-flex.align-items-center.gap-2.mb-1
+      %span.badge.bg-light.text-dark.border= link['text']
+      %span →
+      - if entry
+        = link_to entry.title, lexicon_entry_path(entry), target: '_blank', rel: 'noopener'
+      - else
+        %span.text-muted= t('lexicon.person_works.title_links.entry_not_found')
+      %button.btn.btn-sm.btn-outline-danger{ onclick: "removeTitleLink(#{@work.id}, #{idx})" }
+        = t(:delete)
+
+%hr.my-2
+%strong= t('lexicon.person_works.title_links.add_link')
+.row.g-2.align-items-end.mt-1#add-title-link-form
+  .col-sm-5
+    = label_tag :title_link_text, t('lexicon.person_works.title_links.text_in_title'), class: 'form-label form-label-sm'
+    = text_field_tag :title_link_text, nil, class: 'form-control form-control-sm', id: 'title_link_text', placeholder: t('lexicon.person_works.title_links.text_placeholder')
+  .col-sm-5
+    = label_tag :title_link_entry_autocomplete, t('lexicon.person_works.title_links.target_person'), class: 'form-label form-label-sm'
+    = hidden_field_tag :title_link_entry_id, nil, id: 'title_link_entry_id'
+    = autocomplete_field_tag :title_link_entry_autocomplete,
+                             nil,
+                             autocomplete_lexicon_entries_path(entry_type: :person),
+                             id_element: '#title_link_entry_id',
+                             class: 'form-control form-control-sm',
+                             placeholder: t('lexicon.person_works.title_links.person_placeholder')
+  .col-sm-2
+    %button.btn.btn-sm.btn-primary.w-100{ onclick: "addTitleLink(#{@work.id})" }
+      = t(:add)
+
+:javascript
+  $.ui.autocomplete.prototype._resizeMenu = function () {
+    const ul = this.menu.element;
+    ul.outerWidth(this.element.outerWidth());
+  };

--- a/app/views/lexicon/person_works/title_links.html.haml
+++ b/app/views/lexicon/person_works/title_links.html.haml
@@ -1,7 +1,7 @@
 -# haml-lint:disable LineLength
 %ul.title-links-list.list-unstyled.mb-2
   - (@work.title_links || []).each_with_index do |link, idx|
-    - entry = LexEntry.find_by(id: link['entry_id'])
+    - entry = @title_link_entries[link['entry_id']]
     %li.d-flex.align-items-center.gap-2.mb-1
       %span.badge.bg-light.text-dark.border= link['text']
       %span →

--- a/app/views/lexicon/verification/_person_sections.html.haml
+++ b/app/views/lexicon/verification/_person_sections.html.haml
@@ -154,7 +154,7 @@
         - works.each do |work|
           .work-card{ id: "work-#{work.id}", class: work_card_css(work, checklist) }
             .work-content{dir: text_dir(work.title)}
-              %strong!= render_person_work_title(work)
+              %strong= render_person_work_title(work)
               - pub_detail = format_publication_details(work)
               - if pub_detail
                 %br

--- a/app/views/lexicon/verification/_person_sections.html.haml
+++ b/app/views/lexicon/verification/_person_sections.html.haml
@@ -150,11 +150,11 @@
         %button.btn-close{type: 'button', 'data-bs-dismiss': 'alert', 'aria-label': 'Close'}
     - if all_works.present?
       - all_works.group_by(&:work_type).each do |work_type, works|
-        %h6.mt-2= LexPersonWork.human_enum_name(:work_type, work_type)
+        %h5.mt-3.mb-1.work-type-heading= LexPersonWork.human_enum_name(:work_type, work_type)
         - works.each do |work|
           .work-card{ id: "work-#{work.id}", class: work_card_css(work, checklist) }
             .work-content{dir: text_dir(work.title)}
-              %strong= work.title
+              %strong!= render_person_work_title(work)
               - pub_detail = format_publication_details(work)
               - if pub_detail
                 %br

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3247,6 +3247,16 @@ en:
         add_work: Add Work
         drag_to_reorder: Drag to reorder
         reordering_failed: Reordering failed
+      form:
+        associated_people: Associated People
+      title_links:
+        section_heading: Title Links
+        add_link: Add Title Link
+        text_in_title: Text in title
+        text_placeholder: Text that becomes a link
+        target_person: Target person
+        person_placeholder: Search person entry...
+        entry_not_found: Entry not found
     citations:
       index:
         add_citation: Add Citation

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -2499,6 +2499,15 @@ he:
         no_authority_warning: לא ניתן לקשר יצירות לפרסומים מבלי לקשר את האדם לישות במאגר בן-יהודה
         select_publication: בחר פרסום...
         select_collection: בחר אוסף...
+        associated_people: אנשים קשורים
+      title_links:
+        section_heading: קישורים בכותרת
+        add_link: הוספת קישור בכותרת
+        text_in_title: טקסט בכותרת
+        text_placeholder: טקסט שיהפוך לקישור
+        target_person: אדם ביעד
+        person_placeholder: חפש ערך אדם...
+        entry_not_found: ערך לא נמצא
     citations:
       index:
         add_citation: הוספת מראה מקום

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -72,6 +72,11 @@ Bybeconv::Application.routes.draw do
       resources :works, controller: 'person_works', shallow: true, except: %i(show) do
         post :reorder, on: :member
         resources :linked_people, only: %i(index create)
+        member do
+          get :title_links
+          post :add_title_link
+          delete :remove_title_link
+        end
       end
     end
 

--- a/db/migrate/20260527222817_add_title_links_to_lex_person_works.rb
+++ b/db/migrate/20260527222817_add_title_links_to_lex_person_works.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddTitleLinksToLexPersonWorks < ActiveRecord::Migration[8.1]
+  def change
+    add_column :lex_person_works, :title_links, :json
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_27_163007) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_27_222817) do
   create_table "aboutnesses", id: :integer, charset: "utf8mb4", collation: "utf8mb4_bin", force: :cascade do |t|
     t.integer "aboutable_id"
     t.string "aboutable_type"
@@ -671,6 +671,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_27_163007) do
     t.json "external_identifiers"
     t.bigint "lex_item_id"
     t.string "lex_item_type"
+    t.datetime "locked_at"
+    t.integer "locked_by_user_id"
     t.string "other_designation", limit: 1024
     t.bigint "profile_image_id"
     t.string "sort_title"
@@ -679,6 +681,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_27_163007) do
     t.datetime "updated_at", precision: nil, null: false
     t.json "verification_progress"
     t.index ["lex_item_type", "lex_item_id"], name: "index_lex_entries_on_lex_item_type_and_lex_item_id", unique: true
+    t.index ["locked_by_user_id"], name: "index_lex_entries_on_locked_by_user_id"
     t.index ["profile_image_id"], name: "index_lex_entries_on_profile_image_id"
     t.index ["sort_title"], name: "index_lex_entries_on_sort_title"
     t.index ["status"], name: "index_lex_entries_on_status"
@@ -720,7 +723,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_27_163007) do
     t.string "new_path", null: false
     t.string "old_path", null: false
     t.index ["lex_entry_id"], name: "index_lex_legacy_links_on_lex_entry_id"
-    t.index ["old_path"], name: "index_lex_legacy_links_on_old_path", unique: true
+    t.index ["old_path"], name: "index_lex_legacy_links_on_old_path"
   end
 
   create_table "lex_linked_people", charset: "utf8mb4", collation: "utf8mb4_bin", force: :cascade do |t|
@@ -786,6 +789,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_27_163007) do
     t.string "publisher"
     t.integer "seqno", null: false
     t.string "title", limit: 500, null: false
+    t.json "title_links"
     t.datetime "updated_at", null: false
     t.integer "work_type", null: false
     t.index ["collection_id"], name: "index_lex_person_works_on_collection_id"

--- a/spec/fixtures/files/lexicon/bio_in_span_works_outside.php
+++ b/spec/fixtures/files/lexicon/bio_in_span_works_outside.php
@@ -1,0 +1,38 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>סופרת לדוגמה</title>
+</head>
+<!-- page header --><?php
+include "header.php";
+?><span dir="rtl">
+<body dir="rtl">
+
+<table border="0" width="100%" id="table4">
+  <tr>
+    <td><p align="center"><font size="5" color="#FF0000">סופרת לדוגמה</font><font size="4" color="#FF0000"> (1972)</font></td>
+    <td><p align="center" dir="ltr"><font size="5" color="#FF0000">Example Author</font></td>
+  </tr>
+</table>
+<p class="margin" align="justify">
+ביוגרפיה קצרה של הסופרת לדוגמה. היא נולדה בשנת 1972 וכתבה ספרים רבים.
+</p>
+</span>
+<font size="4" color="#0000FF">
+<a name="Books">ספריה:</a></font></p>
+<span dir="rtl">
+<ul style="MARGIN-TOP: 0in" type="circle">
+  <li>ספר ראשון : שירים (תל אביב : הוצאה לדוגמה, 1980)</li>
+  <li>ספר שני : פרוזה (תל אביב : הוצאה אחרת, 1990)</li>
+</ul>
+</span>
+<font size="4" color="#0000FF"><a name="Bib.">על המחברת ויצירתה:</a></font></p>
+<p>לא נמצאו מקורות.</p>
+<font size="4" color="#0000FF"><a name="links">קישורים:</a></font>
+<ul style="MARGIN-TOP: 0in" type="circle">
+</ul>
+<!-- page footer --><?php
+include "footer.php";
+?>
+</body>
+</html>

--- a/spec/helpers/lexicon_helper_spec.rb
+++ b/spec/helpers/lexicon_helper_spec.rb
@@ -132,4 +132,47 @@ RSpec.describe LexiconHelper, type: :helper do
       expect(result).to include('rel="noopener noreferrer"')
     end
   end
+
+  describe '#render_person_work_title' do
+    let(:work) { build(:lex_person_work, title: 'ספר זכרון לאפרת דנון', title_links: nil) }
+
+    context 'when no lex_publication and no title_links' do
+      it 'returns the plain title string' do
+        expect(helper.render_person_work_title(work)).to eq('ספר זכרון לאפרת דנון')
+      end
+    end
+
+    context 'when title_links are present' do
+      let!(:target_entry) { create(:lex_entry, :person, title: 'אפרת דנון') }
+
+      before do
+        work.title_links = [{ 'text' => 'אפרת דנון', 'entry_id' => target_entry.id }]
+      end
+
+      it 'replaces the linked text with an anchor tag' do
+        result = helper.render_person_work_title(work)
+        expect(result).to include('<a ')
+        expect(result).to include('אפרת דנון')
+        expect(result).to include(lexicon_entry_path(target_entry))
+      end
+
+      it 'preserves surrounding title text' do
+        result = helper.render_person_work_title(work)
+        expect(result).to include('ספר זכרון ל')
+      end
+    end
+
+    context 'when lex_publication is present' do
+      let!(:publication_entry) { create(:lex_entry, :publication, title: 'כותרת הפרסום') }
+
+      before { work.lex_publication = publication_entry.lex_item }
+
+      it 'links the title to the publication entry regardless of title_links' do
+        work.title_links = [{ 'text' => 'אפרת דנון', 'entry_id' => 999 }]
+        result = helper.render_person_work_title(work)
+        expect(result).to include(lexicon_entry_path(publication_entry))
+        expect(result).to include('כותרת הפרסום')
+      end
+    end
+  end
 end

--- a/spec/requests/lexicon/person_works_spec.rb
+++ b/spec/requests/lexicon/person_works_spec.rb
@@ -260,14 +260,14 @@ describe '/lexicon/person_works' do
   end
 
   describe 'POST /lex/works/:id/add_title_link' do
-    let!(:work) { create(:lex_person_work, person: person, title: 'ספר זכרון לאפרת דנון') }
-    let!(:target_entry) { create(:lex_file, :person, title: 'אפרת דנון').lex_entry }
-
     subject(:call) do
       post "/lex/works/#{work.id}/add_title_link",
            params: { text: 'אפרת דנון', entry_id: target_entry.id },
            xhr: true
     end
+
+    let!(:work) { create(:lex_person_work, person: person, title: 'ספר זכרון לאפרת דנון') }
+    let!(:target_entry) { create(:lex_file, :person, title: 'אפרת דנון').lex_entry }
 
     it 'adds the title link and returns 200' do
       expect(call).to eq(200)
@@ -302,19 +302,34 @@ describe '/lexicon/person_works' do
         expect(call).to eq(422)
       end
     end
+
+    context 'when entry is not a person' do
+      subject(:call) do
+        post "/lex/works/#{work.id}/add_title_link",
+             params: { text: 'ספר כלשהו', entry_id: publication_entry.id },
+             xhr: true
+      end
+
+      let!(:publication_entry) { create(:lex_file, :publication, title: 'ספר כלשהו').lex_entry }
+
+      it 'returns 422' do
+        expect(call).to eq(422)
+      end
+    end
   end
 
   describe 'DELETE /lex/works/:id/remove_title_link' do
+    subject(:call) do
+      delete "/lex/works/#{work.id}/remove_title_link", params: { index: 0 }, xhr: true
+    end
+
     let!(:work) do
-      create(:lex_person_work, person: person,
+      create(:lex_person_work,
+             person: person,
              title_links: [
                { 'text' => 'אפרת דנון', 'entry_id' => 1 },
                { 'text' => 'שמואל כץ', 'entry_id' => 2 }
              ])
-    end
-
-    subject(:call) do
-      delete "/lex/works/#{work.id}/remove_title_link", params: { index: 0 }, xhr: true
     end
 
     it 'removes the link at the given index and returns 200' do

--- a/spec/requests/lexicon/person_works_spec.rb
+++ b/spec/requests/lexicon/person_works_spec.rb
@@ -250,4 +250,82 @@ describe '/lexicon/person_works' do
       end
     end
   end
+
+  describe 'GET /lex/works/:id/title_links' do
+    let(:work) { create(:lex_person_work, person: person) }
+
+    it 'returns 200' do
+      expect(get("/lex/works/#{work.id}/title_links", xhr: true)).to eq(200)
+    end
+  end
+
+  describe 'POST /lex/works/:id/add_title_link' do
+    let!(:work) { create(:lex_person_work, person: person, title: 'ספר זכרון לאפרת דנון') }
+    let!(:target_entry) { create(:lex_file, :person, title: 'אפרת דנון').lex_entry }
+
+    subject(:call) do
+      post "/lex/works/#{work.id}/add_title_link",
+           params: { text: 'אפרת דנון', entry_id: target_entry.id },
+           xhr: true
+    end
+
+    it 'adds the title link and returns 200' do
+      expect(call).to eq(200)
+      expect(work.reload.title_links).to eq([{ 'text' => 'אפרת דנון', 'entry_id' => target_entry.id }])
+    end
+
+    it 'does not duplicate an existing link with the same text' do
+      work.update!(title_links: [{ 'text' => 'אפרת דנון', 'entry_id' => target_entry.id }])
+      expect { call }.not_to(change { work.reload.title_links.size })
+    end
+
+    context 'when text is blank' do
+      subject(:call) do
+        post "/lex/works/#{work.id}/add_title_link",
+             params: { text: '', entry_id: target_entry.id },
+             xhr: true
+      end
+
+      it 'returns 422' do
+        expect(call).to eq(422)
+      end
+    end
+
+    context 'when entry does not exist' do
+      subject(:call) do
+        post "/lex/works/#{work.id}/add_title_link",
+             params: { text: 'אפרת דנון', entry_id: 999_999 },
+             xhr: true
+      end
+
+      it 'returns 422' do
+        expect(call).to eq(422)
+      end
+    end
+  end
+
+  describe 'DELETE /lex/works/:id/remove_title_link' do
+    let!(:work) do
+      create(:lex_person_work, person: person,
+             title_links: [
+               { 'text' => 'אפרת דנון', 'entry_id' => 1 },
+               { 'text' => 'שמואל כץ', 'entry_id' => 2 }
+             ])
+    end
+
+    subject(:call) do
+      delete "/lex/works/#{work.id}/remove_title_link", params: { index: 0 }, xhr: true
+    end
+
+    it 'removes the link at the given index and returns 200' do
+      expect(call).to eq(200)
+      expect(work.reload.title_links).to eq([{ 'text' => 'שמואל כץ', 'entry_id' => 2 }])
+    end
+
+    it 'sets title_links to nil when removing the last link' do
+      work.update!(title_links: [{ 'text' => 'אפרת דנון', 'entry_id' => 1 }])
+      delete "/lex/works/#{work.id}/remove_title_link", params: { index: 0 }, xhr: true
+      expect(work.reload.title_links).to be_nil
+    end
+  end
 end

--- a/spec/services/lexicon/ingest_person_spec.rb
+++ b/spec/services/lexicon/ingest_person_spec.rb
@@ -103,6 +103,35 @@ describe Lexicon::IngestPerson do
     end
   end
 
+  context 'when bio is inside the heading span but works header is outside it' do
+    # Regression test for 00118.php: the <span dir="rtl"> wraps only the heading table
+    # and the bio <p>, but the Books header <font> and works are siblings of the span.
+    # The old promotion logic (heading_table = span) caused the bio <p> to be skipped
+    # because span.next_element immediately hit the Books header.
+    let!(:file) do
+      create(
+        :lex_file,
+        {
+          entrytype: :person,
+          status: :classified,
+          title: 'סופרת לדוגמה',
+          fname: 'bio_in_span_works_outside.php',
+          full_path: Rails.root.join('spec/fixtures/files/lexicon/bio_in_span_works_outside.php')
+        }
+      )
+    end
+
+    it 'ingests bio and works correctly' do
+      expect { call }.to change(LexPerson, :count).by(1)
+
+      person = file.lex_entry.lex_item
+      expect(person.bio).to be_present
+      expect(person.bio).to include('ביוגרפיה קצרה')
+      expect(person.works.count).to eq(2)
+      expect(person.works.map(&:title)).to include('ספר ראשון : שירים', 'ספר שני : פרוזה')
+    end
+  end
+
   context 'when a link has href as its only attribute (no target="_blank")' do
     let!(:file) do
       create(

--- a/spec/services/lexicon/lex_person_content_spec.rb
+++ b/spec/services/lexicon/lex_person_content_spec.rb
@@ -18,4 +18,22 @@ describe Lexicon::LexPersonContent do
   it 'completes successfully' do
     expect(result).to be_present
   end
+
+  context 'when a work is linked to a lex_publication' do
+    let(:publication_entry) { create(:lex_entry, title: 'פרסום ייחודי', lex_item: create(:lex_publication)) }
+
+    let(:lex_person) do
+      create(:lex_entry, :person).lex_item.tap do |person|
+        person.birthdate = '1950'
+        person.deathdate = '2020'
+        person.works = [build(:lex_person_work, title: 'original title', lex_publication: publication_entry.lex_item)]
+        person.save!
+      end
+    end
+
+    it 'uses the publication entry title in the indexed content' do
+      expect(result).to include('פרסום ייחודי')
+      expect(result).not_to include('original title')
+    end
+  end
 end

--- a/spec/services/lexicon/parse_person_work_spec.rb
+++ b/spec/services/lexicon/parse_person_work_spec.rb
@@ -173,4 +173,44 @@ describe Lexicon::ParsePersonWork do
       )
     end
   end
+
+  context 'when the title contains a link to a person LexEntry' do
+    let!(:person_entry) { create(:lex_file, :person, title: 'אפרת דנון').lex_entry }
+    let(:line) do
+      "ספר זכרון: <a href=\"/lex/entries/#{person_entry.id}\">אפרת דנון</a> (ירושלים : מוסד ביאליק, 1995)"
+    end
+
+    it 'extracts the title without HTML tags' do
+      expect(result.title).to eq('ספר זכרון: אפרת דנון')
+    end
+
+    it 'stores the title link with text and entry_id' do
+      expect(result.title_links).to eq([{ 'text' => 'אפרת דנון', 'entry_id' => person_entry.id }])
+    end
+  end
+
+  context 'when a comment contains a person link but the title does not' do
+    let!(:editor_entry) { create(:lex_file, :person, title: 'יעל גובר').lex_entry }
+    let(:line) do
+      "ילדים מהנים (תל-אביב : הקיבוץ, 2010) <font size=\"2\">&lt;עריכה – " \
+        "<a href=\"/lex/entries/#{editor_entry.id}\">יעל גובר</a>&gt;</font>"
+    end
+
+    it 'does not add title_links for comment-only person links' do
+      expect(result.title_links).to be_nil
+    end
+
+    it 'adds the person as a linked_person instead' do
+      expect(result.linked_people.size).to eq(1)
+      expect(result.linked_people[0]).to have_attributes(name: 'יעל גובר', link_type: 'editor')
+    end
+  end
+
+  context 'when there are no links anywhere' do
+    let(:line) { 'ספרי שירה (תל-אביב : שוקן, 2005)' }
+
+    it 'returns nil for title_links' do
+      expect(result.title_links).to be_nil
+    end
+  end
 end

--- a/spec/services/lexicon/parse_person_work_spec.rb
+++ b/spec/services/lexicon/parse_person_work_spec.rb
@@ -192,7 +192,7 @@ describe Lexicon::ParsePersonWork do
   context 'when a comment contains a person link but the title does not' do
     let!(:editor_entry) { create(:lex_file, :person, title: 'יעל גובר').lex_entry }
     let(:line) do
-      "ילדים מהנים (תל-אביב : הקיבוץ, 2010) <font size=\"2\">&lt;עריכה – " \
+      'ילדים מהנים (תל-אביב : הקיבוץ, 2010) <font size="2">&lt;עריכה – ' \
         "<a href=\"/lex/entries/#{editor_entry.id}\">יעל גובר</a>&gt;</font>"
     end
 

--- a/spec/system/lexicon/person_work_title_links_spec.rb
+++ b/spec/system/lexicon/person_work_title_links_spec.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'LexPersonWork title links in edit modal', type: :system, js: true do
+  before do
+    skip 'WebDriver not available or misconfigured' unless webdriver_available?
+    login_as_lexicon_editor
+  end
+
+  let!(:target_entry) { create(:lex_file, :person, title: 'אפרת דנון').lex_entry }
+
+  let!(:person) do
+    create(:lex_person, birthdate: '1970', gender: :female)
+  end
+
+  let!(:entry) do
+    create(:lex_entry, title: 'Test Author', lex_item: person, status: :draft)
+  end
+
+  let!(:lex_file) do
+    file_path = Rails.root.join('tmp/test_title_links_author.php')
+    File.write(file_path, '<html><body><h1>Test Author</h1></body></html>')
+    create(:lex_file,
+           lex_entry: entry,
+           fname: 'test_title_links_author.php',
+           full_path: file_path.to_s,
+           status: :ingested,
+           entrytype: :person)
+  end
+
+  let!(:work) do
+    create(:lex_person_work,
+           person: person,
+           work_type: :edited,
+           title: 'דג בבטן / אפרת דנון',
+           title_links: [{ 'text' => 'אפרת דנון', 'entry_id' => target_entry.id }])
+  end
+
+  after { FileUtils.rm_f(Rails.root.join('tmp/test_title_links_author.php')) }
+
+  it 'shows the existing title link in the edit modal opened from the verification page' do
+    visit "/lex/verification/#{entry.id}"
+
+    within "#work-#{work.id}" do
+      click_button I18n.t('lexicon.verification.migrated.edit')
+    end
+
+    expect(page).to have_css('#generalDlg.show', wait: 5)
+
+    within '#generalDlg' do
+      # Wait for title-links AJAX to load
+      expect(page).to have_css('#title-links-list', wait: 5)
+      expect(page).to have_css('#title-links-list ul li', wait: 5)
+      expect(page).to have_css('#title-links-list .badge', text: 'אפרת דנון', wait: 5)
+    end
+  end
+
+  it 'shows the existing title link in the edit modal opened from the entry edit page' do
+    visit "/lex/entries/#{entry.id}/edit"
+
+    # Click the Works tab to trigger lazy-loading
+    find('#works_tab').click
+    expect(page).to have_css('#works .edit-person-work', wait: 10)
+
+    # Click the edit link for our work
+    find("#work_#{work.id} .edit-person-work").click
+
+    expect(page).to have_css('#generalDlg.show', wait: 5)
+
+    within '#generalDlg' do
+      expect(page).to have_css('#title-links-list ul li', wait: 10)
+      expect(page).to have_css('#title-links-list .badge', text: 'אפרת דנון', wait: 5)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- **Title links**: Adds a `title_links` JSON column to `lex_person_works` to store hyperlinks embedded in work titles (e.g. a work titled "ספר זכרון: אפרת דנון" can link the name to that person's lexicon entry). This functionality existed in the legacy PHP files and is now preserved.
- **Parser update**: `ParsePersonWork` now extracts `<a>` tags from the title portion of HTML elements (excluding comment-bracket anchors) and stores them as `[{text:, entry_id:}]` arrays.
- **Display**: `LexiconHelper#render_person_work_title` applies the stored links at render time, covering both the verification workbench and the public-facing lexicon entry view.
- **Editing UI**: New `title_links`, `add_title_link`, and `remove_title_link` actions on `PersonWorksController` (with AJAX UI in the work edit form) allow editors to manually manage title links.
- **Heading prominence**: Work-type group headings (original/edited/translated/festschrift) in the verification workbench are promoted from `h6` to `h5` with a `border-bottom` for better visibility when scrolling.
- **Bug fix**: Fixes a pre-existing bug in `render_person_work` where `lex_publication.title` was called (no such column on `LexPublication`); corrected to `lex_publication.entry.title`.

## Test plan

- [ ] `bundle exec rspec spec/services/lexicon/parse_person_work_spec.rb` — tests for title_links extraction from HTML
- [ ] `bundle exec rspec spec/helpers/lexicon_helper_spec.rb` — tests for `render_person_work_title` with and without links
- [ ] `bundle exec rspec spec/requests/lexicon/person_works_spec.rb` — tests for add/remove title_links AJAX endpoints
- [ ] Open a work in the verification workbench edit modal → "Title Links" section appears at bottom
- [ ] Add a title link via the autocomplete form; confirm it appears in the list and in the work title display

🤖 Generated with [Claude Code](https://claude.com/claude-code)