### PR TITLE
Make checklist modal draggable in lexicon verification view

### DIFF
--- a/app/assets/javascripts/lexicon_backend.js
+++ b/app/assets/javascripts/lexicon_backend.js
@@ -120,31 +120,41 @@ function closeModal() {
     $('#generalDlg').data('onSuccess', null);
 };
 
-function initModalManipulation() {
-    var $modal = $('#generalDlg');
+// Make a Bootstrap modal draggable (by its header) and resizable (via edge handles).
+// Defaults to '#generalDlg' to preserve existing behavior; pass another selector to
+// apply the same manipulation to a different modal (e.g. '#checklistModal').
+function initModalManipulation(modalSelector) {
+    modalSelector = modalSelector || '#generalDlg';
+    var $modal = $(modalSelector);
     if (!$modal.length) return;
 
     var $dialog = $modal.find('.modal-dialog');
     var $content = $modal.find('.modal-content');
 
-    // Inject resize handle CSS once
-    $('head').append(
-        '<style id="generalDlg-manip-style">' +
-        '#generalDlg .modal-resize-handle{position:absolute;z-index:10;}' +
-        '#generalDlg .modal-resize-handle.dlg-n {top:-3px;left:12px;right:12px;height:6px;cursor:n-resize;}' +
-        '#generalDlg .modal-resize-handle.dlg-s {bottom:-3px;left:12px;right:12px;height:6px;cursor:s-resize;}' +
-        '#generalDlg .modal-resize-handle.dlg-e {right:-3px;top:12px;bottom:12px;width:6px;cursor:e-resize;}' +
-        '#generalDlg .modal-resize-handle.dlg-w {left:-3px;top:12px;bottom:12px;width:6px;cursor:w-resize;}' +
-        '#generalDlg .modal-resize-handle.dlg-ne{top:-3px;right:-3px;width:14px;height:14px;cursor:ne-resize;}' +
-        '#generalDlg .modal-resize-handle.dlg-se{bottom:-3px;right:-3px;width:14px;height:14px;cursor:se-resize;}' +
-        '#generalDlg .modal-resize-handle.dlg-sw{bottom:-3px;left:-3px;width:14px;height:14px;cursor:sw-resize;}' +
-        '#generalDlg .modal-resize-handle.dlg-nw{top:-3px;left:-3px;width:14px;height:14px;cursor:nw-resize;}' +
-        '</style>'
-    );
+    // Inject resize handle + draggable-header CSS once per modal
+    var styleId = ($modal.attr('id') || 'modal') + '-manip-style';
+    if (!document.getElementById(styleId)) {
+        $('head').append(
+            '<style id="' + styleId + '">' +
+            modalSelector + ' .modal-header{cursor:move;user-select:none;}' +
+            modalSelector + ' .modal-resize-handle{position:absolute;z-index:10;}' +
+            modalSelector + ' .modal-resize-handle.dlg-n {top:-3px;left:12px;right:12px;height:6px;cursor:n-resize;}' +
+            modalSelector + ' .modal-resize-handle.dlg-s {bottom:-3px;left:12px;right:12px;height:6px;cursor:s-resize;}' +
+            modalSelector + ' .modal-resize-handle.dlg-e {right:-3px;top:12px;bottom:12px;width:6px;cursor:e-resize;}' +
+            modalSelector + ' .modal-resize-handle.dlg-w {left:-3px;top:12px;bottom:12px;width:6px;cursor:w-resize;}' +
+            modalSelector + ' .modal-resize-handle.dlg-ne{top:-3px;right:-3px;width:14px;height:14px;cursor:ne-resize;}' +
+            modalSelector + ' .modal-resize-handle.dlg-se{bottom:-3px;right:-3px;width:14px;height:14px;cursor:se-resize;}' +
+            modalSelector + ' .modal-resize-handle.dlg-sw{bottom:-3px;left:-3px;width:14px;height:14px;cursor:sw-resize;}' +
+            modalSelector + ' .modal-resize-handle.dlg-nw{top:-3px;left:-3px;width:14px;height:14px;cursor:nw-resize;}' +
+            '</style>'
+        );
+    }
 
-    $.each(['n','ne','e','se','s','sw','w','nw'], function(_, dir) {
-        $content.append('<div class="modal-resize-handle dlg-' + dir + '"></div>');
-    });
+    if ($content.find('.modal-resize-handle').length === 0) {
+        $.each(['n','ne','e','se','s','sw','w','nw'], function(_, dir) {
+            $content.append('<div class="modal-resize-handle dlg-' + dir + '"></div>');
+        });
+    }
 
     var MIN_W = 300, MIN_H = 100;
 

--- a/app/assets/javascripts/verification.js
+++ b/app/assets/javascripts/verification.js
@@ -9,6 +9,12 @@ $(function() {
 
 function initVerification() {
     const container = $('.verification-container');
+
+    // Make the checklist modal draggable/resizable, matching the #generalDlg modals.
+    if (typeof initModalManipulation === 'function') {
+        initModalManipulation('#checklistModal');
+    }
+
     const entryId = container.data('verification-entry-id');
     const updateUrl = container.data('verification-update-url');
     const saveProgressUrl = container.data('verification-save-progress-url');

--- a/spec/system/lexicon/verification_checklist_modal_draggable_spec.rb
+++ b/spec/system/lexicon/verification_checklist_modal_draggable_spec.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe 'Verification Checklist Modal draggability', :js do
+  let!(:person) do
+    create(:lex_person, birthdate: '1900', deathdate: '1980', gender: :male)
+  end
+
+  let!(:entry) do
+    create(:lex_entry, title: 'Test Author', lex_item: person, status: :draft)
+  end
+
+  let!(:lex_file) do
+    file_path = Rails.root.join('tmp/test_author_checklist.php')
+    File.write(file_path, '<html><body><h1>Test Author</h1></body></html>')
+    create(:lex_file,
+           lex_entry: entry,
+           fname: 'test_author_checklist.php',
+           full_path: file_path.to_s,
+           status: :ingested,
+           entrytype: :person)
+  end
+
+  before do
+    skip 'WebDriver not available or misconfigured' unless webdriver_available?
+    login_as_lexicon_editor
+    visit "/lex/verification/#{entry.id}"
+    click_button I18n.t('lexicon.verification.checklist.title')
+    # rubocop:disable RSpec/ExpectInHook
+    expect(page).to have_css('#checklistModal.show', wait: 5)
+    # rubocop:enable RSpec/ExpectInHook
+  end
+
+  after { FileUtils.rm_f(lex_file.full_path) }
+
+  it 'modal header shows move cursor indicating draggability' do
+    cursor = page.evaluate_script(
+      "window.getComputedStyle(document.querySelector('#checklistModal .modal-header')).cursor"
+    )
+    expect(cursor).to eq('move')
+  end
+
+  it 'resize handles are present on all 8 directions' do
+    handle_classes = page.evaluate_script(
+      "Array.from(document.querySelectorAll('#checklistModal .modal-resize-handle')).map(h => h.className)"
+    )
+    %w(dlg-n dlg-ne dlg-e dlg-se dlg-s dlg-sw dlg-w dlg-nw).each do |dir|
+      expect(handle_classes.any? { |c| c.include?(dir) }).to be true
+    end
+  end
+
+  it 'dragging the modal header repositions the dialog' do
+    initial_top = page.evaluate_script(
+      "document.querySelector('#checklistModal .modal-dialog').getBoundingClientRect().top"
+    )
+
+    # Simulate drag: mousedown on header, mousemove 100px down, mouseup
+    page.evaluate_script(<<~JS)
+      (function() {
+        var header = document.querySelector('#checklistModal .modal-header');
+        var rect = header.getBoundingClientRect();
+        var cx = rect.left + rect.width / 2;
+        var cy = rect.top + rect.height / 2;
+        header.dispatchEvent(new MouseEvent('mousedown', {bubbles: true, cancelable: true, clientX: cx, clientY: cy}));
+        document.dispatchEvent(new MouseEvent('mousemove', {bubbles: true, cancelable: true, clientX: cx, clientY: cy + 100}));
+        document.dispatchEvent(new MouseEvent('mouseup',   {bubbles: true, cancelable: true}));
+      })();
+    JS
+
+    new_top = page.evaluate_script(
+      "document.querySelector('#checklistModal .modal-dialog').getBoundingClientRect().top"
+    )
+    expect(new_top).to be > initial_top
+  end
+end


### PR DESCRIPTION
## Summary

All modals opening from the lexicon migration verification view are now movable (draggable).

The `#generalDlg`-based modals (edit-section, per-work edit, works auto-match, bio comparison, escalate form, etc.) were **already** draggable and resizable via `initModalManipulation()`. The only verification modal left unmovable was the static **checklist modal** (`#checklistModal`).

## Changes

- **`app/assets/javascripts/lexicon_backend.js`**: Generalized `initModalManipulation()` to take a modal selector argument, defaulting to `#generalDlg` so existing behavior is unchanged. Injected CSS is now keyed per-modal, includes the `cursor: move` header rule, and resize-handle injection is guarded so repeated calls don't duplicate handles.
- **`app/assets/javascripts/verification.js`**: Call `initModalManipulation('#checklistModal')` when the verification page initializes, giving the checklist modal the same drag + resize behavior as the other modals.
- **`spec/system/lexicon/verification_checklist_modal_draggable_spec.rb`**: New system spec verifying the checklist modal header shows the move cursor, has all 8 resize handles, and repositions when its header is dragged.

## Test plan

- `bundle exec rspec spec/system/lexicon/verification_checklist_modal_draggable_spec.rb` — 3 examples, 0 failures
- `bundle exec rspec spec/system/lexicon/verification_works_modal_spec.rb` — 6 examples, 0 failures (regression check on the refactored `#generalDlg` path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)