### PR TITLE
Fix lexicon citation extraction for well-formed bibliography HTML

### DIFF
--- a/app/services/lexicon/extract_citations.rb
+++ b/app/services/lexicon/extract_citations.rb
@@ -17,15 +17,18 @@ module Lexicon
 
       html_nodes = [citations_node]
 
-      # Sometimes we have not a single node with citations, but a node with following li or ul tags (malformed document)
-      # So we check if citations_node does not contains other section header (e.g. Links), and if so
-      # consider following li and ul nodes as part of citations section
-      # Another common issue is when part of following list is wrapped in a font tag with size = 2
+      # Sometimes we have not a single node with citations, but a node with following li or ul tags.
+      # In malformed documents an unclosed <font> wrapper used to nest the whole bibliography, but in
+      # well-formed documents each subject is a separate, properly-closed <font> header (e.g.
+      # <font color="#FF0000">) sitting as a flat sibling alongside its <ul>. So we walk forward
+      # collecting li, ul and any non-header <font> nodes (subject headers, or the legacy size=2
+      # list fragments), stopping at the next real section header (e.g. the Links block), which is a
+      # <font>/<p> carrying an a[name] anchor.
       if citations_node.at_css('a[name]').blank?
         next_elem = next_element_skipping_blank(citations_node)
 
-        while next_elem&.name == 'li' || next_elem&.name == 'ul' ||
-              (next_elem&.name == 'font' && next_elem['size'] == '2')
+        while next_elem && (%w(li ul).include?(next_elem.name) ||
+              (next_elem.name == 'font' && !header?(next_elem)))
           html_nodes << next_elem
           next_elem = next_element_skipping_blank(next_elem)
         end

--- a/spec/fixtures/files/lexicon/00006.php
+++ b/spec/fixtures/files/lexicon/00006.php
@@ -1,0 +1,250 @@
+<html>
+
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<link rel="stylesheet" href="lexicon2.css" type="text/css">
+<!-- #BeginEditable "doctitle" -->
+<title>תלמה אדמון</title>
+<!-- #EndEditable -->
+</head>
+
+<!-- page header --><?php
+			// include page header
+			include "header.php";
+			?><span dir="rtl">
+<body dir="rtl">
+
+<table border="0" width="100%" id="table4">
+	<tr>
+		<td>
+		<p align="center"><font size="5" color="#FF0000">תלמה אדמון</font><font size="4" color="#FF0000"> 
+		(1950–2025)</font></p>
+		</td>
+		<td>
+		<p align="center" dir="ltr"><font size="5" color="#FF0000">Talma Admon</font></p>
+		</td>
+	</tr>
+</table>
+</span>
+<p class="margin" align="justify">
+<img border="0" src="00006-files/image003.jpg" width="180" height="271" align="left" hspace="10">&nbsp;&nbsp;&nbsp; 
+תלמה אדמון (גורלניק), סופרת, עיתונאית ומתרגמת, נולדה בקיבוץ פלמחים בח׳ באדר תש״י, 
+25 בפברואר 1950. בתו הבכירה של ישראל גורלניק, ממייסדי הקיבוץ. בשירותה הצבאי שימשה 
+ככתבת העיתון ״במחנה נח״ל״. בהמשך דרכה פיתחה קריירה ענפה בעיתון ״מעריב״, שכללה כתיבה 
+ועריכה במגזין ״את״. כתבה למוספי העיתון ובעלת הטור הספרותי ״פרולוג״. בשנים 1994–2005 
+ערכה את המוסף לספרות של ״מעריב״. ב־1985 פירסמה את ספרה הראשון ״נועה כבר גרה כאן״ 
+(״מעריב״), קובץ רשימות של אם צעירה על חוויית האימהות, שחלקן התפרסמו קודם לכן בגיליונות 
+כתב־העת ״את״. ספר הילדים הראשון שלה, ״צריף עף ברוח״, יצא לאור ב־1989, ולאחריו ראו 
+אור ספרי ילדים נוספים. ספרה לנוער, ״מכתבים לעמוס: רומן מכתבים לנוער״, זיכה אותה 
+בפרס זאב ל״ספרות ילדים ונוער״ ב־2007. בדברי ועדת הפרס נכתב: ״מכתבים לעמוס הוא ספר 
+מרתק, אמין ומשכנע כאחד, כתוב בשפה פשוטה ובהירה, ספר מעודן המצליח לגעת בנימי נפשם 
+של צעירים ומבוגרים כאחד״. תירגמה כמה ספרים מאנגלית, בהם: ״יהודים אחרונים בקראלה״ מאת עדנה פרננדס 
+(2011); ״מחאה משלי״ מאת אלינור ליפמן (2009). ערכה את הספר ״מסעות 
+בלי קנה מידה״ מאת משה גלעד (2010). ב־2005 יצא ספרה ״אגמים״. הספר מקבץ שבעה־עשר סיפורים 
+קצרים המשלחים את גיבורותיהם למסעות במקומות שונים בארץ ובעולם, ומציגים אותן במצבי 
+משבר. אריאלה אופיר (2005) מציעה לקרוא את הספר לפי מונחיה של חנה נוה (בספר ״נוסעים 
+ונוסעות, סיפור מסע בספרות העברית החדשה״, 2002), ולראות במסעות אלו ״קליפה נרטיבית״, הצופנת בחובה מסע אחר: טעון, אמביוולנטי ובעל אופי מגדרי. הספר נחתם בחלק ייחודי: 
+״חלון 
+פנורמי – שתי קריאות בשיר: במקום אחרית דבר״, שמציע שתי קריאות בשיר ״החלון״ מאת דליה 
+רביקוביץ. קריאות אלה מאירות באור נוסף את עמדתה של המספרת ב״אגמים״, ואת גישתה למחוזות 
+שמחוץ לארצה. פירסמה גם רשימות וסיפורים באנתולוגיות שונות ובכתבי עת לספרות. כמו כן, 
+יזמה וערכה את הספר ״העיתונאי שחצה את הקווים״ (2007), קובץ סיפורים קצרים שנכתבו על 
+ידי בעלי מקצוע מתחום העיתונאות הישראלית. ב־2002 זכתה אדמון בפרס ראש הממשלה ליצירה 
+על שם לוי אשכול.<br>
+&nbsp;&nbsp;&nbsp; תלמה אדמון נפטרה בא׳ באלול תשפ״ה, 25 באוגוסט 2025.&nbsp; </p>
+<table border="0" width="50%" align="left" id="table6">
+	<tr>
+		<td>
+		&nbsp;</td>
+		<td>
+		&nbsp;</td>
+		<td>&nbsp;</td>
+		<td>
+		&nbsp;</td>
+	</tr>
+</table>
+<p class="margin" align="justify">נכתב על־ידי <b>רון לסרי</b> עבור <i>
+<a target="_blank" href="https://heksherimlexicon.bgu.ac.il/lexicon-entry/%D7%90%D7%93%D7%9E%D7%95%D7%9F-%D7%AA%D7%9C%D7%9E%D7%94/">לקסיקון הקשרים לספרות ישראלית&nbsp;
+<img border="0" src="00000_files/heksherim-mainlogo-300x139.jpg" width="64" height="30"></a></i><br>
+<font size="2">[מקורות נוספים: 
+<a target="_blank" href="https://he.wikipedia.org/wiki/תלמה_אדמון">ויקיפדיה</a>]<br>
+[צילום: ׳הארץ׳]</font></p>
+<font size="4" color="#0000FF"><a name="Books">ספריה:</a></font><p></p>
+<ul style="MARGIN-TOP: 0in" type="circle">
+	<li>רשימות שלי (ישראל : הוצאה עצמית, 1969)</li>
+	<li>נועה כבר גרה כאן / עיצוב ואיור, יעל ליאור (תל־אביב :ספרית מעריב, 1985)
+	<font size="2">&lt;רשימות על אמהות שהתפרסמו בירחון ׳את׳&gt;</font></li>
+	<li>צריף עף ברוח / ציורים, <a href="00007.php">הנה אדלן</a> (ירושלים : כתר, 
+	1989) <font size="2">(ראשית קריאה) &lt;לילדים&gt;</font></li>
+	<li>אגמים (אור־יהודה : זמורה־ביתן, תשס״ה 2005)<font size="2"> &lt;עריכה, תרצה פלור&gt; 
+	&lt;סיפורים&gt;</font></li>
+	<li>מכתבים לעמוס : רומן מכתבים לנוער (אור־יהודה : זמורה־ביתן, 2006&gt;
+	<font size="2">&lt;עריכה, תרצה פלור; איורים – הלה חבקין&gt;</font></li>
+	<li>שלי בוחרת מתנה (אור־יהודה : זמורה־ביתן, 2008) <font size="2">&lt;איורים 
+	– דורון 
+	מאיר&gt; &lt;עריכה – מיכל פז־קלפ&gt;</font></li>
+	<li>אלה של החתולים (אור־יהודה : זמורה־ביתן, תשע״ב 2011) <font size="2">&lt;איורים 
+	– הלה חבקין&gt;</font></li>
+	<li>בוקר ראשון באירופה : הערה על מקום אחר (אור־יהודה : כנרת, זמורה־ביתן, דביר 
+	– מוציאים לאור, 2014) <font size="2">&lt;עריכה – תרצה פלור&gt;</font></li>
+	<li>המון דודות (רעננה : הוצאת אבן־חושן, תשע״ו 2015) <font size="2">&lt;איורים – 
+	הלה חבקין&gt;</font></li>
+	<li>בלגור : החמור שבא לגור (רמת־השרון : אסיה הוצאה לאור, תשפ״ד 2024)
+	<font size="2">&lt;איורים – הלה חבקין&gt;</font></li>
+</ul>
+<font size="4" color="#0000FF">עריכה:</font>
+<ul style="MARGIN-TOP: 0in" type="circle">
+	<li>העיתונאי שחצה את הקווים (מושב בן שמן : מודן, 2007) <font size="2">&lt;סיפורים 
+	של עיתונאים ישראליים&gt;</font></li>
+	<li>מסעות בלי קנה מידה / משה גלעד (תל־אביב : עם עובד, תש״ע)</li>
+</ul>
+<font size="4" color="#0000FF">תרגום:</font>
+<ul style="MARGIN-TOP: 0in" type="circle">
+	<li>לב החורף / מאריה הורנבאכר (אור־יהודה : כנרת, 2007) <font size="2">&lt;רומן&gt;</font></li>
+	<li>המלחמה הסודית של אבא : זכרונות / לוסינדה פראנקס (תל־אביב : ספרית מעריב, 
+	תשס״ח 2008)</li>
+	<li>ציפורים באור אחרון / בראד קסלר (תל־אביב : מטר, תשס״ט 2009)</li>
+	<li>בית בחצי הדרך / קתרין נואל (תל־אביב : ספרית מעריב, תשס״ט 2009)</li>
+	<li>מחאה משלי / אלינור ליפמן (תל אביב : ספרית מעריב, 2009)</li>
+	<li>בקתה קטנה, דגים מנתרים / צ׳יו־סיה טיי (תל־אביב : ספרית מעריב, תשע״א 2010)</li>
+	<li>בית חמשת החושים / נאדים אסלאם (תל אביב : מטר, תשע״א 2011)</li>
+	<li>יהודים אחרונים בקראלה / עדנה פרננדס (תל אביב : עם עובד, תשע״ב 2011)</li>
+	<li>מסביב לעולם ב־80 ספורים / סויור פירוטה (חבל מודיעין : כנרת בית הוצאה 
+	לאור, תשע״ו 2016)</li>
+</ul>
+<font size="4" color="#0000FF"><a name="Bib.">על המחברת ויצירתה:</a></font><p>
+</p>
+<font color="#FF0000">על ״צריף עף ברוח״</font>
+<ul style="MARGIN-TOP: 0in" type="circle">
+	<li><b>צור, יגאל.</b> [ביקורת]. <u>הד החינוך</u>, ספטמבר 1989, עמ׳ 30.</li>
+</ul>
+<font color="#FF0000">על ״אגמים״</font>
+<ul style="MARGIN-TOP: 0in" type="circle">
+	<li><b>אופיר, אריאלה.</b> גם עורכת זקוקה לעורך. <u>הארץ, מוסף ספרים</u>, גל׳ 
+	640 (כ״ג באייר תשס״ה, 1 ביוני 2005), עמ׳ 6.</li>
+	<li><b>הופמן, חיה.</b> שלווה מדומה. <u>ידיעות אחרונות</u>, המוסף לשבת – ספרות, 
+	כ״ג באדר א תשס״ה, 4 במארס 2005, עמ׳ 28–29.</li>
+	<li><b>פרידמן, פאר.</b> נשים ללא מוצא. <u>מעריב</u>, מוסף שבת – ספרות וספרים, 
+	ז׳ באדר ב תשס״ה, 18 במארס 2005, עמ׳ 29 &lt;גרסה שונה פורסמה ב<a target="_blank" href="https://web.archive.org/web/20110310233207/https://makropulos.net/reviews/?p=817">אתרו 
+	של פאר פרידמן</a>&gt;</li>
+</ul>
+<font color="#FF0000">על ״מכתבים לעמוס״</font>
+<ul style="MARGIN-TOP: 0in" type="circle">
+	<li><b>אדמון, תלמה.</b>&nbsp; <a target="_blank" href="https://www.haaretz.co.il/literature/2006-10-02/ty-article/0000017f-e868-dea7-adff-f9fb689b0000">השאלון: מחפשת כל חיי שקט מלא קולות.</a>&nbsp; <u>הארץ, מוסף ספרים</u>, גל׳ 710 (י״ב בתשרי תשס״ז, 4 באוקטובר 2006), עמ׳ 3.</li>
+	<li><b>פרס זאב.</b>&nbsp; נימוקי ועדת השופטים לפרס זאב תשס״ז לתלמה אדמון על 
+	ספרה ״מכתבים לעמוס״.&nbsp; <u>ספרות ילדים ונוער</u>, שנה 33, חוב׳ 2 (126) 
+	(תמוז תשס״ז, יולי 2007), עמ׳&nbsp; 7.</li>
+</ul>
+<font color="#FF0000">על ״אלה של החתולים״</font>
+<ul style="MARGIN-TOP: 0in" type="circle">
+	<li><b>קופפר, רותה.</b>&nbsp;
+	<a target="_blank" href="http://www.haaretz.co.il/literature/youngsters/1.1658195">
+	המדונה של הילדים.</a>&nbsp; <u>הארץ, מוסף ספרים</u>, גל׳&nbsp; 993 (י״ג באדר 
+	תשע״ב, 7 במארס 2012), עמ׳ 12.</li>
+</ul>
+<font color="#FF0000"></font>
+<ul style="MARGIN-TOP: 0in" type="circle">
+</ul>
+<font color="#FF0000"></font>
+<ul style="MARGIN-TOP: 0in" type="circle">
+</ul>
+<font color="#FF0000"></font>
+<ul style="MARGIN-TOP: 0in" type="circle">
+</ul>
+<font color="#FF0000"></font>
+<ul style="MARGIN-TOP: 0in" type="circle">
+</ul>
+<hr><font color="#FF0000">על ״העיתונאי שחצה את הקווים״</font>
+<ul style="MARGIN-TOP: 0in" type="circle">
+	<li><b><a href="00564.php">אביטוב, ירון.</a></b>&nbsp; סיפורים ושאר ירקות.&nbsp; <u>ידיעות אחרונות</u>, המוסף לשבת – ספרות, א׳ בסיון תשס״ז, 18 במאי 2007, עמ׳ 29.</li>
+	<li><b>גרפינקל, אבי.</b>&nbsp;
+	<a target="_blank" href="https://www.haaretz.co.il/literature/prose/2007-03-29/ty-article/0000017f-efdc-da6f-a77f-ffded2bd0000">23 עיתונאים, אבל מי סופר.</a>&nbsp; <u>הארץ, מוסף ספרים</u>, גל׳ 736 (י״ד בניסן תשס״ז, 2 באפריל 2007), עמ׳ 52.</li>
+	<li><b>דואניס, סמי.</b> דבר העורך. <u>Time Out תל אביב</u>, גל׳ 229 (22 עד 29 במארס 2007), עמ׳ 54 &lt;על הקובץ ״העיתונאי שחצה את הקווים״, אנתולוגיה בעריכת תלמה אדמון וראיון עם <a href="00318.php">בני ציפר</a> ורענן שקד&gt;</li>
+	<li><b>לב־ארי, שירי.</b>&nbsp; <a target="_blank" href="https://www.haaretz.co.il/gallery/2007-03-18/ty-article/0000017f-e28d-d804-ad7f-f3ff2a130000">כולנו סובלים.</a>&nbsp; <u>הארץ</u>, גלריה, א׳ בניסן תשס״ז, 20 במארס 2007, עמ׳ 7. &lt;שיחה עם תלמה אדמון עם הופעת הקובץ&gt;</li>
+	<li><b>פז, מירי.</b>&nbsp; שאלה של זהות.&nbsp; <u>מקור ראשון</u>, דיוקן, כ״ג באייר תשס״ז, 11 במאי 2007, עמ׳ 38.</li>
+</ul>
+<font color="#FF0000"></font>
+<ul style="MARGIN-TOP: 0in" type="circle">
+</ul>
+<font color="#FF0000"></font>
+<ul style="MARGIN-TOP: 0in" type="circle">
+</ul>
+<font color="#FF0000"></font>
+<ul style="MARGIN-TOP: 0in" type="circle">
+</ul>
+<font color="#FF0000">על ״ציפורים באור אחרון״ לבראד קסלר</font>
+<ul style="MARGIN-TOP: 0in" type="circle">
+	<li><b>לי, ורד.</b>&nbsp;
+	נוגע לא נוגע.&nbsp;&nbsp; <u>הארץ, מוסף ספרים</u>, גל׳ 858 (ט״ו באב תשס״ט, 
+	5 באוגוסט 2009), עמ׳ 7.</li>
+</ul>
+<font color="#FF0000"></font>
+<ul style="MARGIN-TOP: 0in" type="circle">
+</ul>
+<font color="#FF0000">על ״בקתה קטנה, דגים מנתרים״ מאת ציו־סיה טיי</font><ul style="MARGIN-TOP: 0in" type="circle">
+	<li><b>קרפ, עלית. </b>
+	<a target="_blank" href="https://www.haaretz.co.il/literature/2011-02-16/ty-article/0000017f-e268-df7c-a5ff-e27a27f90000">בקצרה: 
+	״בקתה קטנה, דגים מנתרים״.</a> <u>הארץ, מוסף ספרים</u>, גל׳ 938 (י״ב באדר א׳ תשע״א, 16 בפברואר 2011), עמ׳ 30.</li>
+</ul>
+<font color="#FF0000"></font>
+<ul style="MARGIN-TOP: 0in" type="circle">
+</ul>
+<font color="#FF0000">על ״בית חמשת החושים״ לנאדים אסלאם</font>
+<ul style="MARGIN-TOP: 0in" type="circle">
+	<li><b>קרפ, עלית.</b>
+	<a target="_blank" href="https://www.haaretz.co.il/literature/2011-03-16/ty-article/0000017f-f687-d318-afff-f7e7d5500000">
+	בקצרה: בית חמשת החושים.</a> <u>הארץ, מוסף ספרים</u>, גל׳ 942 (י׳ באדר תשע״א, 
+	16 במארס 2011), עמ׳ 14.</li>
+	<li><b><a href="02293.php">רונן, יהודית</a>.</b>
+	<a target="_blank" href="99995-files/99995019/99995019-2011/99995019-354-19.pdf">שגרת האימים</a>. <a href="99995019-2011.php#no354"><u>עתון 77</u></a></span>, גל׳ 354 (אייר–סיון תשע״א, מאי–יוני 2011), עמ׳ 19.</li>
+</ul>
+<font color="#FF0000"></font>
+<ul style="MARGIN-TOP: 0in" type="circle">
+</ul>
+<font color="#FF0000"></font>
+<ul style="MARGIN-TOP: 0in" type="circle">
+</ul>
+<font color="#FF0000"></font>
+<ul style="MARGIN-TOP: 0in" type="circle">
+</ul>
+<font color="#FF0000"></font>
+<ul style="MARGIN-TOP: 0in" type="circle">
+</ul>
+<font color="#FF0000"></font>
+<ul style="MARGIN-TOP: 0in" type="circle">
+</ul>
+<font size="4" color="#0000FF"><a name="links">קישורים:</a></font><p></p>
+<font color="#FF0000"></font>
+<ul style="MARGIN-TOP: 0in" type="circle">
+	<li><i>
+	<a target="_blank" href="http://www.text.org.il/index.php?book=0701038">העיתונאי 
+	שחצה את הקווים</a></i> באתר
+	<img border="0" src="00000_files/text.gif" width="50" height="28" alt="טקסט"></li>
+	<li><i>
+	<a target="_blank" href="http://www.text.org.il/index.php?book=0501064">אגמים</a></i> 
+	באתר <img border="0" src="00000_files/text.gif" width="50" height="28"></li>
+</ul>
+<div style="border-top-style: solid; border-top-width: 1px; padding-top: 1px">
+	<table align="left" border="0" width="85%">
+		<tr>
+			<td dir="ltr"><font size="2">OpenLibrary –
+			<a target="_blank" href="https://openlibrary.org/authors/OL4980811A">OL4980811A</font></a></td>
+			<td dir="ltr"><font size="2">Wikidata –
+			<a target="_blank" href="https://www.wikidata.org/entity/Q110567662">Q110567662</font></a></td>
+			<td dir="ltr"><font size="2">NLI –
+			<a target="_blank" href="https://www.nli.org.il/he/authorities/987007306908005171">
+			987007306908005171</font></a></td>
+			<!--	<td dir="ltr"><font size="2">NLI – <a target="_blank" href="http://olduli.nli.org.il/F/?func=direct&local_base=nlx10&doc_number=000228163">000228163</font></td> -->
+			<td dir="ltr"><font size="2">LC –
+			<a target="_blank" href="https://id.loc.gov/authorities/nr90015791/">nr90015791</font></a></td>
+			<td dir="ltr"><font size="2">VIAF –
+			<a target="_blank" href="https://viaf.org/viaf/47049631/">47049631</font></a></td>
+		</tr>					
+	</table>
+	<font size="2">עודכן לאחרונה: 27 באפריל 2026</font> </div>
+<!-- page footer --><?php
+			// include page footer
+			include "footerf.php";
+			?>
+</body>
+</html>

--- a/spec/services/lexicon/extract_citations_spec.rb
+++ b/spec/services/lexicon/extract_citations_spec.rb
@@ -23,6 +23,32 @@ describe Lexicon::ExtractCitations do
     end
   end
 
+  context 'when the document is well-formed and each subject is a separate closed <font> header' do
+    # Regression test for 00006.php: the updated (well-formed) export no longer relies on an
+    # unclosed <font> wrapper to nest the whole bibliography. Instead each subject is its own
+    # properly-closed <font color="#FF0000"> header sitting as a flat sibling beside its <ul>.
+    # The old sibling-walk only continued across font[size=2], so it stopped at the second subject
+    # header and only the first citation group was migrated.
+    let(:filename) { Rails.root.join('spec/fixtures/files/lexicon/00006.php') }
+
+    it 'collects every citation group, not just the first one' do
+      captured_html = nil
+      allow(Lexicon::ParseCitations).to receive(:call) do |html|
+        captured_html = html
+        []
+      end
+
+      result
+
+      expect(captured_html).not_to be_nil
+      # All 16 citations across the subject groups must reach ParseCitations.
+      expect(Nokogiri::HTML(captured_html).css('li').size).to eq(16)
+      # Content from a late subject group (the last one) must be present, proving the walk did not
+      # stop at the first subject header.
+      expect(captured_html).to include('בית חמשת החושים')
+    end
+  end
+
   context 'when a stray </span> inside a <li> prematurely closes the parent span' do
     # Regression test for 00034.php: a stray </span> after </b> inside a citation <li>
     # caused Nokogiri to prematurely close the <span dir="rtl"> wrapping the citations section.


### PR DESCRIPTION
## Problem

In lexicon migration, the legacy `00006.php` (16 citations) migrates fine, but an updated, well-formed export of the same file migrates only the **first** citation.

## Root cause

`Lexicon::ExtractCitations` walks forward from the `Bib.` header collecting sibling nodes, but its continuation condition only accepted `<li>`, `<ul>`, and `<font size="2">`:

```ruby
while next_elem&.name == 'li' || next_elem&.name == 'ul' ||
      (next_elem&.name == 'font' && next_elem['size'] == '2')
```

Legacy PHP exports happen to nest the **entire** bibliography inside a single *unclosed* `<font>` wrapper, so the walk never needed to traverse subject headers — everything was already nested in `citations_node`. The extraction was relying on malformed HTML by accident.

Well-formed exports close each subject's `<font color="#FF0000">` header properly, so the subject headers and their `<ul>` lists become **flat siblings**. The walk then hit the second subject header (`<font color="#FF0000">` with no `size`), the condition was false, and the walk stopped — capturing only the first group.

## Fix

Continue the walk across any **non-header** `<font>` node (subject headers, plus the legacy `size=2` list fragments), stopping at the next real section header — a `<font>`/`<p>` carrying an `a[name]` anchor (e.g. the Links block):

```ruby
while next_elem && (%w(li ul).include?(next_elem.name) ||
      (next_elem.name == 'font' && !header?(next_elem)))
```

## Verification

- Byte-for-byte comparison of the captured HTML before/after across the legacy malformed fixtures (`00002`, `00020`, `00024`) — **unchanged**, so the existing VCR cassettes still match (no LLM re-recording needed).
- The well-formed `00006.php` now yields **16** `<li>` citations instead of **1**.

## Tests

- New regression spec in `extract_citations_spec.rb` using `spec/fixtures/files/lexicon/00006.php` (the well-formed export). It stubs `ParseCitations` to capture the extracted HTML and asserts all 16 `<li>` are present and that late-group content (`בית חמשת החושים`) is included — no cassette/LLM call required.
- Existing VCR-backed cases (`00002` → 53, `00024` → 4) still pass.
- Full suite: **2914 examples, 0 failures, 17 pending**.

Fixes beads_by-0jh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)