### PR TITLE
Distinguish main vs secondary legacy lexicon entries (9uh)

### DIFF
--- a/app/controllers/lexicon/entries_controller.rb
+++ b/app/controllers/lexicon/entries_controller.rb
@@ -65,8 +65,9 @@ module Lexicon
                                @death_year_from.present? || @death_year_to.present?
 
       # Start with base scope
-      # We render all not-completed migrations (they will redirected to old site) plus published entries
-      @lex_entries = LexEntry.includes(:lex_item).where(status: LexEntry::MIGRATION_STATUSES + %w(published))
+      # We render all not-completed migrations (they will redirected to old site) plus published entries.
+      # Only main entries are listed; secondary entries are reachable via internal links only.
+      @lex_entries = LexEntry.main.includes(:lex_item).where(status: LexEntry::MIGRATION_STATUSES + %w(published))
 
       # Calculate gender facets (before applying gender filter)
       @gender_facet = calculate_gender_facets

--- a/app/controllers/lexicon/entries_controller.rb
+++ b/app/controllers/lexicon/entries_controller.rb
@@ -65,7 +65,7 @@ module Lexicon
                                @death_year_from.present? || @death_year_to.present?
 
       # Start with base scope
-      # We render all not-completed migrations (they will redirected to old site) plus published entries.
+      # We render all not-completed migrations (they will be redirected to old site) plus published entries.
       # Only main entries are listed; secondary entries are reachable via internal links only.
       @lex_entries = LexEntry.main.includes(:lex_item).where(status: LexEntry::MIGRATION_STATUSES + %w(published))
 

--- a/app/models/lex_entry.rb
+++ b/app/models/lex_entry.rb
@@ -41,6 +41,10 @@ class LexEntry < ApplicationRecord
   scope :needs_verification, -> { where(status: %i(draft verifying error escalated)) }
   scope :in_verification, -> { where(status: :verifying) }
 
+  # Main entries are shown in /lex; secondary entries (main: false) are only
+  # reachable via internal links from another entry.
+  scope :main, -> { where(main: true) }
+
   update_index('lex_entries') { self }
   update_index('lex_entries_autocomplete') { self }
 

--- a/db/migrate/20260601200000_add_main_to_lex_entries.rb
+++ b/db/migrate/20260601200000_add_main_to_lex_entries.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+# Distinguishes main lexicon entries (shown in /lex) from secondary entries,
+# which are ingested but only reachable via internal links from another entry.
+class AddMainToLexEntries < ActiveRecord::Migration[8.1]
+  def up
+    add_column :lex_entries, :main, :boolean, default: true, null: false
+
+    # Backfill: legacy entries whose source PHP filename is numeric but NOT
+    # exactly five digits (e.g. 02645001.php) are secondary entries.
+    say_with_time 'Marking non-five-digit legacy entries as non-main' do
+      LexEntry.reset_column_information
+      LexEntry.joins(:lex_file)
+              .where.not('lex_files.fname REGEXP ?', '^[0-9]{5}\\.php$')
+              .update_all(main: false)
+    end
+  end
+
+  def down
+    remove_column :lex_entries, :main
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_29_031027) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_01_200000) do
   create_table "aboutnesses", id: :integer, charset: "utf8mb4", collation: "utf8mb4_bin", force: :cascade do |t|
     t.integer "aboutable_id"
     t.string "aboutable_type"
@@ -675,6 +675,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_29_031027) do
     t.string "lex_item_type"
     t.timestamp "locked_at"
     t.integer "locked_by_user_id"
+    t.boolean "main", default: true, null: false
     t.string "other_designation", limit: 1024
     t.bigint "profile_image_id"
     t.string "sort_title"

--- a/lib/tasks/ingest_lexicon.rake
+++ b/lib/tasks/ingest_lexicon.rake
@@ -121,10 +121,17 @@ def process_legacy_lexicon_entry(fname)
   title = validate_title(title, fname)
 
   status = entrytype == 'unknown' ? :unclassified : :classified
+
+  # Main entries (shown in /lex) have a filename of precisely five digits, e.g.
+  # 00001.php. Other numeric filenames (e.g. 02645001.php) are secondary entries,
+  # reachable only via internal links from another entry.
+  is_main = filepart.match?(/\A\d{5}\.php\z/)
+
   if lf.nil?
     lex_entry = LexEntry.create!(
       title: title,
-      status: :raw
+      status: :raw,
+      main: is_main
     )
 
     LexFile.create!(
@@ -139,6 +146,7 @@ def process_legacy_lexicon_entry(fname)
   else
     lf.update!(entrytype: entrytype, status: status)
     lex_entry = lf.lex_entry
+    lex_entry.update!(main: is_main) if lex_entry.main != is_main
     lex_item = lex_entry.lex_item
     # destroying item to be recreated during ingestion
     if lex_item.present?

--- a/spec/controllers/lexicon/entries_controller_spec.rb
+++ b/spec/controllers/lexicon/entries_controller_spec.rb
@@ -27,6 +27,13 @@ RSpec.describe Lexicon::EntriesController, type: :controller do
       expect(assigns(:lex_entries)).not_to include(deprecated_person_entry)
     end
 
+    it 'excludes secondary (non-main) entries from @lex_entries' do
+      secondary_entry = create(:lex_entry, :person, status: :published, title: 'Secondary Author', main: false)
+      call
+      expect(assigns(:lex_entries)).to include(published_person_entry)
+      expect(assigns(:lex_entries)).not_to include(secondary_entry)
+    end
+
     it 'orders entries by title' do
       # Create entries with different titles
       create(:lex_entry, :person, status: :published, title: 'Zebra')

--- a/spec/lib/tasks/ingest_lexicon_rake_spec.rb
+++ b/spec/lib/tasks/ingest_lexicon_rake_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'rake'
+require 'fileutils'
+require 'tmpdir'
+
+RSpec.describe 'ingest_lexicon rake task' do # rubocop:disable RSpec/DescribeClass
+  before(:all) do
+    Rake.application.rake_require 'tasks/ingest_lexicon'
+    Rake::Task.define_task(:environment)
+  end
+
+  let(:task) { Rake::Task['ingest_lexicon'] }
+  let(:fixtures_dir) { Rails.root.join('spec/fixtures/files/lexicon') }
+  let(:work_dir) { Dir.mktmpdir }
+
+  before { task.reenable }
+
+  after { FileUtils.remove_entry(work_dir) }
+
+  # Copies the given fixture php filenames into an isolated working directory
+  # so the task only processes the files relevant to the example.
+  def stage(*filenames)
+    filenames.each { |name| FileUtils.cp(fixtures_dir.join(name), File.join(work_dir, name)) }
+  end
+
+  def entry_for(fname)
+    LexFile.find_by(fname: fname)&.lex_entry
+  end
+
+  it 'marks a five-digit filename as a main entry' do
+    stage('00020.php')
+
+    task.invoke(work_dir)
+
+    expect(entry_for('00020.php').main).to be true
+  end
+
+  it 'marks a non-five-digit numeric filename as a secondary (non-main) entry' do
+    stage('02645001.php')
+
+    task.invoke(work_dir)
+
+    expect(entry_for('02645001.php').main).to be false
+  end
+end


### PR DESCRIPTION
## Summary

Introduces a boolean `main` column on `LexEntry` to distinguish **main** lexicon entries (displayed in `/lex`) from **secondary** entries, which are ingested and migrated but only reachable via internal links from another entry.

Implements bead `9uh`.

## Changes

- **Migration** (`add_main_to_lex_entries`): adds `main` (boolean, default `true`, not null) and backfills existing legacy entries whose source PHP filename is numeric but **not** exactly five digits to `false`.
- **`ingest_lexicon` rake task**: sets `main = true` iff the legacy filename is precisely five digits (e.g. `00001.php`), `false` otherwise (e.g. `02645001.php`). Applied on both create and update paths.
- **`LexEntry.main` scope** + **`entries#list`** (the `/lex` public view) now filters to main entries only.

## Design decisions

- **Default `true`**: manually-created entries (no `lex_file`) and ordinary entries should be visible in `/lex`; only specific legacy secondary entries are non-main.
- **Backfill in the migration**: makes the distinction take effect immediately on existing data without requiring a full re-ingestion. (Updated 898 rows in dev.)
- The rake task already only processes pure-numeric filenames, so the `00001z.php`-style examples in the bead are filtered out upstream; "five digits" is `/\A\d{5}\.php\z/`.

## Test plan

- New `spec/lib/tasks/ingest_lexicon_rake_spec.rb`: ingests a five-digit fixture (`00020.php` → main) and a non-five-digit fixture (`02645001.php` → secondary).
- New controller spec: secondary (`main: false`) entries are excluded from `/lex`.
- Ran `entries_controller_spec`, `entries_list_filtering_spec`, `entries_filtering_spec`, `requests/lexicon/entries_spec` — all green (92 examples, 0 failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)