### PR TITLE
Recover citation backup_url deterministically + surface it in the editor

### DIFF
--- a/app/controllers/lexicon/citations_controller.rb
+++ b/app/controllers/lexicon/citations_controller.rb
@@ -113,7 +113,8 @@ module Lexicon
 
     # Only allow a list of trusted parameters through.
     def lex_citation_params
-      params.expect(lex_citation: %i(title from_publication pages link manifestation_id subject lex_person_work_id))
+      params.expect(lex_citation: %i(title from_publication pages link backup_url manifestation_id subject
+                                     lex_person_work_id))
     end
   end
 end

--- a/app/services/lexicon/parse_citations.rb
+++ b/app/services/lexicon/parse_citations.rb
@@ -63,6 +63,7 @@ PROMPT
 
     def call(html)
       Rails.logger.info('Parsing citations HTML with LLM API started.')
+      @asterisk_backups = []
       html = preprocess_asterisk_links(html)
       chat = RubyLLM.chat(model: 'gpt-4.1-mini')
       chat.with_instructions(SYSTEM_PROMPT).with_params(response_format: { type: :json_object })
@@ -99,6 +100,11 @@ PROMPT
           result << citation
         end
       end
+
+      # The LLM is unreliable at copying data-file-link into backup_url, so we
+      # recover it deterministically from the asterisk links we captured.
+      recover_backup_urls(result)
+
       Rails.logger.info('Parsing citations complete.')
       result
     end
@@ -134,10 +140,74 @@ PROMPT
 
         modified = true
         href = asterisk_links.map { |a| a['href'] }.find(&:present?)
-        li['data-file-link'] = href if href.present?
+
+        # Record the asterisk backup before removing the anchors, so we can
+        # re-attach it to the parsed citation deterministically afterwards.
+        # Inline (non-asterisk) hrefs are the citation's own links and serve as
+        # the strongest join key back to the LLM-parsed citation.
+        if href.present?
+          li['data-file-link'] = href
+          inline_hrefs = (li.css('a').to_a - asterisk_links).filter_map { |a| a['href'].presence }
+          @asterisk_backups << {
+            backup_href: href,
+            inline_hrefs: inline_hrefs.reject { |h| h.end_with?('.php') || h.start_with?('#') },
+            text: normalize_text(li.text)
+          }
+        end
+
         asterisk_links.each(&:remove)
       end
       modified ? doc.to_html : html
+    end
+
+    # Deterministically assign backup_url to the citation each asterisk link came
+    # from, since the LLM frequently omits it. Each backup is assigned at most
+    # once, preferring an exact match on the citation's inline link and falling
+    # back to a title/text containment match.
+    def recover_backup_urls(citations)
+      return if @asterisk_backups.blank?
+
+      assigned = Set.new
+      @asterisk_backups.each do |backup|
+        citation = match_by_link(citations, backup, assigned) ||
+                   match_by_text(citations, backup, assigned)
+        next if citation.nil?
+
+        citation.backup_url = backup[:backup_href]
+        assigned << citation.object_id
+      end
+    end
+
+    def match_by_link(citations, backup, assigned)
+      return nil if backup[:inline_hrefs].empty?
+
+      hrefs = backup[:inline_hrefs].map { |h| normalize_url(h) }
+      citations.find do |c|
+        c.link.present? && assigned.exclude?(c.object_id) && hrefs.include?(normalize_url(c.link))
+      end
+    end
+
+    # Fallback: pick the not-yet-assigned citation whose (sufficiently long)
+    # title appears within the source <li> text. Longest title wins to avoid
+    # matching a short, generic title contained in several entries.
+    def match_by_text(citations, backup, assigned)
+      candidates = citations.select do |c|
+        next false if assigned.include?(c.object_id)
+
+        title = normalize_text(c.title)
+        title.length >= 8 && backup[:text].include?(title)
+      end
+      candidates.max_by { |c| normalize_text(c.title).length }
+    end
+
+    def normalize_url(url)
+      url&.strip&.chomp('/')
+    end
+
+    def normalize_text(text)
+      return '' if text.blank?
+
+      text.gsub(/[[:punct:]]/, ' ').gsub(/\s+/, ' ').strip
     end
   end
 end

--- a/app/views/lexicon/citations/_form.html.haml
+++ b/app/views/lexicon/citations/_form.html.haml
@@ -11,6 +11,14 @@
   = f.input :from_publication
   = f.input :pages
   = f.input :link
+  = f.input :backup_url
+  - if @citation.backup_file.attached?
+    .form-group
+      %label= LexCitation.human_attribute_name(:backup_file)
+      %div
+        = link_to @citation.backup_file.filename,
+                  rails_blob_path(@citation.backup_file, disposition: :inline),
+                  target: '_blank', rel: 'noopener'
   = f.input :notes
   = f.submit t(:save)
 %hr

--- a/app/views/lexicon/citations/show.html.haml
+++ b/app/views/lexicon/citations/show.html.haml
@@ -16,6 +16,15 @@
   %b #{LexCitation.human_attribute_name(:link)}:
   = @lex_citation.link
 %p
+  %b #{LexCitation.human_attribute_name(:backup_url)}:
+  = @lex_citation.backup_url
+- if @lex_citation.backup_file.attached?
+  %p
+    %b #{LexCitation.human_attribute_name(:backup_file)}:
+    = link_to @lex_citation.backup_file.filename,
+              rails_blob_path(@lex_citation.backup_file, disposition: :inline),
+              target: '_blank', rel: 'noopener'
+%p
   %b #{LexCitation.human_attribute_name(:item)}:
   = @lex_citation.item
 %p

--- a/config/locales/active_record.en.yml
+++ b/config/locales/active_record.en.yml
@@ -126,6 +126,8 @@ en:
           failed: Upload failed
       lex_citation:
         authors: Authors
+        backup_file: Backup File
+        backup_url: Backup URL
         from_publication: From Publication
         notes: Context notes
         pages: Pages

--- a/config/locales/active_record.he.yml
+++ b/config/locales/active_record.he.yml
@@ -132,6 +132,8 @@ he:
           failed: ההעלאה נכשלה
       lex_citation:
         authors: מחברים
+        backup_file: קובץ גיבוי
+        backup_url: כתובת גיבוי
         from_publication: מתוך החיבור
         notes: הקשר והערות
         pages: עמודים

--- a/spec/requests/lexicon/citations_spec.rb
+++ b/spec/requests/lexicon/citations_spec.rb
@@ -90,6 +90,11 @@ describe '/lexicon/citations' do
     subject(:call) { get "/lex/citations/#{citation.id}/edit" }
 
     it { is_expected.to eq(200) }
+
+    it 'renders the backup_url field' do
+      call
+      expect(response.body).to include('lex_citation[backup_url]')
+    end
   end
 
   describe 'PATCH /lex/citations/:id' do
@@ -101,6 +106,15 @@ describe '/lexicon/citations' do
       it 'updates record' do
         expect(call).to eq(200)
         expect(citation.reload).to have_attributes(citation_params)
+      end
+    end
+
+    context 'when editing backup_url' do
+      let(:citation_params) { { backup_url: '/files/lex/5013/00022200.pdf' } }
+
+      it 'persists the backup_url' do
+        expect(call).to eq(200)
+        expect(citation.reload.backup_url).to eq('/files/lex/5013/00022200.pdf')
       end
     end
 

--- a/spec/services/lexicon/parse_citations_spec.rb
+++ b/spec/services/lexicon/parse_citations_spec.rb
@@ -196,6 +196,65 @@ describe Lexicon::ParseCitations do
     end
   end
 
+  # The LLM frequently omits backup_url even when data-file-link is present, so
+  # ParseCitations recovers it deterministically from the asterisk link.
+  context 'when the LLM omits backup_url for an asterisk citation' do
+    def stub_llm(works)
+      chat_double = instance_double(RubyLLM::Chat)
+      allow(RubyLLM).to receive(:chat).and_return(chat_double)
+      allow(chat_double).to receive_messages(with_instructions: chat_double, with_params: chat_double)
+      allow(chat_double).to receive(:ask).and_return(
+        instance_double(RubyLLM::Message, content: { result: [{ subject: nil, works: works }] }.to_json)
+      )
+    end
+
+    context 'when the citation has an inline link matching the asterisk <li>' do
+      let(:html) do
+        <<~HTML
+          <ul>
+            <li><b>הראל, מעין.</b>
+              <a href="https://www.haaretz.co.il/literature/1.1311393">להיות אשה</a>. הארץ, 2008, עמ' 4.
+              <a href="/files/lex/5013/00022200.pdf">*</a></li>
+          </ul>
+        HTML
+      end
+
+      it 'recovers backup_url by matching the citation link' do
+        stub_llm([
+                   { title: 'להיות אשה פירושו להיות חולה', authors: [{ name: 'הראל, מעין', link: nil }],
+                     from_publication: 'הארץ, 2008', pages: '4',
+                     link: 'https://www.haaretz.co.il/literature/1.1311393', backup_url: nil, notes: nil }
+                 ])
+
+        result = described_class.call(html)
+
+        expect(result.first.backup_url).to eq('/files/lex/5013/00022200.pdf')
+      end
+    end
+
+    context 'when the citation has no inline link' do
+      let(:html) do
+        <<~HTML
+          <ul>
+            <li>כותרת ייחודית ארוכה למאמר. עיתון, 2024, עמ' 1-5.
+              <a href="/files/lex/5013/00022200.pdf">*</a></li>
+          </ul>
+        HTML
+      end
+
+      it 'recovers backup_url by matching the citation title text' do
+        stub_llm([
+                   { title: 'כותרת ייחודית ארוכה למאמר', authors: [], from_publication: 'עיתון, 2024',
+                     pages: '1-5', link: nil, backup_url: nil, notes: nil }
+                 ])
+
+        result = described_class.call(html)
+
+        expect(result.first.backup_url).to eq('/files/lex/5013/00022200.pdf')
+      end
+    end
+  end
+
   context 'when the LLM returns citations with blank titles' do
     let(:html) { '<ul><li>some html</li></ul>' }
 


### PR DESCRIPTION
## The bug

Migrating `00022.php` attached `00022200.pdf` to the entry but **did not associate it with the LexCitation** it came from, and the citation editor showed no evidence of any backup.

Root cause is two independent problems:

1. **`backup_url` was populated solely by the LLM, which is unreliable.** The deterministic Ruby steps both work — `preprocess_asterisk_links` correctly tags the source `<li>` with `data-file-link`, and `attach_backup_files` correctly resolves the `LexLegacyLink` + blob. But the value only flows through if `gpt-4.1-mini` copies `data-file-link` → `backup_url`. For citation #503 it didn't, so `backup_url` stayed `nil` and `attach_backup_files` had nothing to attach. (The PDF still landed on the entry via the separate attachment-download path.)
2. **The citation edit/show views never rendered `backup_url` or `backup_file`** — so even a successful run left no UI evidence.

## The fix

**Deterministic recovery (no longer trust the LLM for this field):**
- During `preprocess_asterisk_links`, capture each asterisk `<li>`'s backup href, its inline (non-asterisk) link(s), and its normalized text.
- After the LLM returns, `recover_backup_urls` assigns `backup_url` to the originating citation:
  - **Primary:** match the citation's `link` against the `<li>`'s inline href (the asterisk is almost always a saved copy of that very link — a strong join key).
  - **Fallback:** longest citation title contained in the `<li>` text.
  - Each backup is assigned at most once.
- Verified against the real `00022.php`: recovery correctly sets `backup_url` on the citation the LLM left blank. Because `ProcessLinks` runs before citation parsing, the captured href is already the rewritten `new_path`, so the downstream `attach_backup_files` lookup matches.

**UI:**
- Citation edit form and show view now display `backup_url` (editable) and a link to the attached `backup_file`; controller permits `backup_url`.
- He/En attribute labels for `backup_url` / `backup_file`.

## Scope decision
Fix-forward only — no bulk backfill of the ~900 already-migrated entries (per maintainer direction). Affected entries get corrected when re-ingested/re-verified.

## Test plan
- `spec/services/lexicon/parse_citations_spec.rb`: recovery via inline-link match and via title-text fallback when the LLM omits `backup_url`.
- `spec/requests/lexicon/citations_spec.rb`: edit form renders the `backup_url` field; PATCH persists an edited `backup_url`.
- Ran parse_citations, ingest_person, ingest_publication, and citations request specs — 47 examples, 0 failures. RuboCop + haml-lint clean on changed lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)