### PR TITLE
Suppress periodicals with zero issues from /periodicals index

### DIFF
--- a/app/controllers/periodicals_controller.rb
+++ b/app/controllers/periodicals_controller.rb
@@ -2,9 +2,10 @@
 
 class PeriodicalsController < ApplicationController
   def index
+    issue_ids = Collection.where(collection_type: 'periodical_issue').select(:id)
     @periodicals = Collection.includes(:collection_items)
                              .where(collection_type: 'periodical')
-                             .where(id: CollectionItem.where(item_type: 'Collection').select(:collection_id))
+                             .where(id: CollectionItem.where(item_type: 'Collection', item_id: issue_ids).select(:collection_id))
                              .order(:title)
                              .to_a
     @periodicals_count = @periodicals.size

--- a/app/controllers/periodicals_controller.rb
+++ b/app/controllers/periodicals_controller.rb
@@ -2,10 +2,12 @@
 
 class PeriodicalsController < ApplicationController
   def index
-    @periodicals = Collection.includes(:collection_items).where(collection_type: 'periodical').order(:title) # TODO: what order would make sense?
-    @periodicals_count = Rails.cache.fetch('periodicals_count', expires_in: 60.minutes) do
-      Collection.where(collection_type: 'periodical').count
-    end
+    @periodicals = Collection.includes(:collection_items)
+                             .where(collection_type: 'periodical')
+                             .where(id: CollectionItem.where(item_type: 'Collection').select(:collection_id))
+                             .order(:title)
+                             .to_a
+    @periodicals_count = @periodicals.size
     @popular_works = ManifestationsIndex.query(match: { in_periodical: true })
                                         .filter(range: { impressions_count: { gte: 1 } })
                                         .order(impressions_count: :desc)

--- a/spec/requests/periodicals_spec.rb
+++ b/spec/requests/periodicals_spec.rb
@@ -143,4 +143,34 @@ RSpec.describe 'Periodicals', type: :request do
       expect(response.body).not_to include('periodical-with-cover')
     end
   end
+
+  describe 'suppression of zero-issue periodicals' do
+    let!(:periodical_with_issue) do
+      create(:collection, collection_type: 'periodical', title: 'Has Issues Periodical')
+    end
+    let!(:periodical_no_issues) do
+      create(:collection, collection_type: 'periodical', title: 'No Issues Periodical')
+    end
+    let!(:issue) { create(:collection, collection_type: 'periodical_issue') }
+
+    before do
+      create(:collection_item, collection: periodical_with_issue, item: issue, seqno: 1)
+    end
+
+    it 'does not include zero-issue periodicals in @periodicals' do
+      get '/periodicals'
+      expect(assigns(:periodicals)).to include(periodical_with_issue)
+      expect(assigns(:periodicals)).not_to include(periodical_no_issues)
+    end
+
+    it 'does not render the zero-issue periodical title on the page' do
+      get '/periodicals'
+      expect(response.body).not_to include('No Issues Periodical')
+    end
+
+    it 'sets @periodicals_count to only count periodicals with issues' do
+      get '/periodicals'
+      expect(assigns(:periodicals_count)).to eq(assigns(:periodicals).size)
+    end
+  end
 end


### PR DESCRIPTION
## Summary

- Filters `@periodicals` to only include periodicals that have at least one sub-collection (issue), using a `WHERE id IN (SELECT collection_id FROM collection_items WHERE item_type = 'Collection')` subquery.
- Derives `@periodicals_count` from the already-loaded array (`.size`) instead of a separate cached `COUNT(*)` query, so the count in the header always matches what is actually displayed.

## Test plan

- [x] New `describe 'suppression of zero-issue periodicals'` block in `spec/requests/periodicals_spec.rb` covers the filtered assigns, the rendered page, and the count consistency.
- [x] All 16 existing + new specs pass (`bundle exec rspec spec/requests/periodicals_spec.rb`).

🤖 Generated with [Claude Code](https://claude.ai/claude-code)