### PR TITLE
Show first issue cover images on periodicals index tiles

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1157,3 +1157,33 @@ p.by-genre-name-v02.headline-2-v02 {
 .donation-btn-v02 {
   min-width: 122px;
 }
+
+.author-card-v02.periodical-with-cover {
+  .periodical-cover-img {
+    width: 160px;
+    height: 280px;
+    border-radius: 3px;
+    object-fit: cover;
+    position: absolute;
+    top: 0;
+    left: 0;
+  }
+
+  .author-name-area {
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    height: auto;
+    min-height: 50px;
+    z-index: 1;
+    background: rgba(0, 0, 0, 0.55);
+    border-bottom-left-radius: 3px;
+    border-bottom-right-radius: 3px;
+    padding: 6px 4px;
+
+    .author-name-v02 {
+      text-shadow: 0 1px 3px rgba(0, 0, 0, 0.9);
+    }
+  }
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1159,14 +1159,15 @@ p.by-genre-name-v02.headline-2-v02 {
 }
 
 .author-card-v02.periodical-with-cover {
+  overflow: hidden;
+  border-radius: 3px;
+
   .periodical-cover-img {
-    width: 160px;
-    height: 280px;
-    border-radius: 3px;
+    width: 100%;
+    height: 100%;
     object-fit: cover;
     position: absolute;
-    top: 0;
-    left: 0;
+    inset: 0;
   }
 
   .author-name-area {
@@ -1178,8 +1179,6 @@ p.by-genre-name-v02.headline-2-v02 {
     min-height: 50px;
     z-index: 1;
     background: rgba(0, 0, 0, 0.55);
-    border-bottom-left-radius: 3px;
-    border-bottom-right-radius: 3px;
     padding: 6px 4px;
 
     .author-name-v02 {

--- a/app/controllers/periodicals_controller.rb
+++ b/app/controllers/periodicals_controller.rb
@@ -22,7 +22,33 @@ class PeriodicalsController < ApplicationController
     end
     @periodical_authors_in_genre = cached_periodical_authors_in_genre
     @periodical_works_by_genre = Manifestation.cached_periodical_work_counts_by_genre
+    @periodical_first_covers = build_periodical_first_covers(@periodicals)
   end
 
   def show; end
+
+  private
+
+  def build_periodical_first_covers(periodicals)
+    issue_ids_by_periodical = {}
+    periodicals.each do |p|
+      ids = p.collection_items.select { |ci| ci.item_type == 'Collection' }.map(&:item_id)
+      issue_ids_by_periodical[p.id] = ids
+    end
+
+    all_issue_ids = issue_ids_by_periodical.values.flatten.uniq
+    return {} if all_issue_ids.empty?
+
+    all_issues = Collection.where(id: all_issue_ids).to_a
+    ActiveRecord::Associations::Preloader.new(
+      records: all_issues,
+      associations: { cover_image_attachment: :blob }
+    ).call
+    issues_by_id = all_issues.index_by(&:id)
+
+    periodicals.each_with_object({}) do |p, hash|
+      ids = issue_ids_by_periodical[p.id]
+      hash[p.id] = ids.lazy.map { |id| issues_by_id[id] }.find { |i| i&.cover_image&.attached? }
+    end
+  end
 end

--- a/app/views/periodicals/index.html.haml
+++ b/app/views/periodicals/index.html.haml
@@ -15,13 +15,25 @@
           %div{style: 'display: flex; align-items: center; justify-content: center; flex-wrap: wrap; gap: 15px;'}
             - i = 0
             - @periodicals.each do |periodical|
+              - cover_issue = @periodical_first_covers[periodical.id]
               .slide{ style: i >= 5 ? 'display: none;' : '' }
                 %a{ href: collection_path(periodical) }
-                  .author-card-v02{style: 'margin-left: 0; margin-right: 0;'}
-                    %img.author-pic-v02{src: periodical.logo_image.present? ? url_for(periodical.logo_image) : '', alt: periodical.title }/
-                    .author-name-area
-                      .author-name-v02= t('.x_issues', x: periodical.collection_items.count)
-                      .author-name-v02= t('.x_texts', x: periodical.manifestations_count)
+                  - if cover_issue
+                    - if cover_issue.cover_image.variable?
+                      - cover_src = url_for(cover_issue.cover_image.variant(resize_to_fill: [160, 280]))
+                    - else
+                      - cover_src = url_for(cover_issue.cover_image)
+                    .author-card-v02.periodical-with-cover{ style: 'margin-left: 0; margin-right: 0;' }
+                      %img.periodical-cover-img{ src: cover_src, alt: periodical.title }/
+                      .author-name-area
+                        .author-name-v02= t('.x_issues', x: periodical.collection_items.count)
+                        .author-name-v02= t('.x_texts', x: periodical.manifestations_count)
+                  - else
+                    .author-card-v02{ style: 'margin-left: 0; margin-right: 0;' }
+                      %img.author-pic-v02{ src: periodical.logo_image.present? ? url_for(periodical.logo_image) : '', alt: periodical.title }/
+                      .author-name-area
+                        .author-name-v02= t('.x_issues', x: periodical.collection_items.count)
+                        .author-name-v02= t('.x_texts', x: periodical.manifestations_count)
               - i += 1
           .link-to-all-v02.pointer
             %a#periodicals-view-all{:href => "#"}

--- a/app/views/periodicals/index.html.haml
+++ b/app/views/periodicals/index.html.haml
@@ -26,6 +26,7 @@
                     .author-card-v02.periodical-with-cover{ style: 'margin-left: 0; margin-right: 0;' }
                       %img.periodical-cover-img{ src: cover_src, alt: periodical.title }/
                       .author-name-area
+                        .author-name-v02= periodical.title
                         .author-name-v02= t('.x_issues', x: periodical.collection_items.count)
                         .author-name-v02= t('.x_texts', x: periodical.manifestations_count)
                   - else

--- a/app/views/periodicals/index.html.haml
+++ b/app/views/periodicals/index.html.haml
@@ -27,13 +27,13 @@
                       %img.periodical-cover-img{ src: cover_src, alt: periodical.title }/
                       .author-name-area
                         .author-name-v02= periodical.title
-                        .author-name-v02= t('.x_issues', x: periodical.collection_items.count)
+                        .author-name-v02= t('.x_issues', x: periodical.collection_items.size)
                         .author-name-v02= t('.x_texts', x: periodical.manifestations_count)
                   - else
                     .author-card-v02{ style: 'margin-left: 0; margin-right: 0;' }
                       %img.author-pic-v02{ src: periodical.logo_image.present? ? url_for(periodical.logo_image) : '', alt: periodical.title }/
                       .author-name-area
-                        .author-name-v02= t('.x_issues', x: periodical.collection_items.count)
+                        .author-name-v02= t('.x_issues', x: periodical.collection_items.size)
                         .author-name-v02= t('.x_texts', x: periodical.manifestations_count)
               - i += 1
           .link-to-all-v02.pointer

--- a/spec/requests/periodicals_spec.rb
+++ b/spec/requests/periodicals_spec.rb
@@ -88,4 +88,58 @@ RSpec.describe 'Periodicals', type: :request do
       expect(response).to have_http_status(:success)
     end
   end
+
+  describe '@periodical_first_covers assignment' do
+    let!(:periodical) { create(:collection, collection_type: 'periodical') }
+    let!(:issue_no_cover) { create(:collection, collection_type: 'periodical_issue') }
+    let!(:issue_with_cover) do
+      c = create(:collection, collection_type: 'periodical_issue')
+      c.cover_image.attach(
+        io: StringIO.new(Rails.root.join('spec/fixtures/files/test_image.jpg').binread),
+        filename: 'cover.jpg',
+        content_type: 'image/jpeg'
+      )
+      c
+    end
+
+    before do
+      create(:collection_item, collection: periodical, item: issue_no_cover, seqno: 1)
+      create(:collection_item, collection: periodical, item: issue_with_cover, seqno: 2)
+    end
+
+    it 'assigns @periodical_first_covers as a hash' do
+      get '/periodicals'
+      expect(assigns(:periodical_first_covers)).to be_a(Hash)
+    end
+
+    it 'maps the periodical to the first issue with a cover image' do
+      get '/periodicals'
+      expect(assigns(:periodical_first_covers)[periodical.id]).to eq(issue_with_cover)
+    end
+
+    it 'renders the cover image tile for periodicals with a covered issue' do
+      get '/periodicals'
+      expect(response.body).to include('periodical-with-cover')
+      expect(response.body).to include('periodical-cover-img')
+    end
+  end
+
+  describe '@periodical_first_covers with no covered issues' do
+    let!(:periodical) { create(:collection, collection_type: 'periodical') }
+    let!(:issue_no_cover) { create(:collection, collection_type: 'periodical_issue') }
+
+    before do
+      create(:collection_item, collection: periodical, item: issue_no_cover, seqno: 1)
+    end
+
+    it 'maps the periodical to nil when no issues have a cover' do
+      get '/periodicals'
+      expect(assigns(:periodical_first_covers)[periodical.id]).to be_nil
+    end
+
+    it 'does not render the cover image tile' do
+      get '/periodicals'
+      expect(response.body).not_to include('periodical-with-cover')
+    end
+  end
 end

--- a/spec/requests/periodicals_spec.rb
+++ b/spec/requests/periodicals_spec.rb
@@ -90,7 +90,7 @@ RSpec.describe 'Periodicals', type: :request do
   end
 
   describe '@periodical_first_covers assignment' do
-    let!(:periodical) { create(:collection, collection_type: 'periodical') }
+    let!(:periodical) { create(:collection, collection_type: 'periodical', title: 'Test Periodical Title') }
     let!(:issue_no_cover) { create(:collection, collection_type: 'periodical_issue') }
     let!(:issue_with_cover) do
       c = create(:collection, collection_type: 'periodical_issue')

--- a/spec/requests/periodicals_spec.rb
+++ b/spec/requests/periodicals_spec.rb
@@ -121,6 +121,7 @@ RSpec.describe 'Periodicals', type: :request do
       get '/periodicals'
       expect(response.body).to include('periodical-with-cover')
       expect(response.body).to include('periodical-cover-img')
+      expect(response.body).to include(periodical.title)
     end
   end
 


### PR DESCRIPTION
## Summary

- In `/periodicals`, each periodical tile now shows the cover image of its first issue that has one attached, instead of a plain solid-color background
- The cover image fills the full card with `object-fit: cover`; the stats text (issue count, text count) overlays at the bottom behind a semi-transparent dark backdrop for legibility
- Falls back to the existing logo/solid-color tile for periodicals where no issue has a cover attached
- Preloads all cover image attachments in bulk (single extra query + preloader) to avoid N+1

## How it works

**Controller** (`periodicals_controller.rb`): new private `build_periodical_first_covers` method collects all sub-issue IDs from the already-loaded `collection_items`, loads those `Collection` records, preloads their `cover_image_attachment` blob via `ActiveRecord::Associations::Preloader`, then builds a hash `periodical.id → first_issue_with_cover`.

**View** (`periodicals/index.html.haml`): the tile section now checks `@periodical_first_covers[periodical.id]` and renders either the new cover-image tile (`.periodical-with-cover`) or the original tile.

**CSS** (`application.scss`): `.author-card-v02.periodical-with-cover` positions the cover `<img>` absolutely to fill the card, and the `.author-name-area` is absolutely positioned at the bottom with `rgba(0,0,0,0.55)` backdrop.

## Test plan

- [x] New request specs verify `@periodical_first_covers` is a hash, maps to the first covered issue, renders the cover tile when one exists, renders the fallback tile when none does
- [x] All 13 specs in `spec/requests/periodicals_spec.rb` pass
- [ ] Manual smoke test: visit `/periodicals` and confirm covered periodicals show their issue cover; uncovered ones still show the solid-color tile

Closes by-est

🤖 Generated with [Claude Code](https://claude.com/claude-code)