### PR TITLE
Locking concern and Locking support for LexEntries

### DIFF
--- a/app/assets/javascripts/lexicon_backend.js
+++ b/app/assets/javascripts/lexicon_backend.js
@@ -46,7 +46,12 @@ function reloadContent(tabContent) {
         loadUrl,
         function( response, status, xhr ) {
             if ( status == 'error' ) {
-                tabContent.html('<h2 class="text-danger">Error: ' + xhr.status + " " + xhr.statusText + '</h2>');
+                let content = '<h2 class="text-danger">Error: ' + xhr.status + " " + xhr.statusText + '</h2>';
+                if (xhr.status == '423') {
+                  // Message about locked object
+                  content += '<h3>' + xhr.responseText + '</h3>';
+                }
+                tabContent.html(content);
                 tabContent.data('load-complete', null);
             } else {
                 tabContent.data('load-complete', true);

--- a/app/controllers/concerns/lock_ingestible_concern.rb
+++ b/app/controllers/concerns/lock_ingestible_concern.rb
@@ -1,17 +1,16 @@
 # frozen_string_literal: true
 
-# Logic to lock Ingestible object, to be included in related controllers
+# Implements methods required by LockRecordConcern to work with Ingestible records
 module LockIngestibleConcern
   extend ActiveSupport::Concern
 
-  def try_to_lock_ingestible
-    return if @ingestible.obtain_lock(current_user)
+  include LockRecordConcern
 
-    respond_to do |format|
-      flash.alert = t('ingestibles.ingestible_locked', user: @ingestible.locked_by_user.name)
+  def record_to_lock
+    @ingestible
+  end
 
-      format.html { redirect_to ingestibles_path }
-      format.js { render js: "window.location.href = '#{ingestibles_path}';" }
-    end
+  def redirect_if_locked_path
+    ingestibles_path
   end
 end

--- a/app/controllers/concerns/lock_lex_entry_concern.rb
+++ b/app/controllers/concerns/lock_lex_entry_concern.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+# Implements methods required by LockRecordConcern to work with LexEntry records
+module LockLexEntryConcern
+  extend ActiveSupport::Concern
+
+  include LockRecordConcern
+
+  def redirect_if_locked_path
+    lexicon_verification_index_path
+  end
+
+  def record_to_lock
+    @lex_entry
+  end
+end

--- a/app/controllers/concerns/lock_record_concern.rb
+++ b/app/controllers/concerns/lock_record_concern.rb
@@ -18,7 +18,13 @@ module LockRecordConcern
         model_name: rec.class.model_name.human
       )
 
-      format.html { redirect_to redirect_if_locked_path, alert: alert }
+      format.html do
+        if request.xhr?
+          render plain: alert, status: :locked
+        else
+          redirect_to redirect_if_locked_path, alert: alert
+        end
+      end
       format.js do
         flash.alert = alert
         render js: "window.location.href = '#{redirect_if_locked_path}';"

--- a/app/controllers/concerns/lock_record_concern.rb
+++ b/app/controllers/concerns/lock_record_concern.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+# To be used in Controllers for actions related to editing records implementing Lockable concern
+module LockRecordConcern
+  extend ActiveSupport::Concern
+
+  # This method tries to lock record. If record is already locked by different user it redirects to
+  # path returned by redirect_if_locked_path method.
+  # Should be used as `before_action` hook
+  def try_to_lock_record
+    rec = record_to_lock
+    return if rec.obtain_lock(current_user)
+
+    respond_to do |format|
+      flash.alert = t(
+        'lock_record.record_locked',
+        user: rec.locked_by_user.name,
+        model_name: rec.class.model_name.human
+      )
+
+      format.html { redirect_to redirect_if_locked_path }
+      format.js { render js: "window.location.href = '#{redirect_if_locked_path}';" }
+    end
+  end
+
+  # This method should be implemented in controller and should return record to be locked
+  # @return record to be locked
+  def record_to_lock
+    raise 'not implemented!'
+  end
+
+  # @return path where we should redirect user if object is locked by different user
+  def redirect_if_locked_path
+    raise 'not implemented!'
+  end
+end

--- a/app/controllers/concerns/lock_record_concern.rb
+++ b/app/controllers/concerns/lock_record_concern.rb
@@ -9,17 +9,23 @@ module LockRecordConcern
   # Should be used as `before_action` hook
   def try_to_lock_record
     rec = record_to_lock
-    return if rec.obtain_lock(current_user)
+    return if rec.obtain_lock?(current_user)
 
     respond_to do |format|
-      flash.alert = t(
+      alert = t(
         'lock_record.record_locked',
         user: rec.locked_by_user.name,
         model_name: rec.class.model_name.human
       )
 
-      format.html { redirect_to redirect_if_locked_path }
-      format.js { render js: "window.location.href = '#{redirect_if_locked_path}';" }
+      format.html { redirect_to redirect_if_locked_path, alert: alert }
+      format.js do
+        flash.alert = alert
+        render js: "window.location.href = '#{redirect_if_locked_path}';"
+      end
+      format.json do
+        render json: { success: false, error: alert, redirect_to: redirect_if_locked_path }, status: :locked
+      end
     end
   end
 

--- a/app/controllers/concerns/lock_record_concern.rb
+++ b/app/controllers/concerns/lock_record_concern.rb
@@ -30,7 +30,7 @@ module LockRecordConcern
         render js: "window.location.href = '#{redirect_if_locked_path}';"
       end
       format.json do
-        render json: { success: false, error: alert, redirect_to: redirect_if_locked_path }, status: :locked
+        render json: { success: false, errors: [alert], redirect_to: redirect_if_locked_path }, status: :locked
       end
     end
   end

--- a/app/controllers/ingestible_authorities_controller.rb
+++ b/app/controllers/ingestible_authorities_controller.rb
@@ -7,7 +7,7 @@ class IngestibleAuthoritiesController < ApplicationController
 
   before_action { |c| c.require_editor('edit_catalog') }
   before_action :set_ingestible
-  before_action :try_to_lock_ingestible
+  before_action :try_to_lock_record
 
   # responds with js callback
   def create

--- a/app/controllers/ingestible_collection_authorities_controller.rb
+++ b/app/controllers/ingestible_collection_authorities_controller.rb
@@ -7,7 +7,7 @@ class IngestibleCollectionAuthoritiesController < ApplicationController
 
   before_action { |c| c.require_editor('edit_catalog') }
   before_action :set_ingestible
-  before_action :try_to_lock_ingestible
+  before_action :try_to_lock_record
 
   # responds with js callback
   def create

--- a/app/controllers/ingestible_texts_controller.rb
+++ b/app/controllers/ingestible_texts_controller.rb
@@ -7,7 +7,7 @@ class IngestibleTextsController < ApplicationController
 
   before_action { |c| c.require_editor('edit_catalog') }
   before_action :set_ingestible
-  before_action :try_to_lock_ingestible
+  before_action :try_to_lock_record
 
   def edit
     @text = @ingestible.texts[@text_index]

--- a/app/controllers/ingestibles_controller.rb
+++ b/app/controllers/ingestibles_controller.rb
@@ -12,7 +12,7 @@ class IngestiblesController < ApplicationController
   before_action :set_ingestible,
                 only: %i(show edit update update_markdown update_toc destroy review ingest edit_toc update_toc_list
                          undo unlock purge_docx)
-  before_action :try_to_lock_ingestible,
+  before_action :try_to_lock_record,
                 only: %i(edit update update_markdown destroy review update_toc update_toc_list edit_toc undo)
 
   DEFAULTS = { title: '', status: 'draft', orig_lang: 'he', default_authorities: [], collection_authorities: [],

--- a/app/controllers/lexicon/attachments_controller.rb
+++ b/app/controllers/lexicon/attachments_controller.rb
@@ -4,11 +4,14 @@ module Lexicon
   # Controller to handle work with LexEntry attachments
   # This controller is mounted on lexicon/entries/:id/attachments path
   class AttachmentsController < ApplicationController
+    include LockLexEntryConcern
+
     before_action do
       require_editor('edit_lexicon')
     end
 
     before_action :set_lex_entry
+    before_action :try_to_lock_record
 
     helper_method :format_filesize
 

--- a/app/controllers/lexicon/citation_authors_controller.rb
+++ b/app/controllers/lexicon/citation_authors_controller.rb
@@ -3,11 +3,14 @@
 module Lexicon
   # Controller for LexCitationAuthor
   class CitationAuthorsController < ApplicationController
+    include LockLexEntryConcern
+
     before_action do
       require_editor('edit_lexicon')
     end
     before_action :set_citation, only: %i(index create)
     before_action :set_author, only: %i(destroy)
+    before_action :try_to_lock_record
 
     layout false
 
@@ -51,6 +54,10 @@ module Lexicon
     def set_author
       @author = LexCitationAuthor.find(params[:id])
       @citation = @author.citation
+    end
+
+    def record_to_lock
+      @citation.person.lex_entry
     end
   end
 end

--- a/app/controllers/lexicon/citations_controller.rb
+++ b/app/controllers/lexicon/citations_controller.rb
@@ -3,12 +3,15 @@
 module Lexicon
   # Controller to work with Lexicon Citations
   class CitationsController < ApplicationController
+    include LockLexEntryConcern
+
     before_action do
       require_editor('edit_lexicon')
     end
 
     before_action :set_citation, only: %i(edit update destroy reorder)
     before_action :set_person, only: %i(new create index)
+    before_action :try_to_lock_record
 
     layout false
 
@@ -98,6 +101,10 @@ module Lexicon
     def set_citation
       @citation = LexCitation.find(params[:id])
       @person = @citation.person
+    end
+
+    def record_to_lock
+      @person.lex_entry
     end
 
     # Only allow a list of trusted parameters through.

--- a/app/controllers/lexicon/entries_controller.rb
+++ b/app/controllers/lexicon/entries_controller.rb
@@ -3,10 +3,14 @@
 module Lexicon
   # Controller to render list of all Lexicon entries
   class EntriesController < ApplicationController
+    include LockLexEntryConcern
+
     before_action except: %i(show list) do |c|
       c.require_editor('edit_lexicon')
     end
     before_action :set_lex_entry, only: %i(show edit update destroy)
+
+    before_action :try_to_lock_record, only: %i(edit update destroy)
 
     layout 'lexicon_backend', except: %i(show list)
 

--- a/app/controllers/lexicon/linked_people_controller.rb
+++ b/app/controllers/lexicon/linked_people_controller.rb
@@ -3,11 +3,14 @@
 module Lexicon
   # Controller for LexLinkedPerson records attached to LexPersonWork
   class LinkedPeopleController < ApplicationController
+    include LockLexEntryConcern
+
     before_action do
       require_editor('edit_lexicon')
     end
     before_action :set_work, only: %i(index create)
     before_action :set_linked_person, only: %i(destroy reorder)
+    before_action :try_to_lock_record
 
     layout false
 
@@ -73,6 +76,10 @@ module Lexicon
     def set_linked_person
       @linked_person = LexLinkedPerson.find(params[:id])
       @work = @linked_person.person_work
+    end
+
+    def record_to_lock
+      @work.person.lex_entry
     end
   end
 end

--- a/app/controllers/lexicon/links_controller.rb
+++ b/app/controllers/lexicon/links_controller.rb
@@ -3,11 +3,14 @@
 module Lexicon
   # Controller to work with Lexicon Links
   class LinksController < ApplicationController
+    include LockLexEntryConcern
+
     before_action do
       require_editor('edit_lexicon')
     end
     before_action :set_link, only: %i(edit update destroy)
     before_action :set_entry, only: %i(new create index)
+    before_action :try_to_lock_record
 
     layout false
 
@@ -50,7 +53,10 @@ module Lexicon
     def set_link
       @link = LexLink.find(params[:id])
       @item = @link.item
-      @entry = @item.entry
+    end
+
+    def record_to_lock
+      @item.entry
     end
 
     # Only allow a list of trusted parameters through.

--- a/app/controllers/lexicon/people_controller.rb
+++ b/app/controllers/lexicon/people_controller.rb
@@ -3,10 +3,13 @@
 module Lexicon
   # Controller to work with People records in Lexicon
   class PeopleController < ::ApplicationController
+    include LockLexEntryConcern
+
     before_action do
       require_editor('edit_lexicon')
     end
     before_action :set_lex_person, only: %i(edit update)
+    before_action :try_to_lock_record, only: %i(edit update)
 
     layout false
 
@@ -41,6 +44,7 @@ module Lexicon
     # Use callbacks to share common setup or constraints between actions.
     def set_lex_person
       @lex_person = LexPerson.find(params[:id])
+      @lex_entry = @lex_person.lex_entry
     end
 
     # Only allow a list of trusted parameters through.

--- a/app/controllers/lexicon/person_works_controller.rb
+++ b/app/controllers/lexicon/person_works_controller.rb
@@ -3,6 +3,8 @@
 module Lexicon
   # Controller to work with Lexicon Person Works
   class PersonWorksController < ApplicationController
+    include LockLexEntryConcern
+
     before_action do
       require_editor('edit_lexicon')
     end
@@ -139,6 +141,10 @@ module Lexicon
     def set_work
       @work = LexPersonWork.find(params[:id])
       @person = @work.person
+    end
+
+    def record_to_lock
+      @person.lex_entry
     end
 
     # Only allow a list of trusted parameters through.

--- a/app/controllers/lexicon/publications_controller.rb
+++ b/app/controllers/lexicon/publications_controller.rb
@@ -3,10 +3,11 @@
 module Lexicon
   # Controller to work with Lexicon Publications
   class PublicationsController < ApplicationController
-    before_action do
-      require_editor('edit_lexicon')
-    end
+    include LockLexEntryConcern
+
+    before_action { require_editor('edit_lexicon') }
     before_action :set_lex_publication, only: %i(edit update)
+    before_action :try_to_lock_record, only: %i(edit update)
 
     layout false
 
@@ -41,6 +42,7 @@ module Lexicon
     # Use callbacks to share common setup or constraints between actions.
     def set_lex_publication
       @lex_publication = LexPublication.find(params[:id])
+      @lex_entry = @lex_publication.entry
     end
 
     # Only allow a list of trusted parameters through.

--- a/app/controllers/lexicon/verification_controller.rb
+++ b/app/controllers/lexicon/verification_controller.rb
@@ -3,9 +3,12 @@
 module Lexicon
   # Controller for migration verification workbench
   class VerificationController < ApplicationController
+    include LockLexEntryConcern
+
     EXTERNAL_IDENTIFIER_KEYS = LexiconHelper::EXTERNAL_IDENTIFIER_LABELS.keys.freeze
 
     before_action :set_entry, except: %i(index)
+    before_action :try_to_lock_record, except: %i(index)
     before_action do |c|
       c.require_editor('edit_lexicon')
     end
@@ -339,6 +342,10 @@ module Lexicon
 
     def set_entry
       @entry = LexEntry.includes(:lex_item, :lex_file).find(params[:id])
+    end
+
+    def record_to_lock
+      @entry
     end
 
     # Maps Authority's intellectual_property to a LexPerson copyrighted boolean.

--- a/app/models/concerns/lockable.rb
+++ b/app/models/concerns/lockable.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+# To prevent simultaneous editing of same entity by two users this concern implements locking logic.
+# Before editing user needs to obtain lock on record and release lock after editing is done.
+# Locks also should expire after given timeout period
+module Lockable
+  extend ActiveSupport::Concern
+
+  LOCK_TIMEOUT_IN_SECONDS = 60 * 15 # 15 minutes
+
+  included do
+    belongs_to :locked_by_user, class_name: 'User', optional: true
+    belongs_to :last_editor, class_name: 'User', optional: true
+
+    validates :locked_at, presence: true, if: -> { locked_by_user.present? }
+    validates :locked_at, absence: true, unless: -> { locked_by_user.present? }
+  end
+
+  def locked?
+    locked_at.present? && locked_at > LOCK_TIMEOUT_IN_SECONDS.seconds.ago
+  end
+
+  def obtain_lock(user)
+    return false if locked? && locked_by_user_id != user.id
+
+    # To avoid excessive updates we only refresh lock if more than 10 seconds passed since previous lock refresh
+    if locked_at.nil? || locked_at < 10.seconds.ago
+      update_columns(locked_at: Time.zone.now, locked_by_user_id: user.id, last_editor_id: user.id) # we deliberately skip validations here
+    end
+
+    return true
+  end
+
+  def release_lock!
+    update_columns(locked_at: nil, locked_by_user_id: nil) # we deliberately skip validations here
+  end
+end

--- a/app/models/concerns/lockable.rb
+++ b/app/models/concerns/lockable.rb
@@ -20,12 +20,13 @@ module Lockable
     locked_at.present? && locked_at > LOCK_TIMEOUT_IN_SECONDS.seconds.ago
   end
 
-  def obtain_lock(user)
+  def obtain_lock?(user)
     return false if locked? && locked_by_user_id != user.id
 
     # To avoid excessive updates we only refresh lock if more than 10 seconds passed since previous lock refresh
     if locked_at.nil? || locked_at < 10.seconds.ago
-      update_columns(locked_at: Time.zone.now, locked_by_user_id: user.id, last_editor_id: user.id) # we deliberately skip validations here
+      # we deliberately skip validations here
+      update_columns(locked_at: Time.zone.now, locked_by_user_id: user.id, last_editor_id: user.id)
     end
 
     return true

--- a/app/models/concerns/lockable.rb
+++ b/app/models/concerns/lockable.rb
@@ -5,6 +5,7 @@
 # Locks also should expire after given timeout period
 module Lockable
   extend ActiveSupport::Concern
+  include ActionView::Helpers::DateHelper
 
   LOCK_TIMEOUT_IN_SECONDS = 60 * 15 # 15 minutes
 
@@ -34,5 +35,13 @@ module Lockable
 
   def release_lock!
     update_columns(locked_at: nil, locked_by_user_id: nil) # we deliberately skip validations here
+  end
+
+  def locked_by_human
+    I18n.t('lockable.locked_by_human', name: locked_by_user.name)
+  end
+
+  def locked_at_human
+    I18n.t('lockable.locked_at_human', minutes_ago: distance_of_time_in_words(Time.zone.now, locked_at))
   end
 end

--- a/app/models/ingestible.rb
+++ b/app/models/ingestible.rb
@@ -4,23 +4,20 @@ require 'pandoc-ruby' # for generic DOCX-to-HTML conversions
 
 # Ingestible is a set of text being prepared for inclusion into a main database
 class Ingestible < ApplicationRecord
-  LOCK_TIMEOUT_IN_SECONDS = 60 * 15 # 15 minutes
+  include Lockable
+
   COPYRIGHTED_IP_OPTIONS = %w(by_permission orphan).freeze
 
   enum :status, { draft: 0, ingested: 1, failed: 2, awaiting_authorities: 3 }
   enum :scenario, { single: 0, multiple: 1, mixed: 2 }
 
   belongs_to :user, optional: true
-  belongs_to :locked_by_user, class_name: 'User', optional: true
-  belongs_to :last_editor, class_name: 'User', optional: true
   belongs_to :volume, optional: true, class_name: 'Collection'
   belongs_to :project, optional: true
 
   DEFAULTS_SCHEMA = {}.freeze
   validates :title, presence: true
   validates :status, presence: true
-  validates :locked_at, presence: true, if: -> { locked_by_user.present? }
-  validates :locked_at, absence: true, unless: -> { locked_by_user.present? }
   validate :volume_decision
   validate :check_duplicate_volume, if: :should_check_duplicate_volume?
   #  validates :scenario, presence: true
@@ -494,25 +491,6 @@ class Ingestible < ApplicationRecord
       cache.shift if cache.length > TEXTAREA_CACHE_MAX_VERSIONS
       update_columns(textarea_cache: cache.to_json)
     end
-  end
-
-  def locked?
-    locked_at.present? && locked_at > LOCK_TIMEOUT_IN_SECONDS.seconds.ago
-  end
-
-  def obtain_lock(user)
-    return false if locked? && locked_by_user_id != user.id
-
-    # To avoid excessive updates we only refresh lock if more than 10 seconds passed since previous lock refresh
-    if locked_at.nil? || locked_at < 10.seconds.ago
-      update_columns(locked_at: Time.zone.now, locked_by_user_id: user.id, last_editor_id: user.id) # we deliberately skip validations here
-    end
-
-    return true
-  end
-
-  def release_lock!
-    update_columns(locked_at: nil, locked_by_user_id: nil) # we deliberately skip validations here
   end
 
   # Calculate expected copyright status based on involved authorities

--- a/app/models/lex_entry.rb
+++ b/app/models/lex_entry.rb
@@ -4,6 +4,7 @@
 class LexEntry < ApplicationRecord
   include SortedTitle
   include DownloadLink
+  include Lockable
 
   has_one :lex_file, dependent: :nullify
 

--- a/app/views/lexicon/verification/index.html.haml
+++ b/app/views/lexicon/verification/index.html.haml
@@ -47,7 +47,11 @@
         %td
           = t('lexicon.verification.queue.time_updated', time: time_ago_in_words(entry.updated_at))
         %td
-          - if entry.status_verifying? || entry.status_escalated?
+          - if entry.locked? && entry.locked_by_user != current_user
+            -# locked by another user
+            .label.label-warning= entry.locked_by_human
+            %span.text-sm-left.text-muted= entry.locked_at_human
+          - elsif entry.status_verifying? || entry.status_escalated?
             = link_to t('lexicon.verification.queue.actions.continue'), lexicon_verification_path(entry), class: 'btn btn-sm btn-primary'
           - else
             = link_to t('lexicon.verification.queue.actions.start'), lexicon_verification_path(entry), class: 'btn btn-sm btn-success'

--- a/config/locales/active_record.en.yml
+++ b/config/locales/active_record.en.yml
@@ -18,6 +18,7 @@ en:
       collection_item: Collection Item
       corporate_body: Corporate Body
       featured_content: Featured Content
+      ingestible: Ingestible
       lex_citation: Citation of Lexicon Entry
       lex_citation_author: Citation Author
       lex_entry: Lexicon Entry
@@ -131,6 +132,7 @@ en:
         person_work: Work
       lex_file:
         error_message: Error message
+        entrytype: Entry type
         fname: File name
         entrytypes:
           unknown: Unknown
@@ -151,6 +153,7 @@ en:
           error: Error
           verifying: Verifying
           verified: Verified
+          escalated: Escalated
       lex_linked_person:
         person_entry: Lexicon Entry for Person
         link_type: Link Type

--- a/config/locales/active_record.he.yml
+++ b/config/locales/active_record.he.yml
@@ -18,6 +18,7 @@ he:
       collection_item: פריט באוסף
       corporate_body: גוף/מוסד
       featured_content: תוכן מערכת
+      ingestible: ההעלאה
       lex_citation: מראה מקום על אדם או חיבור
       lex_citation_author: מחבר/ת מראה המקום
       lex_entry: ערך בלקסיקון

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -441,6 +441,9 @@ en:
       enter_manifestation_ids: Please enter *work* IDs (separated by space or newline)
       fetch: Load Works
       title: Batch Operations
+  lockable:
+    locked_at_human: "%{minutes_ago} ago"
+    locked_by_human: "Locked by %{name}"
   lock_record:
     record_locked: This %{model_name} is locked by user %{user}
   ingestibles:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -441,8 +441,9 @@ en:
       enter_manifestation_ids: Please enter *work* IDs (separated by space or newline)
       fetch: Load Works
       title: Batch Operations
+  lock_record:
+    record_locked: This %{model_name} is locked by user %{user}
   ingestibles:
-    ingestible_locked: Ingestible locked by user %{user}
     clear_defaults: Clear defaults
     authorities:
       or_new_person: or type a new authority name

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -1939,8 +1939,9 @@ he:
       columns:
         db_intellectual_property: מצב זכויות יוצרים במערכת
         has_non_public_domain_authority: זכויות הישות טרם פקעו
+  lock_record:
+    record_locked: "%{model_name} נעולה לטיפול %{user}"
   ingestibles:
-    ingestible_locked: ההעלאה נעולה לטיפול מידֵי %{user}
     replace_with_authority: החלף ביישות קיימת!
     clear_defaults: הסרת ברירות מחדל
     # _authorities partial

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -1939,6 +1939,9 @@ he:
       columns:
         db_intellectual_property: מצב זכויות יוצרים במערכת
         has_non_public_domain_authority: זכויות הישות טרם פקעו
+  lockable:
+    locked_at_human: "%{minutes_ago} לפני"
+    locked_by_human: "%{name} נעול על ידי"
   lock_record:
     record_locked: "%{model_name} נעולה לטיפול %{user}"
   ingestibles:

--- a/db/migrate/20260528181724_add_locking_fields_to_lex_entries.rb
+++ b/db/migrate/20260528181724_add_locking_fields_to_lex_entries.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class AddLockingFieldsToLexEntries < ActiveRecord::Migration[8.1]
+  def change
+    add_belongs_to :lex_entries,
+                   :locked_by_user,
+                   foreign_key: { to_table: :users},
+                   index: true,
+                   null: true,
+                   type: :integer
+
+    add_belongs_to :lex_entries,
+                   :last_editor,
+                   foreign_key: { to_table: :users},
+                   index: true,
+                   null: true,
+                   type: :integer
+
+    add_column :lex_entries, :locked_at, :timestamp, null: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_27_222817) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_29_031027) do
   create_table "aboutnesses", id: :integer, charset: "utf8mb4", collation: "utf8mb4_bin", force: :cascade do |t|
     t.integer "aboutable_id"
     t.string "aboutable_type"
@@ -646,6 +646,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_27_222817) do
   end
 
   create_table "lex_citations", charset: "utf8mb4", collation: "utf8mb4_bin", force: :cascade do |t|
+    t.string "backup_url", limit: 1024
     t.datetime "created_at", precision: nil, null: false
     t.string "from_publication"
     t.bigint "lex_person_id", null: false
@@ -669,9 +670,10 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_27_222817) do
     t.datetime "created_at", precision: nil, null: false
     t.string "english_title"
     t.json "external_identifiers"
+    t.integer "last_editor_id"
     t.bigint "lex_item_id"
     t.string "lex_item_type"
-    t.datetime "locked_at"
+    t.timestamp "locked_at"
     t.integer "locked_by_user_id"
     t.string "other_designation", limit: 1024
     t.bigint "profile_image_id"
@@ -680,6 +682,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_27_222817) do
     t.string "title", limit: 1024
     t.datetime "updated_at", precision: nil, null: false
     t.json "verification_progress"
+    t.index ["last_editor_id"], name: "index_lex_entries_on_last_editor_id"
     t.index ["lex_item_type", "lex_item_id"], name: "index_lex_entries_on_lex_item_type_and_lex_item_id", unique: true
     t.index ["locked_by_user_id"], name: "index_lex_entries_on_locked_by_user_id"
     t.index ["profile_image_id"], name: "index_lex_entries_on_profile_image_id"
@@ -723,7 +726,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_27_222817) do
     t.string "new_path", null: false
     t.string "old_path", null: false
     t.index ["lex_entry_id"], name: "index_lex_legacy_links_on_lex_entry_id"
-    t.index ["old_path"], name: "index_lex_legacy_links_on_old_path"
+    t.index ["old_path"], name: "index_lex_legacy_links_on_old_path", unique: true
   end
 
   create_table "lex_linked_people", charset: "utf8mb4", collation: "utf8mb4_bin", force: :cascade do |t|
@@ -1230,6 +1233,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_27_222817) do
   add_foreign_key "lex_citations", "lex_person_works"
   add_foreign_key "lex_citations", "manifestations"
   add_foreign_key "lex_entries", "active_storage_attachments", column: "profile_image_id", on_delete: :nullify
+  add_foreign_key "lex_entries", "users", column: "last_editor_id"
+  add_foreign_key "lex_entries", "users", column: "locked_by_user_id"
   add_foreign_key "lex_files", "lex_entries"
   add_foreign_key "lex_issues", "lex_publications"
   add_foreign_key "lex_legacy_links", "lex_entries"

--- a/spec/controllers/ingestibles_controller_spec.rb
+++ b/spec/controllers/ingestibles_controller_spec.rb
@@ -116,7 +116,7 @@ describe IngestiblesController do
 
       context 'when ingestible is locked by another user' do
         let(:locked_by_user) { create(:user, name: 'John Connor') }
-        let(:locked_at) { Time.zone.now - 2.minutes }
+        let(:locked_at) { 2.minutes.ago }
 
         it 'redirects to ingestible index page' do
           expect(call).to redirect_to ingestibles_path

--- a/spec/controllers/ingestibles_controller_spec.rb
+++ b/spec/controllers/ingestibles_controller_spec.rb
@@ -114,6 +114,20 @@ describe IngestiblesController do
 
       it { is_expected.to be_successful }
 
+      context 'when ingestible is locked by another user' do
+        let(:locked_by_user) { create(:user, name: 'John Connor') }
+        let(:locked_at) { Time.zone.now - 2.minutes }
+
+        it 'redirects to ingestible index page' do
+          expect(call).to redirect_to ingestibles_path
+          expect(flash.alert).to eq I18n.t(
+            'lock_record.record_locked',
+            user: 'John Connor',
+            model_name: Ingestible.model_name.human
+          )
+        end
+      end
+
       context 'when ingestible has works with footnotes' do
         let(:ingestible) { create(:ingestible, :with_footnotes) }
 

--- a/spec/models/ingestible_spec.rb
+++ b/spec/models/ingestible_spec.rb
@@ -123,8 +123,8 @@ describe Ingestible do
     end
   end
 
-  describe '.obtain_lock' do
-    subject(:result) { ingestible.obtain_lock(user) }
+  describe '.obtain_lock?' do
+    subject(:result) { ingestible.obtain_lock?(user) }
 
     let(:user) { create(:user) }
     let(:ingestible) { create(:ingestible, locked_by_user: other_user, locked_at: locked_at) }

--- a/spec/requests/lexicon/citation_authors_spec.rb
+++ b/spec/requests/lexicon/citation_authors_spec.rb
@@ -7,7 +7,7 @@ describe '/lexicon/citation_authors' do
     login_as_lexicon_editor
   end
 
-  let(:person) { create(:lex_person) }
+  let(:person) { create(:lex_entry, :person).lex_item }
   let!(:citation) { create(:lex_citation, person: person) }
   let(:author) { citation.authors.first }
 

--- a/spec/requests/lexicon/verification_spec.rb
+++ b/spec/requests/lexicon/verification_spec.rb
@@ -375,7 +375,7 @@ RSpec.describe 'Lexicon::Verification', type: :request do
       get "/lex/verification/#{entry.id}/escalate_form"
 
       expect(response).to have_http_status(:ok)
-      expect(response.body).to include('העברה לבדיקה נוספת') # Title in Hebrew
+      expect(response.body).to include(I18n.t('lexicon.verification.show.escalate'))
       expect(response.body).to include('some existing notes')
     end
   end


### PR DESCRIPTION
Generalized locking logic we use for Ingestibles and created two concerns:

- Lockable (to be included in models)
- LockRecord (to be included in controllers) This concern expects controller to have two methods `record_to_lock` and `redirect_if_locked`.

Now we can add three columns (locked_by_user_id, locked_at and last_editor_id) to any model table and then include Lockable concern there to get `obtain_lock?`/locked?/release_lock! methods.

Added such support to LexEntry and related contrllers.

