### PR TITLE
Lexicon verification: queue-driven migration flow + external-link re-checking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@
 /config/newrelic.yml
 /config/s3.yml
 /config/behead.payload
+/config/sidekiq.yml
 
 /vendor/analysis*
 /public/assets/*

--- a/app/controllers/concerns/link_checking_concern.rb
+++ b/app/controllers/concerns/link_checking_concern.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+# Shared synchronous external-link (re-)checking for Lexicon controllers that let editors
+# edit a URL (LexLink and LexCitation). On a URL change the controller re-checks the link
+# and stores the fresh HTTP status on the record, exposing a toast for the JS response.
+#
+# Records differ in their column names, so the caller passes them in:
+#   - LexLink:     status_column: :http_status,      checked_at_column: :checked_at
+#   - LexCitation: status_column: :link_http_status, checked_at_column: :link_checked_at
+module LinkCheckingConcern
+  extend ActiveSupport::Concern
+
+  private
+
+  # Re-checks +url+ synchronously and stores the resulting HTTP status on +record+.
+  # A blank URL clears the stored status without making a network request.
+  # Sets @link_check_performed / @link_toast_type / @link_toast_message for the JS view.
+  def check_link_synchronously(record, url, status_column:, checked_at_column:)
+    if url.blank?
+      record.update_columns(status_column => nil, checked_at_column => nil)
+      return
+    end
+
+    status = Lexicon::CheckExternalLinks.new.check_url(url)
+    record.update_columns(status_column => status, checked_at_column => Time.current)
+    @link_check_performed = true
+    @link_toast_type, @link_toast_message = link_toast_for(status)
+    # flash (not flash.now) is intentional: the JS response triggers a full page reload in the
+    # verification view, and the toast must survive into the reloaded request.
+    flash[:link_check_toast_type] = @link_toast_type
+    flash[:link_check_toast_message] = @link_toast_message
+  end
+
+  def link_toast_for(status)
+    if status.nil?
+      ['error', t('lexicon.verification.broken_link.inaccessible')]
+    elsif status < 400
+      ['success', t('lexicon.verification.broken_link.now_accessible')]
+    else
+      ['error', t('lexicon.verification.broken_link.still_broken', status: status)]
+    end
+  end
+end

--- a/app/controllers/lexicon/citations_controller.rb
+++ b/app/controllers/lexicon/citations_controller.rb
@@ -4,6 +4,7 @@ module Lexicon
   # Controller to work with Lexicon Citations
   class CitationsController < ApplicationController
     include LockLexEntryConcern
+    include LinkCheckingConcern
 
     before_action do
       require_editor('edit_lexicon')
@@ -46,7 +47,10 @@ module Lexicon
       end
 
       if @citation.save
-        check_link_synchronously if @citation.saved_change_to_link?
+        if @citation.saved_change_to_link?
+          check_link_synchronously(@citation, @citation.link,
+                                   status_column: :link_http_status, checked_at_column: :link_checked_at)
+        end
         return
       end
 
@@ -110,32 +114,6 @@ module Lexicon
     # Only allow a list of trusted parameters through.
     def lex_citation_params
       params.expect(lex_citation: %i(title from_publication pages link manifestation_id subject lex_person_work_id))
-    end
-
-    def check_link_synchronously
-      if @citation.link.blank?
-        @citation.update_columns(link_http_status: nil, link_checked_at: nil)
-        return
-      end
-
-      status = CheckExternalLinks.new.check_url(@citation.link)
-      @citation.update_columns(link_http_status: status, link_checked_at: Time.current)
-      @link_check_performed = true
-      @link_toast_type, @link_toast_message = link_toast_for(status)
-      # rubocop:disable Rails/ActionControllerFlashBeforeRender
-      flash[:link_check_toast_type] = @link_toast_type
-      flash[:link_check_toast_message] = @link_toast_message
-      # rubocop:enable Rails/ActionControllerFlashBeforeRender
-    end
-
-    def link_toast_for(status)
-      if status.nil?
-        ['error', t('lexicon.verification.broken_link.inaccessible')]
-      elsif status < 400
-        ['success', t('lexicon.verification.broken_link.now_accessible')]
-      else
-        ['error', t('lexicon.verification.broken_link.still_broken', status: status)]
-      end
     end
   end
 end

--- a/app/controllers/lexicon/files_controller.rb
+++ b/app/controllers/lexicon/files_controller.rb
@@ -56,17 +56,20 @@ module Lexicon
       lex_entry.status_migrating!
 
       Lexicon::IngestFile.perform_async(@lex_file.id)
+      # Signals the JS response to send the editor to the verification queue (see migrate.js.erb).
+      @migration_launched = true
     end
 
     def redo_migration
       lex_entry = @lex_file.lex_entry
-      return unless lex_entry.status_draft? || lex_entry.status_verifying? || lex_entry.status_escalated?
+      return unless lex_entry.redo_migration_eligible?
 
       lex_entry.reset_ingestion!
       @lex_file.reload
       @lex_file.status_classified! if @lex_file.status_ingested?
       lex_entry.status_migrating!
       Lexicon::IngestFile.perform_async(@lex_file.id)
+      @migration_launched = true
     end
 
     private

--- a/app/controllers/lexicon/links_controller.rb
+++ b/app/controllers/lexicon/links_controller.rb
@@ -33,7 +33,12 @@ module Lexicon
     def edit; end
 
     def update
-      return if @link.update(lex_link_params)
+      if @link.update(lex_link_params)
+        # Re-check the link only when its URL actually changed, so a previously-broken
+        # link (e.g. HTTP 403) is re-evaluated instead of keeping its stale status.
+        check_link_synchronously if @link.saved_change_to_url?
+        return
+      end
 
       render :edit, status: :unprocessable_content
     end
@@ -62,6 +67,30 @@ module Lexicon
     # Only allow a list of trusted parameters through.
     def lex_link_params
       params.expect(lex_link: %i(url description))
+    end
+
+    # Re-checks the (changed) URL synchronously and stores the fresh status, mirroring
+    # Lexicon::CitationsController#check_link_synchronously. url has a presence validation,
+    # so it is never blank here. The toast is stashed in flash for the JS response.
+    def check_link_synchronously
+      status = CheckExternalLinks.new.check_url(@link.url)
+      @link.update_columns(http_status: status, checked_at: Time.current)
+      @link_check_performed = true
+      @link_toast_type, @link_toast_message = link_toast_for(status)
+      # rubocop:disable Rails/ActionControllerFlashBeforeRender
+      flash[:link_check_toast_type] = @link_toast_type
+      flash[:link_check_toast_message] = @link_toast_message
+      # rubocop:enable Rails/ActionControllerFlashBeforeRender
+    end
+
+    def link_toast_for(status)
+      if status.nil?
+        ['error', t('lexicon.verification.broken_link.inaccessible')]
+      elsif status < 400
+        ['success', t('lexicon.verification.broken_link.now_accessible')]
+      else
+        ['error', t('lexicon.verification.broken_link.still_broken', status: status)]
+      end
     end
   end
 end

--- a/app/controllers/lexicon/links_controller.rb
+++ b/app/controllers/lexicon/links_controller.rb
@@ -4,6 +4,7 @@ module Lexicon
   # Controller to work with Lexicon Links
   class LinksController < ApplicationController
     include LockLexEntryConcern
+    include LinkCheckingConcern
 
     before_action do
       require_editor('edit_lexicon')
@@ -36,7 +37,9 @@ module Lexicon
       if @link.update(lex_link_params)
         # Re-check the link only when its URL actually changed, so a previously-broken
         # link (e.g. HTTP 403) is re-evaluated instead of keeping its stale status.
-        check_link_synchronously if @link.saved_change_to_url?
+        if @link.saved_change_to_url?
+          check_link_synchronously(@link, @link.url, status_column: :http_status, checked_at_column: :checked_at)
+        end
         return
       end
 
@@ -67,30 +70,6 @@ module Lexicon
     # Only allow a list of trusted parameters through.
     def lex_link_params
       params.expect(lex_link: %i(url description))
-    end
-
-    # Re-checks the (changed) URL synchronously and stores the fresh status, mirroring
-    # Lexicon::CitationsController#check_link_synchronously. url has a presence validation,
-    # so it is never blank here. The toast is stashed in flash for the JS response.
-    def check_link_synchronously
-      status = CheckExternalLinks.new.check_url(@link.url)
-      @link.update_columns(http_status: status, checked_at: Time.current)
-      @link_check_performed = true
-      @link_toast_type, @link_toast_message = link_toast_for(status)
-      # rubocop:disable Rails/ActionControllerFlashBeforeRender
-      flash[:link_check_toast_type] = @link_toast_type
-      flash[:link_check_toast_message] = @link_toast_message
-      # rubocop:enable Rails/ActionControllerFlashBeforeRender
-    end
-
-    def link_toast_for(status)
-      if status.nil?
-        ['error', t('lexicon.verification.broken_link.inaccessible')]
-      elsif status < 400
-        ['success', t('lexicon.verification.broken_link.now_accessible')]
-      else
-        ['error', t('lexicon.verification.broken_link.still_broken', status: status)]
-      end
     end
   end
 end

--- a/app/controllers/lexicon/verification_controller.rb
+++ b/app/controllers/lexicon/verification_controller.rb
@@ -225,8 +225,8 @@ module Lexicon
     # POST /lexicon/verification/:id/mark_verified
     def mark_verified
       @entry.mark_verified!
-      redirect_to lexicon_verification_queue_path,
-                  notice: I18n.t('lexicon.verification.messages.entry_verified')
+      redirect_to lexicon_entry_path(@entry),
+                  notice: I18n.t('lexicon.verification.messages.entry_verified_public')
     rescue StandardError => e
       redirect_to lexicon_verification_path(@entry),
                   alert: e.message

--- a/app/models/lex_entry.rb
+++ b/app/models/lex_entry.rb
@@ -74,6 +74,12 @@ class LexEntry < ApplicationRecord
     attachments.find_by(id: profile_image_id)
   end
 
+  # Whether a (re-)migration can be launched for this entry. Mirrors the guard in
+  # Lexicon::FilesController#redo_migration. A lex_file is required to re-run ingestion.
+  def redo_migration_eligible?
+    lex_file.present? && (status_draft? || status_verifying? || status_escalated?)
+  end
+
   # Should be called if we want to re-ingest the lex file
   def reset_ingestion!
     return if lex_file.nil? # Should not be called for entries without lex_file

--- a/app/models/lex_entry.rb
+++ b/app/models/lex_entry.rb
@@ -74,8 +74,9 @@ class LexEntry < ApplicationRecord
     attachments.find_by(id: profile_image_id)
   end
 
-  # Whether a (re-)migration can be launched for this entry. Mirrors the guard in
-  # Lexicon::FilesController#redo_migration. A lex_file is required to re-run ingestion.
+  # Whether a (re-)migration can be launched for this entry. This is the single source of
+  # truth for redo eligibility, used by Lexicon::FilesController#redo_migration and the
+  # verification queue. A lex_file is required to re-run ingestion.
   def redo_migration_eligible?
     lex_file.present? && (status_draft? || status_verifying? || status_escalated?)
   end

--- a/app/views/lexicon/files/migrate.js.erb
+++ b/app/views/lexicon/files/migrate.js.erb
@@ -1,3 +1,7 @@
+<% if @migration_launched %>
+window.location.href = '<%= lexicon_verification_queue_path %>';
+<% else %>
 $('tr#lex-file-<%= @lex_file.id %>').replaceWith(
   '<%= j render(partial: "lexicon/files/file_row", locals: { lf: @lex_file }) %>'
 );
+<% end %>

--- a/app/views/lexicon/files/redo_migration.js.erb
+++ b/app/views/lexicon/files/redo_migration.js.erb
@@ -1,3 +1,7 @@
+<% if @migration_launched %>
+window.location.href = '<%= lexicon_verification_queue_path %>';
+<% else %>
 $('tr#lex-file-<%= @lex_file.id %>').replaceWith(
   '<%= j render(partial: "lexicon/files/file_row", locals: { lf: @lex_file }) %>'
 );
+<% end %>

--- a/app/views/lexicon/links/update.js
+++ b/app/views/lexicon/links/update.js
@@ -1,1 +1,0 @@
-reloadContent($('#links'));

--- a/app/views/lexicon/links/update.js.erb
+++ b/app/views/lexicon/links/update.js.erb
@@ -6,7 +6,7 @@ if ($('#links').length) {
   <% end %>
 } else {
   // Verification view: store toast data in sessionStorage so it survives the page reload.
-  // flash.now (set by the controller) only lives for the current JS response, not the reload.
+  // flash (set by the controller) is also embedded into the reloaded page as a fallback if sessionStorage isn't available.
 <% if @link_check_performed %>
   sessionStorage.setItem('link-check-toast-type', <%= @link_toast_type.to_json %>);
   sessionStorage.setItem('link-check-toast-message', <%= @link_toast_message.to_json %>);

--- a/app/views/lexicon/links/update.js.erb
+++ b/app/views/lexicon/links/update.js.erb
@@ -1,0 +1,16 @@
+if ($('#links').length) {
+  // Entry-edit view: lazy-reload just the links section
+  reloadContent($('#links'));
+  <% if @link_check_performed %>
+  showToast(<%= @link_toast_message.to_json %>, '<%= @link_toast_type %>');
+  <% end %>
+} else {
+  // Verification view: store toast data in sessionStorage so it survives the page reload.
+  // flash.now (set by the controller) only lives for the current JS response, not the reload.
+<% if @link_check_performed %>
+  sessionStorage.setItem('link-check-toast-type', <%= @link_toast_type.to_json %>);
+  sessionStorage.setItem('link-check-toast-message', <%= @link_toast_message.to_json %>);
+<% end %>
+  // Reload is triggered by the edit-button onSuccess callback; setTimeout is a safety fallback.
+  setTimeout(function() { location.reload(); }, 300);
+}

--- a/app/views/lexicon/verification/_person_sections.html.haml
+++ b/app/views/lexicon/verification/_person_sections.html.haml
@@ -299,7 +299,7 @@
               %br
               %span.text-muted= link.description
           .link-actions.mt-2
-            %button.btn.btn-sm.btn-outline-primary{onclick: "openModal('#{edit_lexicon_link_path(link)}', onSectionEditSuccess('section-links'))"}
+            %button.btn.btn-sm.btn-outline-primary{onclick: "openModal('#{edit_lexicon_link_path(link)}', function() { location.reload(); })"}
               ✏️
               = t('lexicon.verification.migrated.edit')
             %button.btn.btn-sm{class: checklist['links']&.dig('items', link.id.to_s, 'verified') ? 'btn-success' : 'btn-outline-success', data: {action: 'click->verification#quickVerify', path: "links.items.#{link.id}"}}

--- a/app/views/lexicon/verification/_publication_sections.html.haml
+++ b/app/views/lexicon/verification/_publication_sections.html.haml
@@ -124,7 +124,7 @@
               %br
               %span.text-muted= link.description
           .link-actions.mt-2
-            %button.btn.btn-sm.btn-outline-primary{onclick: "openModal('#{edit_lexicon_link_path(link)}', onSectionEditSuccess('section-links'))"}
+            %button.btn.btn-sm.btn-outline-primary{onclick: "openModal('#{edit_lexicon_link_path(link)}', function() { location.reload(); })"}
               ✏️
               = t('lexicon.verification.migrated.edit')
             %button.btn.btn-sm{class: checklist['links']&.dig('items', link.id.to_s, 'verified') ? 'btn-success' : 'btn-outline-success', data: {action: 'click->verification#quickVerify', path: "links.items.#{link.id}"}}

--- a/app/views/lexicon/verification/index.html.haml
+++ b/app/views/lexicon/verification/index.html.haml
@@ -51,9 +51,18 @@
             -# locked by another user
             .label.label-warning= entry.locked_by_human
             %span.text-sm-left.text-muted= entry.locked_at_human
-          - elsif entry.status_verifying? || entry.status_escalated?
-            = link_to t('lexicon.verification.queue.actions.continue'), lexicon_verification_path(entry), class: 'btn btn-sm btn-primary'
           - else
-            = link_to t('lexicon.verification.queue.actions.start'), lexicon_verification_path(entry), class: 'btn btn-sm btn-success'
+            - if entry.status_verifying? || entry.status_escalated?
+              = link_to t('lexicon.verification.queue.actions.continue'), lexicon_verification_path(entry), class: 'btn btn-sm btn-primary'
+            - else
+              = link_to t('lexicon.verification.queue.actions.start'), lexicon_verification_path(entry), class: 'btn btn-sm btn-success'
+            - if entry.redo_migration_eligible?
+              = link_to t('lexicon.files.redo_migrate.title'), redo_migration_lexicon_file_path(entry.lex_file),
+                        remote: true, method: :post, class: 'btn btn-sm btn-outline-warning ms-1',
+                        data: { confirm: t('lexicon.files.redo_migrate.confirm') }
 
 = paginate @entries
+
+-# Auto-refresh the queue so async migrations completing elsewhere become visible without a manual reload.
+:javascript
+  setTimeout(function () { window.location.reload(); }, 60000);

--- a/app/views/lexicon/verification/index.html.haml
+++ b/app/views/lexicon/verification/index.html.haml
@@ -53,9 +53,11 @@
             %span.text-sm-left.text-muted= entry.locked_at_human
           - else
             - if entry.status_verifying? || entry.status_escalated?
-              = link_to t('lexicon.verification.queue.actions.continue'), lexicon_verification_path(entry), class: 'btn btn-sm btn-primary'
+              = link_to t('lexicon.verification.queue.actions.continue'), lexicon_verification_path(entry),
+                        class: 'btn btn-sm btn-primary'
             - else
-              = link_to t('lexicon.verification.queue.actions.start'), lexicon_verification_path(entry), class: 'btn btn-sm btn-success'
+              = link_to t('lexicon.verification.queue.actions.start'), lexicon_verification_path(entry),
+                        class: 'btn btn-sm btn-success'
             - if entry.redo_migration_eligible?
               = link_to t('lexicon.files.redo_migrate.title'), redo_migration_lexicon_file_path(entry.lex_file),
                         remote: true, method: :post, class: 'btn btn-sm btn-outline-warning ms-1',

--- a/config/locales/lexicon.en.yml
+++ b/config/locales/lexicon.en.yml
@@ -281,6 +281,7 @@ en:
       messages:
         progress_saved: Progress saved successfully
         entry_verified: Entry verified successfully
+        entry_verified_public: Entry marked as verified. Here is its public view.
         entry_escalated: Entry escalated for review
         error_escalating_entry: Error escalating entry
         add_escalation_notes: Add notes for the reviewer...

--- a/config/locales/lexicon.he.yml
+++ b/config/locales/lexicon.he.yml
@@ -281,6 +281,7 @@ he:
       messages:
         progress_saved: ההתקדמות נשמרה בהצלחה
         entry_verified: הערך אומת בהצלחה
+        entry_verified_public: הערך סומן כמאומת. לפניך התצוגה הציבורית שלו.
         entry_escalated: הערך הועבר לבדיקה נוספת
         error_escalating_entry: שגיאה בהעברה לבדיקה נוספת
         add_escalation_notes: הוספת הערות לבודק...

--- a/spec/models/lex_entry_spec.rb
+++ b/spec/models/lex_entry_spec.rb
@@ -326,6 +326,27 @@ RSpec.describe LexEntry, type: :model do
     end
   end
 
+  describe '#redo_migration_eligible?' do
+    it 'is true for draft, verifying, and escalated entries that have a lex_file' do
+      %i(draft verifying escalated).each do |status|
+        file = create(:lex_file, :person, entry_status: status)
+        expect(file.lex_entry.redo_migration_eligible?).to be(true)
+      end
+    end
+
+    it 'is false for entries in other statuses even with a lex_file' do
+      %i(raw migrating error verified published).each do |status|
+        file = create(:lex_file, :person, entry_status: status)
+        expect(file.lex_entry.redo_migration_eligible?).to be(false)
+      end
+    end
+
+    it 'is false when the entry has no lex_file' do
+      entry = create(:lex_entry, status: :verifying, verification_progress: { 'checklist' => {} })
+      expect(entry.redo_migration_eligible?).to be(false)
+    end
+  end
+
   describe '#last_content_update' do
     let(:person) { create(:lex_person) }
     let(:entry) { create(:lex_entry, lex_item: person) }

--- a/spec/requests/lexicon/files_spec.rb
+++ b/spec/requests/lexicon/files_spec.rb
@@ -244,6 +244,12 @@ describe '/lexicon/files' do
           expect(Lexicon::IngestFile.jobs.last['args']).to eq([file.id])
           expect(file.lex_entry.reload.status).to eq('migrating')
         end
+
+        it 'redirects the editor to the verification queue via the JS response' do
+          call
+          expect(response.body).to include('window.location')
+          expect(response.body).to include(lexicon_verification_queue_path)
+        end
       end
 
       context 'when entry_status is error' do
@@ -269,6 +275,12 @@ describe '/lexicon/files' do
           expect { call }.not_to(change { Lexicon::IngestFile.jobs.size })
           expect(call).to eq(200)
           expect(file.lex_entry.reload.status).to eq(entry_status)
+        end
+
+        it 'does not redirect to the verification queue when no job is launched' do
+          call
+          expect(response.body).not_to include('window.location')
+          expect(response.body).to include("lex-file-#{file.id}")
         end
       end
     end
@@ -299,6 +311,12 @@ describe '/lexicon/files' do
         expect(file.lex_entry.reload.status).to eq('migrating')
         expect(file.lex_entry.lex_item).to be_nil
         expect(file.reload.status).to eq('classified')
+      end
+
+      it 'redirects the editor to the verification queue via the JS response' do
+        call
+        expect(response.body).to include('window.location')
+        expect(response.body).to include(lexicon_verification_queue_path)
       end
     end
 

--- a/spec/requests/lexicon/links_spec.rb
+++ b/spec/requests/lexicon/links_spec.rb
@@ -10,7 +10,6 @@ describe '/lexicon/links' do
   let(:entry) { create(:lex_entry, :person) }
   let(:person) { entry.lex_item }
 
-
   let!(:links) { create_list(:lex_link, 3, item: person) }
 
   let(:link) { links.first }
@@ -65,6 +64,13 @@ describe '/lexicon/links' do
     context 'when valid params' do
       let(:link_params) { attributes_for(:lex_link) }
 
+      before do
+        # attributes_for changes the URL, which now triggers a synchronous re-check.
+        # Stub the network call so this example stays offline.
+        allow(Lexicon::CheckExternalLinks).to receive(:new)
+          .and_return(instance_double(Lexicon::CheckExternalLinks, check_url: 200))
+      end
+
       it 'updates record' do
         expect(call).to eq(200)
         expect(link.reload).to have_attributes(link_params.except(:item))
@@ -77,6 +83,65 @@ describe '/lexicon/links' do
       it 're-renders edit form' do
         expect(call).to eq(422)
         expect(call).to render_template(:edit)
+      end
+    end
+
+    context 'when the URL is changed' do
+      let(:checker) { instance_double(Lexicon::CheckExternalLinks) }
+      let(:link_params) { { url: 'https://new.example.com/' } }
+
+      before do
+        allow(Lexicon::CheckExternalLinks).to receive(:new).and_return(checker)
+        link.update_columns(http_status: 403, checked_at: 1.day.ago)
+      end
+
+      context 'when the new link is accessible' do
+        before { allow(checker).to receive(:check_url).and_return(200) }
+
+        it 'launches a fresh check and stores the new status' do
+          call
+          expect(checker).to have_received(:check_url).with('https://new.example.com/')
+          expect(link.reload.http_status).to eq(200)
+          expect(link).not_to be_broken
+        end
+
+        it 'includes a success toast in the response' do
+          call
+          expect(response.body).to include('showToast')
+          expect(response.body).to include('success')
+        end
+      end
+
+      context 'when the new link is still broken' do
+        before { allow(checker).to receive(:check_url).and_return(404) }
+
+        it 'stores the new broken status' do
+          call
+          expect(link.reload.http_status).to eq(404)
+          expect(link).to be_broken
+        end
+      end
+
+      context 'when the link is unreachable (host defunct)' do
+        before { allow(checker).to receive(:check_url).and_return(nil) }
+
+        it 'stores nil status but records the check time and flags it broken' do
+          call
+          link.reload
+          expect(link.http_status).to be_nil
+          expect(link.checked_at).to be_present
+          expect(link).to be_broken
+        end
+      end
+    end
+
+    context 'when the URL is not changed' do
+      let(:link_params) { { description: 'Updated description', url: link.url } }
+
+      it 'does not check the link' do
+        allow(Lexicon::CheckExternalLinks).to receive(:new).and_call_original
+        call
+        expect(Lexicon::CheckExternalLinks).not_to have_received(:new)
       end
     end
   end

--- a/spec/requests/lexicon/verification_spec.rb
+++ b/spec/requests/lexicon/verification_spec.rb
@@ -344,10 +344,12 @@ RSpec.describe 'Lexicon::Verification', type: :request do
           entry.update_checklist_item(key, true)
         end
         entry.reload
-        raise 'fixture entry is not verification-complete' unless entry.verification_complete?
       end
 
       it "redirects to the entry's public view with a verified flash" do
+        # Precondition: the fixture must be complete, else mark_verified! raises.
+        expect(entry.verification_complete?).to be(true)
+
         post url
 
         expect(response).to redirect_to(lexicon_entry_path(entry))
@@ -355,6 +357,8 @@ RSpec.describe 'Lexicon::Verification', type: :request do
       end
 
       it 'marks the entry as published' do
+        expect(entry.verification_complete?).to be(true)
+
         post url
 
         expect(entry.reload).to be_status_published

--- a/spec/requests/lexicon/verification_spec.rb
+++ b/spec/requests/lexicon/verification_spec.rb
@@ -326,6 +326,80 @@ RSpec.describe 'Lexicon::Verification', type: :request do
     end
   end
 
+  describe 'POST /lex/verification/:id/mark_verified' do
+    let(:entry) do
+      e = create(:lex_entry, :person, status: :verifying)
+      e.start_verification!('editor@example.com')
+      e
+    end
+    let(:url) { "/lex/verification/#{entry.id}/mark_verified" }
+
+    context 'when verification is complete' do
+      before do
+        # mark_verified! guards on verification_complete?, so check every checklist item.
+        # A bare person entry has no works/citations/links items.
+        entry.verification_progress['checklist'].each_key do |key|
+          next if %w(works citations links).include?(key)
+
+          entry.update_checklist_item(key, true)
+        end
+        entry.reload
+        raise 'fixture entry is not verification-complete' unless entry.verification_complete?
+      end
+
+      it "redirects to the entry's public view with a verified flash" do
+        post url
+
+        expect(response).to redirect_to(lexicon_entry_path(entry))
+        expect(flash[:notice]).to eq(I18n.t('lexicon.verification.messages.entry_verified_public'))
+      end
+
+      it 'marks the entry as published' do
+        post url
+
+        expect(entry.reload).to be_status_published
+      end
+    end
+
+    context 'when verification is not complete' do
+      it 'redirects back to the workbench with the raised error' do
+        post url
+
+        expect(response).to redirect_to(lexicon_verification_path(entry))
+        expect(flash[:alert]).to be_present
+      end
+    end
+  end
+
+  describe 'GET /lex/verification/queue' do
+    it 'auto-refreshes the page periodically' do
+      get '/lex/verification/queue'
+
+      expect(response.body).to include('window.location.reload()')
+    end
+
+    context 'with a re-migrate button' do
+      let!(:verifying_file) { create(:lex_file, :person, entry_status: :verifying) }
+      let!(:escalated_file) { create(:lex_file, :person, entry_status: :escalated) }
+      let!(:draft_file) { create(:lex_file, :person, entry_status: :draft) }
+      let!(:error_file) { create(:lex_file, :person, entry_status: :error) }
+
+      it 'shows the re-migrate button for redo-eligible entries' do
+        get '/lex/verification/queue'
+
+        expect(response.body).to include(redo_migration_lexicon_file_path(verifying_file))
+        expect(response.body).to include(redo_migration_lexicon_file_path(escalated_file))
+        expect(response.body).to include(redo_migration_lexicon_file_path(draft_file))
+      end
+
+      it 'does not show the re-migrate button for entries in error status' do
+        get '/lex/verification/queue'
+
+        expect(response.body).not_to include(redo_migration_lexicon_file_path(error_file))
+      end
+    end
+  end
+
   describe 'POST /lex/verification/:id/escalate' do
     let(:entry) do
       e = create(:lex_entry, :person, status: :verifying)

--- a/spec/system/lexicon/verification_link_check_spec.rb
+++ b/spec/system/lexicon/verification_link_check_spec.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'External link check feedback on verification page', :js, type: :system do
+  before do
+    skip 'WebDriver not available or misconfigured' unless webdriver_available?
+    login_as_lexicon_editor
+    allow(Lexicon::CheckExternalLinks).to receive(:new).and_return(checker)
+  end
+
+  let(:checker) { instance_double(Lexicon::CheckExternalLinks, check_url: check_url_result) }
+  let(:entry) { create(:lex_entry, :person, status: :draft) }
+  let(:person) { entry.lex_item }
+  let!(:link) do
+    create(:lex_link,
+           item: person,
+           url: 'https://broken.example.com/old',
+           http_status: 403,
+           checked_at: Time.current)
+  end
+
+  def visit_verification_page
+    visit lexicon_verification_path(entry)
+  end
+
+  def open_link_edit_modal
+    within('#section-links') do
+      find('button.btn-outline-primary').click
+    end
+    expect(page).to have_css('#generalDlg.show', wait: 5)
+  end
+
+  def submit_link_change(new_url)
+    within('#generalDlg') do
+      fill_in 'lex_link[url]', with: new_url
+      click_button I18n.t(:save)
+    end
+  end
+
+  context 'when the new link is accessible (HTTP 200)' do
+    let(:check_url_result) { 200 }
+
+    it 'reloads the page and shows a green success toast' do
+      visit_verification_page
+      open_link_edit_modal
+      submit_link_change('https://working.example.com/page')
+
+      expected = I18n.t('lexicon.verification.broken_link.now_accessible')
+      expect(page).to have_css('.toast-notification.toast-success', text: expected, wait: 8)
+    end
+
+    it 'removes the broken-link badge after reload' do
+      visit_verification_page
+      within('#section-links') do
+        expect(page).to have_css('.broken-link-badge')
+      end
+
+      open_link_edit_modal
+      submit_link_change('https://working.example.com/page')
+
+      expect(page).not_to have_css('.broken-link-badge', wait: 8)
+    end
+  end
+
+  context 'when the new link is still broken (HTTP 404)' do
+    let(:check_url_result) { 404 }
+
+    it 'reloads the page and shows a red error toast' do
+      visit_verification_page
+      open_link_edit_modal
+      submit_link_change('https://still-broken.example.com/new')
+
+      expected = I18n.t('lexicon.verification.broken_link.still_broken', status: 404)
+      expect(page).to have_css('.toast-notification.toast-error', text: expected, wait: 8)
+    end
+
+    it 'keeps the broken-link badge after reload' do
+      visit_verification_page
+      open_link_edit_modal
+      submit_link_change('https://still-broken.example.com/new')
+
+      expect(page).to have_css('.broken-link-badge', wait: 8)
+    end
+  end
+
+  context 'when the link is not changed' do
+    let(:check_url_result) { nil }
+
+    it 'reloads the page without a toast' do
+      visit_verification_page
+      open_link_edit_modal
+
+      within('#generalDlg') do
+        fill_in 'lex_link[description]', with: 'Updated description'
+        click_button I18n.t(:save)
+      end
+
+      expect(page).not_to have_css('.toast-notification', wait: 5)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Two related improvements to the lexicon migration/verification workflow.

### 1. Queue-driven migration flow
Editors now move naturally from launching a migration → the verification queue → the published public view.

- **Launching a migration redirects to the verification queue.** `migrate` and `redo_migration` (both enqueue `Lexicon::IngestFile`) now send the editor to the verification queue via the JS response, instead of replacing the file row. This only happens when a job is actually enqueued — no-op calls (e.g. an already-migrating entry) still re-render the row as before.
- **The verification queue auto-refreshes every 60s** so async migrations completing elsewhere become visible without a manual reload.
- **Marking an entry verified redirects to its public view** (`/lex/entries/:id`) with a flash. (`mark_verified!` already sets the entry to `published`, so this is genuinely the public view.)
- **Re-migrate button on the verification queue**, mirroring the one in `/lex/files`, backed by a new `LexEntry#redo_migration_eligible?` that centralizes the redo guard previously duplicated in the file row and controller.

### 2. External-link re-checking on edit (parity for standalone links)
Editing a standalone link (`LexLink`) that was previously broken (e.g. HTTP 403) did **not** launch a fresh link check, so its stale `http_status`/`checked_at` persisted and it kept showing as broken. Citation links already re-checked on edit; this brings `LexLink` to parity and de-duplicates the shared logic.

- `LinksController#update` now re-checks the link synchronously when the URL actually changed, storing the fresh status and stashing a toast for the JS response.
- `update.js` → `update.js.erb`: entry-edit view reloads just the `#links` section + shows the toast; verification view reloads the page, carrying the toast via `sessionStorage` (mirrors `citations/update.js.erb`).
- Verification view: the link **edit** button used `onSectionEditSuccess('section-links')` — a no-op for a JS response, so the section never refreshed. Switched it to reload the page (matching the citation edit button), in both person and publication sections.
- **De-duplication:** the synchronous link-check + toast logic, previously duplicated between `LinksController` and `CitationsController`, is extracted into a shared `LinkCheckingConcern`. Callers pass the record, the URL, and the differing status/checked_at column names.

## Implementation notes

- The migration redirect reuses the existing `remote: true` → `window.location.href` pattern already used for lock-redirects; the migrate/redo links are unchanged client-side. `@migration_launched` is set only after `perform_async`, and the `.js.erb` views branch on it.
- New i18n key `lexicon.verification.messages.entry_verified_public` (he + en).
- `LinkCheckingConcern` lives in `app/controllers/concerns/`; it references `Lexicon::CheckExternalLinks` fully-qualified (the concern is top-level, so the `Lexicon::` lexical scope no longer applies).

## Test plan

**Migration flow**
- `spec/models/lex_entry_spec.rb` — `#redo_migration_eligible?` across statuses and missing `lex_file`.
- `spec/requests/lexicon/files_spec.rb` — migrate/redo redirect to the queue when a job launches; no redirect on the no-op path.
- `spec/requests/lexicon/verification_spec.rb` — `mark_verified` redirects to the public view with the verified flash and publishes the entry; queue auto-refresh JS present; re-migrate button shown for redo-eligible entries and hidden for `error` entries.

**Link re-checking**
- `spec/requests/lexicon/links_spec.rb` — re-check on URL change (accessible / still-broken / unreachable), and no check when the URL is unchanged.
- `spec/requests/lexicon/citations_spec.rb` — unchanged, still green through the shared concern.
- `spec/system/lexicon/verification_link_check_spec.rb` — full UI flow: edit a 403 link, page reloads, badge clears/persists, correct success/error toast (mirrors the citation system spec).

All affected request/model specs and the link-check + workbench system specs pass; RuboCop + haml-lint clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
