### PR TITLE
Keep auto-match works modal open after confirming a match

### DIFF
--- a/app/assets/javascripts/verification.js
+++ b/app/assets/javascripts/verification.js
@@ -530,8 +530,21 @@ function confirmWorkMatch(button) {
             collection_id: collectionId || ''
         },
         success: function(data) {
-            $('#generalDlg').modal('hide');
-            reloadScrollingToSection('section-works');
+            // Keep the modal open so the reviewer can approve (or skip) the
+            // remaining proposals. Mark just this row as confirmed.
+            var $row = $('#match-row-' + workId);
+            $row.addClass('text-muted');
+            $row.find('.match-actions').html(
+                $('<span>', { 'class': 'text-success fw-bold', text: '✓ ' + (data.message || '') })
+            );
+            showToast(data.message);
+            // Refresh the works section once, when the reviewer closes the modal,
+            // so the underlying page reflects the confirmed matches.
+            $('#generalDlg')
+                .off('hidden.bs.modal.workmatch')
+                .one('hidden.bs.modal.workmatch', function() {
+                    reloadScrollingToSection('section-works');
+                });
         },
         error: function(xhr) {
             $btn.prop('disabled', false);

--- a/app/assets/javascripts/verification.js
+++ b/app/assets/javascripts/verification.js
@@ -535,7 +535,7 @@ function confirmWorkMatch(button) {
             var $row = $('#match-row-' + workId);
             $row.addClass('text-muted');
             $row.find('.match-actions').html(
-                $('<span>', { 'class': 'text-success fw-bold', text: '✓ ' + (data.message || '') })
+                $('<span>', { 'class': 'text-success font-weight-bold', text: '✓ ' + (data.message || '') })
             );
             showToast(data.message);
             // Refresh the works section once, when the reviewer closes the modal,

--- a/spec/system/lexicon/verification_auto_matching_spec.rb
+++ b/spec/system/lexicon/verification_auto_matching_spec.rb
@@ -160,7 +160,7 @@ describe 'Lexicon Verification Auto-Matching', :js do
     end
     # rubocop:enable RSpec/ExampleLength
 
-    it 'confirms match when user clicks confirm button' do
+    it 'confirms match when user clicks confirm button and keeps the modal open' do
       visit "/lex/verification/#{entry.id}"
       open_auto_match_modal
 
@@ -169,19 +169,46 @@ describe 'Lexicon Verification Auto-Matching', :js do
         find('button', text: I18n.t('lexicon.verification.edit.confirm_match')).click
       end
 
-      # After confirmation the modal closes and the page reloads
-      expect(page).to have_css('#section-works', wait: 10)
+      # The modal stays open and the confirmed row shows a success indicator
+      expect(page).to have_css('#generalDlg.show')
+      within "#match-row-#{work1.id}" do
+        expect(page).to have_content(I18n.t('lexicon.verification.messages.work_match_confirmed'))
+        expect(page).not_to have_button(I18n.t('lexicon.verification.edit.confirm_match'))
+      end
 
-      # After reload, work1's card should display the linked publication and collection
+      # The match was persisted via the AJAX call without a page reload
+      expect(work1.reload.publication_id).to eq(pub1.id)
+      expect(work1.collection_id).to eq(collection1.id)
+
+      # Closing the modal refreshes the works section to reflect the change
+      find('button', text: I18n.t('lexicon.verification.sections.close')).click
+      expect(page).not_to have_css('#generalDlg.show', wait: 5)
       within "#work-#{work1.id}" do
         expect(page).to have_link('Tmol Shilshom')
         expect(page).to have_link('Tmol Shilshom Collection')
       end
+    end
 
-      # Verify the database was updated
-      work1.reload
-      expect(work1.publication_id).to eq(pub1.id)
-      expect(work1.collection_id).to eq(collection1.id)
+    it 'allows confirming multiple matches in a single modal session' do
+      visit "/lex/verification/#{entry.id}"
+      open_auto_match_modal
+
+      # Confirm work1
+      within "#match-row-#{work1.id}" do
+        find('button', text: I18n.t('lexicon.verification.edit.confirm_match')).click
+        expect(page).to have_content(I18n.t('lexicon.verification.messages.work_match_confirmed'))
+      end
+
+      # The modal is still open, so work2 can be confirmed in the same session
+      expect(page).to have_css('#generalDlg.show')
+      within "#match-row-#{work2.id}" do
+        find('button', text: I18n.t('lexicon.verification.edit.confirm_match')).click
+        expect(page).to have_content(I18n.t('lexicon.verification.messages.work_match_confirmed'))
+      end
+
+      # Both matches were persisted
+      expect(work1.reload.publication_id).to eq(pub1.id)
+      expect(work2.reload.publication_id).to eq(pub2.id)
     end
 
     it 'does not propose matches for existing publication assignments' do


### PR DESCRIPTION
## Problem

In the lexicon migration verification view, the auto-match works modal (matching `LexPersonWork`s to publications) closed and reloaded the entire page on **every** successful "Confirm match" click. This meant a reviewer could only approve a single work-to-publication match per modal opening — they had to reopen the modal for each proposed row.

## Fix

`confirmWorkMatch()` (`app/assets/javascripts/verification.js`) now:
- Makes only the AJAX call to record the match (as before).
- Marks the just-confirmed row as done (dimmed + ✓ success message) and removes its confirm button.
- **Keeps the modal open**, so multiple rows can be reviewed and approved (or skipped) in one session.
- Refreshes the `section-works` part of the page **once**, when the reviewer finally closes the modal, so the underlying view reflects the confirmed matches. The refresh handler is namespaced and re-registered idempotently, so confirming N rows still triggers exactly one reload on close.

## Tests

`spec/system/lexicon/verification_auto_matching_spec.rb`:
- Updated the existing single-confirm test to assert the modal stays open, the row shows a success indicator, the DB is updated via AJAX, and closing the modal refreshes the works section.
- Added a regression test confirming **two** matches in a single modal session.

All 7 examples in the spec pass. RuboCop clean on the changed spec.

Closes beads_by-z2x.

🤖 Generated with [Claude Code](https://claude.com/claude-code)