### PR TITLE
Fix Chewy UndefinedUpdateStrategy in Sidekiq jobs via server middleware

### DIFF
--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,3 +1,19 @@
+# frozen_string_literal: true
+
+# Wrap every Sidekiq job in Chewy.strategy(:bypass) so that Chewy
+# index-update callbacks (triggered e.g. by ActiveStorage::AnalyzeJob)
+# silently no-op instead of raising Chewy::UndefinedUpdateStrategy.
+# Jobs that need Elasticsearch indexing (e.g. Lexicon::IngestFile) push
+# :atomic on top of this inside their own perform method.
+class ChewyBypassMiddleware
+  def call(_worker, _job, _queue, &)
+    Chewy.strategy(:bypass, &)
+  end
+end
+
 Sidekiq.configure_server do |config|
   config.logger = Sidekiq::Logger.new($stdout)
+  config.server_middleware do |chain|
+    chain.add ChewyBypassMiddleware
+  end
 end

--- a/spec/middleware/chewy_bypass_middleware_spec.rb
+++ b/spec/middleware/chewy_bypass_middleware_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ChewyBypassMiddleware do
+  subject(:middleware) { described_class.new }
+
+  describe '#call' do
+    it 'wraps the job block in Chewy.strategy(:bypass)' do
+      strategy_inside_job = nil
+      middleware.call(nil, nil, nil) do
+        strategy_inside_job = Chewy.strategy.current.name
+      end
+      expect(strategy_inside_job).to eq(:bypass)
+    end
+
+    it 'does not raise UndefinedUpdateStrategy even when root_strategy is :base' do
+      original_root = Chewy.root_strategy
+      Chewy.root_strategy = :base
+      Chewy.current.delete(:chewy_strategy)
+
+      expect do
+        middleware.call(nil, nil, nil) do
+          Chewy.strategy.current.update(ManifestationsIndex, [], {})
+        end
+      end.not_to raise_error
+    ensure
+      Chewy.root_strategy = original_root
+      Chewy.current.delete(:chewy_strategy)
+    end
+
+    it 'allows :atomic to override bypass inside the job' do
+      strategy_inside_atomic = nil
+      middleware.call(nil, nil, nil) do
+        Chewy.strategy(:atomic) do
+          strategy_inside_atomic = Chewy.strategy.current.name
+        end
+      end
+      expect(strategy_inside_atomic).to eq(:atomic)
+    end
+
+    it 'restores prior strategy after job completes' do
+      outer_strategy_before = Chewy.strategy.current.name
+      middleware.call(nil, nil, nil) { nil }
+      expect(Chewy.strategy.current.name).to eq(outer_strategy_before)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Adds `ChewyBypassMiddleware` as a Sidekiq server middleware in `config/initializers/sidekiq.rb`
- Every Sidekiq job is now wrapped in `Chewy.strategy(:bypass)`, so non-indexing jobs (like `ActiveStorage::AnalyzeJob`) silently skip Elasticsearch updates instead of raising `Chewy::UndefinedUpdateStrategy`
- Jobs that need indexing (e.g. `Lexicon::IngestFile`) continue to push `Chewy.strategy(:atomic)` inside their `perform` method, which takes precedence over the bypass wrapper

## Why the previous fix was insufficient

PR #1276 set `Chewy.root_strategy = :bypass` in the initializer. This only affects the **initial creation** of a thread's strategy stack. Sidekiq threads are long-lived and reuse their thread-local strategy state across jobs — any worker thread whose stack was initialized before the fix kept `:base` as root and continued to crash.

The middleware approach is correct because it wraps **each job execution** in a fresh strategy context, independent of thread history.

## Test plan

- [ ] `bundle exec rspec spec/middleware/chewy_bypass_middleware_spec.rb` — 4 new specs pass
- [ ] Restart Sidekiq locally and run a lexicon migration with file attachments; confirm `ActiveStorage::AnalyzeJob` no longer logs `Chewy::UndefinedUpdateStrategy`

🤖 Generated with [Claude Code](https://claude.com/claude-code)