### PR TITLE
Fix scroll position preservation in verification workbench (Chrome/Edge)

### DIFF
--- a/app/assets/javascripts/verification.js
+++ b/app/assets/javascripts/verification.js
@@ -24,16 +24,38 @@ function initVerification() {
         showToast(linkCheckToastMessage, linkCheckToastType);
     }
 
-    // Restore source pane scroll position after any page reload.
-    var savedSourceScroll = sessionStorage.getItem('source_scroll_top');
-    if (savedSourceScroll !== null) {
-        sessionStorage.removeItem('source_scroll_top');
-        var scrollVal = parseInt(savedSourceScroll, 10);
-        if (scrollVal > 0) {
-            setTimeout(function() {
-                var sourceContent = document.querySelector('.source-content');
-                if (sourceContent) { sourceContent.scrollTop = scrollVal; }
-            }, 100);
+    // Remove legacy key left by older code versions (no-op if already absent).
+    sessionStorage.removeItem('source_scroll_top');
+
+    // Restore source iframe scroll position after any page reload.
+    // Chromium-based browsers (Chrome, Edge) do not auto-preserve iframe internal
+    // scroll across reloads (unlike Firefox which restores it via session history),
+    // so we save/restore iframe.contentWindow.scrollY explicitly.
+    var savedIframeScroll = sessionStorage.getItem('source_iframe_scroll_y');
+    if (savedIframeScroll !== null) {
+        sessionStorage.removeItem('source_iframe_scroll_y');
+        var iframeScrollY = parseInt(savedIframeScroll, 10);
+        if (iframeScrollY > 0) {
+            var iframe = document.querySelector('.source-iframe');
+            if (iframe) {
+                var applyIframeScroll = function() {
+                    try { iframe.contentWindow.scrollTo(0, iframeScrollY); } catch (e) {}
+                };
+                // Always register the load listener so we catch the src loading after
+                // DOMContentLoaded.  The readyState === 'complete' check alone is a
+                // false positive: the initial about:blank document reports 'complete'
+                // before the real src has even started loading.
+                iframe.addEventListener('load', applyIframeScroll);
+                // Also apply immediately if the iframe already holds real source content
+                // (e.g. loaded from cache before DOMContentLoaded fired).
+                try {
+                    if (iframe.contentDocument &&
+                            iframe.contentDocument.readyState === 'complete' &&
+                            iframe.contentWindow.location.href !== 'about:blank') {
+                        applyIframeScroll();
+                    }
+                } catch (e) {}
+            }
         }
     }
 
@@ -63,10 +85,13 @@ function initVerification() {
         sessionStorage.removeItem('migrated_scroll_top');
         var migratedScrollVal = parseInt(savedMigratedScroll, 10);
         if (migratedScrollVal > 0) {
-            setTimeout(function() {
-                var migratedContent = document.querySelector('.migrated-content');
-                if (migratedContent) { migratedContent.scrollTop = migratedScrollVal; }
-            }, 100);
+            var migratedContent = document.querySelector('.migrated-content');
+            if (migratedContent) {
+                // Use rAF-based retry instead of a fixed timeout so that layout changes
+                // (e.g. Edge applying its own scroll restoration after JS runs) are
+                // detected and corrected within ~500 ms across all browsers.
+                restoreScrollWithRetry(migratedContent, migratedScrollVal);
+            }
         }
     }
 
@@ -438,16 +463,35 @@ function closeModalWithReload(reloadSelector) {
     }
 }
 
-// Save both pane scroll positions before any reload
+// Save both pane scroll positions before any reload.
+// For the source pane we save the iframe's internal scrollY, not the outer
+// container's scrollTop, because the meaningful scroll is inside the iframe.
 function saveScrollPositions() {
-    var sourceContent = document.querySelector('.source-content');
-    if (sourceContent) {
-        sessionStorage.setItem('source_scroll_top', String(sourceContent.scrollTop));
+    var iframe = document.querySelector('.source-iframe');
+    if (iframe) {
+        try {
+            sessionStorage.setItem('source_iframe_scroll_y', String(iframe.contentWindow.scrollY || 0));
+        } catch (e) {}
     }
     var migratedContent = document.querySelector('.migrated-content');
     if (migratedContent) {
         sessionStorage.setItem('migrated_scroll_top', String(migratedContent.scrollTop));
     }
+}
+
+// Retry setting scrollTop on every animation frame until it takes effect or 500 ms
+// elapses.  A fixed setTimeout(100) is not reliable on some browsers (e.g. Edge)
+// where the browser's own scroll-restoration can run and override our value after
+// DOMContentLoaded but before the first paint.
+function restoreScrollWithRetry(el, scrollVal) {
+    var deadline = Date.now() + 500;
+    function tryScroll() {
+        el.scrollTop = scrollVal;
+        if (el.scrollTop < scrollVal - 1 && Date.now() < deadline) {
+            requestAnimationFrame(tryScroll);
+        }
+    }
+    requestAnimationFrame(tryScroll);
 }
 
 // Reload the page, preserving source pane scroll position

--- a/app/views/lexicon/verification/_source_php.html.haml
+++ b/app/views/lexicon/verification/_source_php.html.haml
@@ -6,7 +6,7 @@
 
   .source-content
     - if entry.lex_file&.full_path && File.exist?(entry.lex_file.full_path)
-      %iframe.source-iframe{src: lexicon_verification_source_path(entry), style: 'width: 100%; height: calc(100vh - 250px); border: 1px solid #ddd; border-radius: 4px;'}
+      %iframe.source-iframe{ src: lexicon_verification_source_path(entry) }
     - else
       .alert.alert-warning
         = t('lexicon.verification.source.file_not_found')

--- a/spec/system/lexicon/verification_scroll_preservation_spec.rb
+++ b/spec/system/lexicon/verification_scroll_preservation_spec.rb
@@ -1,0 +1,159 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Verification Scroll Position Preservation', type: :system, js: true do
+  let!(:person) do
+    create(:lex_person,
+           birthdate: '1138',
+           deathdate: '1204',
+           bio: '<p>A biography paragraph.</p>',
+           gender: :male)
+  end
+
+  let!(:entry) do
+    create(:lex_entry, title: 'Test Person', lex_item: person, status: :draft)
+  end
+
+  # PHP file with enough paragraphs to exceed any typical viewport height
+  let(:php_content) do
+    lines = ['<html><body><h1>Test Person</h1>']
+    80.times { |i| lines << "<p>Content paragraph #{i + 1}: legacy PHP test line for scroll testing.</p>" }
+    lines << '</body></html>'
+    lines.join("\n")
+  end
+
+  let!(:lex_file) do
+    file_path = Rails.root.join('tmp/test_scroll_person.php')
+    File.write(file_path, php_content)
+    create(:lex_file,
+           lex_entry: entry,
+           fname: 'test_scroll_person.php',
+           full_path: file_path.to_s,
+           status: :ingested,
+           entrytype: :person)
+  end
+
+  # Extra citations to ensure the migrated pane has scrollable content
+  let!(:citations) do
+    6.times.map { |i| create(:lex_citation, person: person, title: "Citation #{i}", from_publication: "Pub #{i}") }
+  end
+
+  after { FileUtils.rm_f(lex_file.full_path) }
+
+  # before must appear after let! blocks so that let! implicit before-hooks
+  # (which create the file and DB records) execute before this hook visits the page.
+  before do
+    skip 'WebDriver not available or misconfigured' unless webdriver_available?
+    login_as_lexicon_editor
+    entry.start_verification!('test@example.com')
+    visit "/lex/verification/#{entry.id}"
+  end
+
+  # Async script that polls until the iframe has loaded real source content,
+  # then resolves to its scrollY.  Times out at 5 seconds.
+  def iframe_scroll_y_js
+    <<~JS
+      var done = arguments[0];
+      var deadline = Date.now() + 5000;
+      function check() {
+        try {
+          var iframe = document.querySelector('.source-iframe');
+          if (!iframe) { done(-1); return; }
+          var href = iframe.contentWindow.location.href;
+          if (href && href !== 'about:blank') { done(iframe.contentWindow.scrollY); return; }
+        } catch(e) {}
+        if (Date.now() > deadline) { done(-1); } else { setTimeout(check, 100); }
+      }
+      check();
+    JS
+  end
+
+  # Async script that polls until .migrated-content scrollTop >= threshold or timeout.
+  def migrated_scroll_top_js(threshold: 50, timeout_ms: 2000)
+    <<~JS
+      var done = arguments[0];
+      var deadline = Date.now() + #{timeout_ms};
+      function check() {
+        var el = document.querySelector('.migrated-content');
+        var top = el ? el.scrollTop : 0;
+        if (top >= #{threshold} || Date.now() > deadline) { done(top); }
+        else { setTimeout(check, 50); }
+      }
+      check();
+    JS
+  end
+
+  describe 'Source iframe scroll preservation' do
+    it 'saves source_iframe_scroll_y to sessionStorage when saveScrollPositions is called' do
+      expect(page).to have_css('.source-iframe', wait: 5)
+      expect(page.evaluate_script("sessionStorage.getItem('source_iframe_scroll_y')")).to be_nil
+
+      page.execute_script('saveScrollPositions()')
+
+      expect(page.evaluate_script("sessionStorage.getItem('source_iframe_scroll_y')")).not_to be_nil
+    end
+
+    it 'does not save the legacy source_scroll_top key' do
+      expect(page).to have_css('.source-iframe', wait: 5)
+      page.execute_script('saveScrollPositions()')
+      expect(page.evaluate_script("sessionStorage.getItem('source_scroll_top')")).to be_nil
+    end
+
+    it 'consumes source_iframe_scroll_y from sessionStorage on page load' do
+      page.execute_script("sessionStorage.setItem('source_iframe_scroll_y', '80')")
+
+      visit "/lex/verification/#{entry.id}"
+      expect(page).to have_css('.source-iframe', wait: 10)
+
+      expect(page.evaluate_script("sessionStorage.getItem('source_iframe_scroll_y')")).to be_nil
+    end
+
+    it 'restores the source iframe scroll position after a page reload' do
+      page.execute_script("sessionStorage.setItem('source_iframe_scroll_y', '80')")
+
+      visit "/lex/verification/#{entry.id}"
+      expect(page).to have_css('.source-iframe', wait: 10)
+
+      # Poll asynchronously until the iframe has loaded real content and scroll is applied
+      scroll_y = page.evaluate_async_script(iframe_scroll_y_js)
+      expect(scroll_y).to be >= 40
+    end
+  end
+
+  describe 'Migrated pane scroll preservation' do
+    it 'saves migrated_scroll_top to sessionStorage when saveScrollPositions is called' do
+      expect(page).to have_css('.migrated-content', wait: 5)
+      page.execute_script('saveScrollPositions()')
+      expect(page.evaluate_script("sessionStorage.getItem('migrated_scroll_top')")).not_to be_nil
+    end
+
+    it 'restores migrated pane scroll position after a page reload' do
+      expect(page).to have_css('.migrated-content', wait: 5)
+
+      # Scroll the pane and measure the actual scrollTop (clamped to content height)
+      page.execute_script("document.querySelector('.migrated-content').scrollTop = 100")
+      actual_before = page.evaluate_script("document.querySelector('.migrated-content').scrollTop")
+      skip 'Migrated content is not tall enough to scroll' if actual_before < 50
+
+      # Simulate what saveScrollPositions() does, then navigate (like location.reload())
+      page.execute_script("sessionStorage.setItem('migrated_scroll_top', '#{actual_before}')")
+      visit "/lex/verification/#{entry.id}"
+      expect(page).to have_css('.verification-container', wait: 5)
+
+      # sessionStorage key should have been consumed by initVerification
+      expect(page.evaluate_script("sessionStorage.getItem('migrated_scroll_top')")).to be_nil
+
+      # Poll asynchronously until the rAF-based retry has applied the scroll
+      scroll_top = page.evaluate_async_script(migrated_scroll_top_js)
+      expect(scroll_top).to be >= 50
+    end
+
+    it 'clears the legacy source_scroll_top key from sessionStorage on page load' do
+      page.execute_script("sessionStorage.setItem('source_scroll_top', '123')")
+      visit "/lex/verification/#{entry.id}"
+      expect(page).to have_css('.verification-container', wait: 5)
+      expect(page.evaluate_script("sessionStorage.getItem('source_scroll_top')")).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- **Chrome**: source pane (legacy PHP iframe) scrolled back to top after each page reload because the JS was saving `.source-content.scrollTop` (the outer container) instead of `iframe.contentWindow.scrollY` (the iframe's internal scroll). Also, the `readyState === 'complete'` guard fired on the initial `about:blank` document, skipping the `load` event listener so real scroll restoration never happened.
- **Edge**: migrated pane scroll also wasn't preserved because `setTimeout(100)` is too fragile; Edge's own scroll-restoration can run and reset `scrollTop` after the timer fires.

### Changes

**`app/assets/javascripts/verification.js`**
- `saveScrollPositions()`: saves `iframe.contentWindow.scrollY` as `source_iframe_scroll_y` (drops the old `source_scroll_top` key)
- Scroll restoration: always registers a `load` listener; only applies immediately if the iframe has real content (`href !== 'about:blank'`), avoiding the false-positive `readyState` check on `about:blank`
- Migrated pane: replaces `setTimeout(100)` with `restoreScrollWithRetry()` — an rAF-based retry loop that keeps setting `scrollTop` until it takes effect or 500 ms elapses
- Cleans up the legacy `source_scroll_top` key on every page load

**`app/views/lexicon/verification/_source_php.html.haml`**
- Removes the inline `height: calc(100vh - 250px)` override, letting the CSS `height: 100%` take effect so the iframe fills its container (the CSS already intended this)

**`spec/system/lexicon/verification_scroll_preservation_spec.rb`** (new)
- 7 system specs covering: key saved by `saveScrollPositions()`, key consumed on page load, scroll applied to iframe after load event, migrated pane scroll restored after navigation

## Test plan

- [x] `bundle exec rspec spec/system/lexicon/verification_scroll_preservation_spec.rb` — 7 examples, 0 failures
- [x] `bundle exec rspec spec/system/lexicon/` — 120 examples, 0 failures
- [x] The 4 pre-existing failures in `spec/requests/lexicon/files_spec.rb` are unrelated to this change (confirmed by reproducing on the base branch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)