### PR TITLE
Preserve person links in plain (non-role) work comments during migration

### DIFF
--- a/app/controllers/lexicon/person_works_controller.rb
+++ b/app/controllers/lexicon/person_works_controller.rb
@@ -87,12 +87,9 @@ module Lexicon
     end
 
     def remove_title_link
-      if params[:index].blank?
-        head :unprocessable_content
-        return
-      end
+      index = link_index_param
+      return head :unprocessable_content if index.nil?
 
-      index = params[:index].to_i
       links = Array(@work.title_links)
       links.delete_at(index) if index >= 0 && index < links.size
       @work.update!(title_links: links.presence)
@@ -124,12 +121,9 @@ module Lexicon
     end
 
     def remove_comment_link
-      if params[:index].blank?
-        head :unprocessable_content
-        return
-      end
+      index = link_index_param
+      return head :unprocessable_content if index.nil?
 
-      index = params[:index].to_i
       links = Array(@work.comment_links)
       links.delete_at(index) if index >= 0 && index < links.size
       @work.update!(comment_links: links.presence)
@@ -170,6 +164,12 @@ module Lexicon
     end
 
     private
+
+    # Parses the :index param as an integer, returning nil when it is missing or not a valid
+    # integer, so a non-numeric value (e.g. 'abc'.to_i == 0) can't silently delete the first link.
+    def link_index_param
+      Integer(params[:index], exception: false)
+    end
 
     def set_person
       @person = LexPerson.find(params[:person_id])

--- a/app/controllers/lexicon/person_works_controller.rb
+++ b/app/controllers/lexicon/person_works_controller.rb
@@ -8,7 +8,8 @@ module Lexicon
     before_action do
       require_editor('edit_lexicon')
     end
-    before_action :set_work, only: %i(edit update destroy reorder title_links add_title_link remove_title_link)
+    before_action :set_work, only: %i(edit update destroy reorder title_links add_title_link remove_title_link
+                                      comment_links add_comment_link remove_comment_link)
     before_action :set_person, only: %i(new create index)
     after_action :sync_verification_checklist, only: %i(create update destroy reorder)
 
@@ -95,6 +96,43 @@ module Lexicon
       links = Array(@work.title_links)
       links.delete_at(index) if index >= 0 && index < links.size
       @work.update!(title_links: links.presence)
+      head :ok
+    end
+
+    def comment_links
+      entry_ids = Array(@work.comment_links).filter_map { |l| l['entry_id'] }
+      @comment_link_entries = LexEntry.where(id: entry_ids).index_by(&:id)
+    end
+
+    def add_comment_link
+      text = params[:text].to_s.strip
+      entry_id = params[:entry_id].to_i
+      entry = LexEntry.find_by(id: entry_id)
+
+      if text.blank? || entry.nil? || !person_entry_for_title_link?(entry)
+        head :unprocessable_content
+        return
+      end
+
+      links = Array(@work.comment_links)
+      unless links.any? { |l| l['text'] == text }
+        links << { 'text' => text, 'entry_id' => entry_id }
+        @work.update!(comment_links: links)
+      end
+
+      head :ok
+    end
+
+    def remove_comment_link
+      if params[:index].blank?
+        head :unprocessable_content
+        return
+      end
+
+      index = params[:index].to_i
+      links = Array(@work.comment_links)
+      links.delete_at(index) if index >= 0 && index < links.size
+      @work.update!(comment_links: links.presence)
       head :ok
     end
 

--- a/app/helpers/lexicon_helper.rb
+++ b/app/helpers/lexicon_helper.rb
@@ -71,10 +71,26 @@ module LexiconHelper
 
     if work.comment.present?
       work.comment.split("\n").each do |comment|
-        result += " < #{comment} >"
+        result += " < #{render_person_work_comment(comment, work.comment_links)} >"
       end
     end
     raw result
+  end
+
+  # Renders a work comment, hyperlinking any names listed in comment_links to their LexEntry.
+  # comment_links mirror title_links ([{ 'text' => ..., 'entry_id' => ... }]). Returns an
+  # HTML-safe String with the comment text escaped and matched names replaced by links.
+  def render_person_work_comment(comment, comment_links)
+    html = ERB::Util.html_escape(comment)
+    Array(comment_links).each do |cl|
+      entry = LexEntry.find_by(id: cl['entry_id'])
+      next unless entry
+
+      escaped_text = ERB::Util.html_escape(cl['text'])
+      # Block form of sub avoids interpreting & or \1 in the replacement string
+      html = html.sub(escaped_text) { link_to(cl['text'], lexicon_entry_path(entry)) }
+    end
+    html.html_safe
   end
 
   def format_publication_details(work)

--- a/app/helpers/lexicon_helper.rb
+++ b/app/helpers/lexicon_helper.rb
@@ -81,9 +81,14 @@ module LexiconHelper
   # comment_links mirror title_links ([{ 'text' => ..., 'entry_id' => ... }]). Returns an
   # HTML-safe String with the comment text escaped and matched names replaced by links.
   def render_person_work_comment(comment, comment_links)
+    links = Array(comment_links)
     html = ERB::Util.html_escape(comment)
-    Array(comment_links).each do |cl|
-      entry = LexEntry.find_by(id: cl['entry_id'])
+    return html.html_safe if links.empty?
+
+    # Preload all referenced entries in a single query to avoid an N+1 over the links
+    entries = LexEntry.where(id: links.filter_map { |cl| cl['entry_id'] }).index_by(&:id)
+    links.each do |cl|
+      entry = entries[cl['entry_id']]
       next unless entry
 
       escaped_text = ERB::Util.html_escape(cl['text'])

--- a/app/services/lexicon/parse_person_work.rb
+++ b/app/services/lexicon/parse_person_work.rb
@@ -67,6 +67,7 @@ module Lexicon
       # removing comments representing coauthors
 
       plain_comments = []
+      comment_links = []
 
       comments.each do |comment_line|
         # sometimes comment can contain several coauthor records separated by ';'
@@ -81,12 +82,18 @@ module Lexicon
             person_work.linked_people << linked_person
           else
             plain_comments << comment
+            # Plain comments may still embed person links (e.g. 'כולל אחרית דבר מאת <a>יגאל שוורץ</a>').
+            # The comment is stored as plain text, so capture the links separately to keep them.
+            comment_links.concat(extract_comment_links(comment, element))
           end
         end
       end
 
       # All non-coauthor comments are stored as lines in coauthor comment field, separated by line breaks
       person_work.comment = plain_comments.join("\n") if plain_comments.present?
+      return unless person_work.respond_to?(:comment_links=)
+
+      person_work.comment_links = comment_links.uniq { |link| link['text'] }.presence
     end
 
     # Linked person comments are in the format 'editor – John Doe' (e.g. 'עריכה – יעל גובר')
@@ -148,6 +155,32 @@ module Lexicon
       end
 
       links.presence
+    end
+
+    # Scans the comment-section <a> tags (inside <font size="2"> wrappers, the same convention
+    # extract_title_links relies on to tell comment anchors apart from title anchors) whose text
+    # appears within the given plain comment and that link to person LexEntries. Returns an array
+    # of {text:, entry_id:} hashes so the link can be reconstructed when rendering the
+    # (otherwise plain-text) comment.
+    def extract_comment_links(comment, element)
+      links = []
+      element.css('font[size="2"] a').each do |anchor|
+        href = anchor['href']
+        next unless href&.start_with?(lexicon_entries_path + '/')
+
+        link_text = anchor.text.squish
+        next if link_text.blank?
+        # Only include anchors whose text actually appears in this comment
+        next unless comment.include?(link_text)
+        next if links.any? { |l| l['text'] == link_text }
+
+        entry_id = href.delete_prefix(lexicon_entries_path + '/').to_i
+        entry = LexEntry.find_by(id: entry_id)
+        next unless entry&.lex_file&.entrytype_person?
+
+        links << { 'text' => link_text, 'entry_id' => entry_id }
+      end
+      links
     end
 
     # It is kind-of difficult to parse Html document as-is, so we initially parse plain text of the comment

--- a/app/views/lexicon/person_works/_form.html.haml
+++ b/app/views/lexicon/person_works/_form.html.haml
@@ -50,6 +50,10 @@
   %h4= t('lexicon.person_works.title_links.section_heading')
   .border.rounded.p-2#title-links-list{ data: { ajax_url: title_links_lexicon_work_path(@work) } }
 
+  %hr
+  %h4= t('lexicon.person_works.comment_links.section_heading')
+  .border.rounded.p-2#comment-links-list{ data: { ajax_url: comment_links_lexicon_work_path(@work) } }
+
   :javascript
     function reloadLinkedPeople() {
       $('#linked-people-list').load('#{lexicon_work_linked_people_path(@work)}');
@@ -57,6 +61,10 @@
 
     function reloadTitleLinks() {
       $('#title-links-list').load('#{title_links_lexicon_work_path(@work)}');
+    }
+
+    function reloadCommentLinks() {
+      $('#comment-links-list').load('#{comment_links_lexicon_work_path(@work)}');
     }
 
     function addTitleLink(workId) {
@@ -80,6 +88,30 @@
         headers: { 'X-CSRF-Token': $('meta[name="csrf-token"]').attr('content') },
         data: { index: index },
         success: reloadTitleLinks
+      });
+    }
+
+    function addCommentLink(workId) {
+      var text = $('#comment_link_text').val();
+      var entryId = $('#comment_link_entry_id').val();
+      if (!text || !entryId) { return; }
+      $.ajax({
+        url: '/lex/works/' + workId + '/add_comment_link',
+        method: 'POST',
+        headers: { 'X-CSRF-Token': $('meta[name="csrf-token"]').attr('content') },
+        data: { text: text, entry_id: entryId },
+        success: reloadCommentLinks
+      });
+    }
+
+    function removeCommentLink(workId, index) {
+      if (!confirm('#{j(t(:are_you_sure))}')) { return; }
+      $.ajax({
+        url: '/lex/works/' + workId + '/remove_comment_link',
+        method: 'DELETE',
+        headers: { 'X-CSRF-Token': $('meta[name="csrf-token"]').attr('content') },
+        data: { index: index },
+        success: reloadCommentLinks
       });
     }
 

--- a/app/views/lexicon/person_works/comment_links.html.haml
+++ b/app/views/lexicon/person_works/comment_links.html.haml
@@ -1,0 +1,38 @@
+-# haml-lint:disable LineLength
+%ul.comment-links-list.list-unstyled.mb-2
+  - Array(@work.comment_links).each_with_index do |link, idx|
+    - entry = @comment_link_entries[link['entry_id']]
+    %li.d-flex.align-items-center.gap-2.mb-1
+      %span.badge.bg-light.text-dark.border= link['text']
+      %span →
+      - if entry
+        = link_to entry.title, lexicon_entry_path(entry), target: '_blank', rel: 'noopener'
+      - else
+        %span.text-muted= t('lexicon.person_works.comment_links.entry_not_found')
+      %button.btn.btn-sm.btn-outline-danger{ onclick: "removeCommentLink(#{@work.id}, #{idx})" }
+        = t(:delete)
+
+%hr.my-2
+%strong= t('lexicon.person_works.comment_links.add_link')
+.row.g-2.align-items-end.mt-1#add-comment-link-form
+  .col-sm-5
+    = label_tag :comment_link_text, t('lexicon.person_works.comment_links.text_in_comment'), class: 'form-label form-label-sm'
+    = text_field_tag :comment_link_text, nil, class: 'form-control form-control-sm', id: 'comment_link_text', placeholder: t('lexicon.person_works.comment_links.text_placeholder')
+  .col-sm-5
+    = label_tag :comment_link_entry_autocomplete, t('lexicon.person_works.comment_links.target_person'), class: 'form-label form-label-sm'
+    = hidden_field_tag :comment_link_entry_id, nil, id: 'comment_link_entry_id'
+    = autocomplete_field_tag :comment_link_entry_autocomplete,
+                             nil,
+                             autocomplete_lexicon_entries_path(entry_type: :person),
+                             id_element: '#comment_link_entry_id',
+                             class: 'form-control form-control-sm',
+                             placeholder: t('lexicon.person_works.comment_links.person_placeholder')
+  .col-sm-2
+    %button.btn.btn-sm.btn-primary.w-100{ onclick: "addCommentLink(#{@work.id})" }
+      = t(:add)
+
+:javascript
+  $.ui.autocomplete.prototype._resizeMenu = function () {
+    const ul = this.menu.element;
+    ul.outerWidth(this.element.outerWidth());
+  };

--- a/app/views/lexicon/verification/_person_sections.html.haml
+++ b/app/views/lexicon/verification/_person_sections.html.haml
@@ -178,7 +178,7 @@
                 %span.text-muted!= render_linked_person(linked_person)
               - if work.comment.present?
                 %br
-                %span.text-muted= work.comment
+                %span.text-muted!= render_person_work_comment(work.comment, work.comment_links)
             .work-actions.mt-2
               %button.btn.btn-sm.btn-outline-primary{ onclick: "openModal('#{edit_lexicon_work_path(work)}', function() { reloadScrollingToSection('section-works'); })" }
                 ✏️

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3263,6 +3263,14 @@ en:
         target_person: Target person
         person_placeholder: Search person entry...
         entry_not_found: Entry not found
+      comment_links:
+        section_heading: Comment Links
+        add_link: Add Comment Link
+        text_in_comment: Text in comment
+        text_placeholder: Text that becomes a link
+        target_person: Target person
+        person_placeholder: Search person entry...
+        entry_not_found: Entry not found
     citations:
       index:
         add_citation: Add Citation

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -2514,6 +2514,14 @@ he:
         target_person: אדם ביעד
         person_placeholder: חפש ערך אדם...
         entry_not_found: ערך לא נמצא
+      comment_links:
+        section_heading: קישורים בהערה
+        add_link: הוספת קישור בהערה
+        text_in_comment: טקסט בהערה
+        text_placeholder: טקסט שיהפוך לקישור
+        target_person: אדם ביעד
+        person_placeholder: חפש ערך אדם...
+        entry_not_found: ערך לא נמצא
     citations:
       index:
         add_citation: הוספת מראה מקום

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -76,6 +76,9 @@ Bybeconv::Application.routes.draw do
           get :title_links
           post :add_title_link
           delete :remove_title_link
+          get :comment_links
+          post :add_comment_link
+          delete :remove_comment_link
         end
       end
     end

--- a/db/migrate/20260605003000_add_comment_links_to_lex_person_works.rb
+++ b/db/migrate/20260605003000_add_comment_links_to_lex_person_works.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+# Stores person links found in plain (non-role) work comments, mirroring title_links.
+# Each element is { 'text' => '...', 'entry_id' => 123 }, so the comment can be rendered
+# with the named person hyperlinked to their LexEntry.
+class AddCommentLinksToLexPersonWorks < ActiveRecord::Migration[8.1]
+  def change
+    add_column :lex_person_works, :comment_links, :json
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_03_221500) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_05_003000) do
   create_table "aboutnesses", id: :integer, charset: "utf8mb4", collation: "utf8mb4_bin", force: :cascade do |t|
     t.integer "aboutable_id"
     t.string "aboutable_type"
@@ -786,6 +786,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_03_221500) do
   create_table "lex_person_works", charset: "utf8mb4", collation: "utf8mb4_bin", force: :cascade do |t|
     t.integer "collection_id"
     t.string "comment"
+    t.json "comment_links"
     t.datetime "created_at", null: false
     t.bigint "lex_person_id", null: false
     t.bigint "lex_publication_id"

--- a/spec/helpers/lexicon_helper_spec.rb
+++ b/spec/helpers/lexicon_helper_spec.rb
@@ -175,4 +175,40 @@ RSpec.describe LexiconHelper, type: :helper do
       end
     end
   end
+
+  describe '#render_person_work_comment' do
+    let!(:target_entry) { create(:lex_entry, :person, title: 'יגאל שוורץ') }
+    let(:comment) { 'כולל אחרית דבר מאת יגאל שוורץ' }
+
+    context 'when comment_links match a name in the comment' do
+      let(:comment_links) { [{ 'text' => 'יגאל שוורץ', 'entry_id' => target_entry.id }] }
+
+      it 'hyperlinks the matched name and keeps the surrounding text' do
+        result = helper.render_person_work_comment(comment, comment_links)
+        expect(result).to include('<a ')
+        expect(result).to include(lexicon_entry_path(target_entry))
+        expect(result).to include('כולל אחרית דבר מאת')
+      end
+    end
+
+    context 'when comment_links is nil' do
+      it 'returns the escaped comment unchanged' do
+        expect(helper.render_person_work_comment(comment, nil)).to eq(comment)
+      end
+    end
+
+    context 'when the comment contains HTML-special characters' do
+      it 'escapes them' do
+        expect(helper.render_person_work_comment('a < b & c', nil)).to eq('a &lt; b &amp; c')
+      end
+    end
+
+    context 'when the linked entry no longer exists' do
+      it 'leaves the name as plain (escaped) text' do
+        result = helper.render_person_work_comment(comment, [{ 'text' => 'יגאל שוורץ', 'entry_id' => 999_999 }])
+        expect(result).not_to include('<a ')
+        expect(result).to include('יגאל שוורץ')
+      end
+    end
+  end
 end

--- a/spec/requests/lexicon/person_works_spec.rb
+++ b/spec/requests/lexicon/person_works_spec.rb
@@ -342,6 +342,12 @@ describe '/lexicon/person_works' do
       delete "/lex/works/#{work.id}/remove_title_link", params: { index: 0 }, xhr: true
       expect(work.reload.title_links).to be_nil
     end
+
+    it 'returns 422 and removes nothing when the index is not an integer' do
+      delete "/lex/works/#{work.id}/remove_title_link", params: { index: 'abc' }, xhr: true
+      expect(response).to have_http_status(:unprocessable_content)
+      expect(work.reload.title_links.size).to eq(2)
+    end
   end
 
   describe 'GET /lex/works/:id/comment_links' do
@@ -422,6 +428,12 @@ describe '/lexicon/person_works' do
       work.update!(comment_links: [{ 'text' => 'יגאל שוורץ', 'entry_id' => 1 }])
       delete "/lex/works/#{work.id}/remove_comment_link", params: { index: 0 }, xhr: true
       expect(work.reload.comment_links).to be_nil
+    end
+
+    it 'returns 422 and removes nothing when the index is not an integer' do
+      delete "/lex/works/#{work.id}/remove_comment_link", params: { index: 'abc' }, xhr: true
+      expect(response).to have_http_status(:unprocessable_content)
+      expect(work.reload.comment_links.size).to eq(2)
     end
   end
 end

--- a/spec/requests/lexicon/person_works_spec.rb
+++ b/spec/requests/lexicon/person_works_spec.rb
@@ -343,4 +343,85 @@ describe '/lexicon/person_works' do
       expect(work.reload.title_links).to be_nil
     end
   end
+
+  describe 'GET /lex/works/:id/comment_links' do
+    let(:work) { create(:lex_person_work, person: person) }
+
+    it 'returns 200' do
+      expect(get("/lex/works/#{work.id}/comment_links", xhr: true)).to eq(200)
+    end
+  end
+
+  describe 'POST /lex/works/:id/add_comment_link' do
+    subject(:call) do
+      post "/lex/works/#{work.id}/add_comment_link",
+           params: { text: 'יגאל שוורץ', entry_id: target_entry.id },
+           xhr: true
+    end
+
+    let!(:work) { create(:lex_person_work, person: person, comment: 'כולל אחרית דבר מאת יגאל שוורץ') }
+    let!(:target_entry) { create(:lex_file, :person, title: 'יגאל שוורץ').lex_entry }
+
+    it 'adds the comment link and returns 200' do
+      expect(call).to eq(200)
+      expect(work.reload.comment_links).to eq([{ 'text' => 'יגאל שוורץ', 'entry_id' => target_entry.id }])
+    end
+
+    it 'does not duplicate an existing link with the same text' do
+      work.update!(comment_links: [{ 'text' => 'יגאל שוורץ', 'entry_id' => target_entry.id }])
+      expect { call }.not_to(change { work.reload.comment_links.size })
+    end
+
+    context 'when text is blank' do
+      subject(:call) do
+        post "/lex/works/#{work.id}/add_comment_link",
+             params: { text: '', entry_id: target_entry.id },
+             xhr: true
+      end
+
+      it 'returns 422' do
+        expect(call).to eq(422)
+      end
+    end
+
+    context 'when entry is not a person' do
+      subject(:call) do
+        post "/lex/works/#{work.id}/add_comment_link",
+             params: { text: 'ספר כלשהו', entry_id: publication_entry.id },
+             xhr: true
+      end
+
+      let!(:publication_entry) { create(:lex_file, :publication, title: 'ספר כלשהו').lex_entry }
+
+      it 'returns 422' do
+        expect(call).to eq(422)
+      end
+    end
+  end
+
+  describe 'DELETE /lex/works/:id/remove_comment_link' do
+    subject(:call) do
+      delete "/lex/works/#{work.id}/remove_comment_link", params: { index: 0 }, xhr: true
+    end
+
+    let!(:work) do
+      create(:lex_person_work,
+             person: person,
+             comment_links: [
+               { 'text' => 'יגאל שוורץ', 'entry_id' => 1 },
+               { 'text' => 'שמואל כץ', 'entry_id' => 2 }
+             ])
+    end
+
+    it 'removes the link at the given index and returns 200' do
+      expect(call).to eq(200)
+      expect(work.reload.comment_links).to eq([{ 'text' => 'שמואל כץ', 'entry_id' => 2 }])
+    end
+
+    it 'sets comment_links to nil when removing the last link' do
+      work.update!(comment_links: [{ 'text' => 'יגאל שוורץ', 'entry_id' => 1 }])
+      delete "/lex/works/#{work.id}/remove_comment_link", params: { index: 0 }, xhr: true
+      expect(work.reload.comment_links).to be_nil
+    end
+  end
 end

--- a/spec/services/lexicon/parse_person_work_spec.rb
+++ b/spec/services/lexicon/parse_person_work_spec.rb
@@ -206,6 +206,42 @@ describe Lexicon::ParsePersonWork do
     end
   end
 
+  context 'when a plain (non-role) comment contains a person link' do
+    let!(:person_entry) { create(:lex_file, :person, title: 'יגאל שוורץ', fname: '00032.php').lex_entry }
+    let(:line) do
+      'מעיל קטון (אור יהודה : זמורה-ביתן, 2008) <font size="2">&lt;כולל אחרית דבר מאת ' \
+        "<a href=\"/lex/entries/#{person_entry.id}\">יגאל שוורץ</a>&gt;</font>"
+    end
+
+    it 'stores the comment as plain text' do
+      expect(result.comment).to eq('כולל אחרית דבר מאת יגאל שוורץ')
+    end
+
+    it 'preserves the embedded person link in comment_links' do
+      expect(result.comment_links).to eq([{ 'text' => 'יגאל שוורץ', 'entry_id' => person_entry.id }])
+    end
+
+    it 'does not create a linked_person for the plain comment' do
+      expect(result.linked_people).to be_empty
+    end
+  end
+
+  context 'when a role-prefixed comment contains a person link' do
+    let!(:editor_entry) { create(:lex_file, :person, title: 'יגאל שוורץ', fname: '00032.php').lex_entry }
+    let(:line) do
+      'זרה בגן עדן (אור יהודה : זמורה-ביתן, 2008) <font size="2">&lt;עריכה – ' \
+        "<a href=\"/lex/entries/#{editor_entry.id}\">יגאל שוורץ</a>&gt;</font>"
+    end
+
+    it 'captures it as a linked_person and not in comment_links' do
+      expect(result.linked_people.size).to eq(1)
+      expect(result.linked_people[0]).to have_attributes(
+        name: 'יגאל שוורץ', link_type: 'editor', person_entry: editor_entry
+      )
+      expect(result.comment_links).to be_nil
+    end
+  end
+
   context 'when there are no links anywhere' do
     let(:line) { 'ספרי שירה (תל-אביב : שוקן, 2005)' }
 

--- a/spec/system/lexicon/person_work_comment_links_spec.rb
+++ b/spec/system/lexicon/person_work_comment_links_spec.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'LexPersonWork comment links in edit modal', :js, type: :system do
+  before do
+    skip 'WebDriver not available or misconfigured' unless webdriver_available?
+    login_as_lexicon_editor
+  end
+
+  let!(:target_entry) { create(:lex_file, :person, title: 'יגאל שוורץ').lex_entry }
+
+  let!(:person) do
+    create(:lex_person, birthdate: '1970', gender: :female)
+  end
+
+  let!(:entry) do
+    create(:lex_entry, title: 'Test Author', lex_item: person, status: :draft)
+  end
+
+  let!(:lex_file) do
+    file_path = Rails.root.join('tmp/test_comment_links_author.php')
+    File.write(file_path, '<html><body><h1>Test Author</h1></body></html>')
+    create(:lex_file,
+           lex_entry: entry,
+           fname: 'test_comment_links_author.php',
+           full_path: file_path.to_s,
+           status: :ingested,
+           entrytype: :person)
+  end
+
+  let!(:work) do
+    create(:lex_person_work,
+           person: person,
+           work_type: :original,
+           title: 'מעיל קטון',
+           comment: 'כולל אחרית דבר מאת יגאל שוורץ',
+           comment_links: [{ 'text' => 'יגאל שוורץ', 'entry_id' => target_entry.id }])
+  end
+
+  after { FileUtils.rm_f(Rails.root.join('tmp/test_comment_links_author.php')) }
+
+  it 'renders the comment link on the verification page' do
+    visit "/lex/verification/#{entry.id}"
+
+    within "#work-#{work.id}" do
+      expect(page).to have_link('יגאל שוורץ', href: "/lex/entries/#{target_entry.id}")
+    end
+  end
+
+  it 'shows the existing comment link in the edit modal' do
+    visit "/lex/verification/#{entry.id}"
+
+    within "#work-#{work.id}" do
+      click_button I18n.t('lexicon.verification.migrated.edit')
+    end
+
+    expect(page).to have_css('#generalDlg.show', wait: 5)
+
+    within '#generalDlg' do
+      # Wait for comment-links AJAX to load
+      expect(page).to have_css('#comment-links-list ul li', wait: 5)
+      expect(page).to have_css('#comment-links-list .badge', text: 'יגאל שוורץ', wait: 5)
+    end
+  end
+end


### PR DESCRIPTION
## Problem

During lexicon migration, person links embedded in **plain** work comments were silently dropped. `Lexicon::ParsePersonWork` only recovered links from comments matching a role prefix (`עריכה`/`איורים`/`בשיתוף`/`על`); any other comment fell through to the `plain_comments` branch and was stored as plain text via `element.text`, discarding the `<a>` href.

**Concrete case** (reported): the `מעיל קטון` work in `00022.php` has the comment `כולל אחרית דבר מאת <a href="00032.php">יגאל שוורץ</a>`. `כולל` is not a role prefix, so the link to יגאל שוורץ was lost while the name survived as text.

## Fix

Mirror the existing `title_links` mechanism with a new `comment_links` JSON column:

- **Migration/parse** — `ParsePersonWork#extract_comment_links` collects person anchors inside comment-section (`<font size="2">`) wrappers whose text appears in a plain comment, and stores them as `[{ 'text' =>, 'entry_id' => }]`. Restricting to `font[size="2"]` anchors uses the same convention `extract_title_links` relies on, avoiding false positives from title links.
- **Rendering** — new `render_person_work_comment` helper escapes the comment and substitutes matched names with links; wired into `render_person_work` and the verification person-sections view.
- **Editor UI** — add/remove `comment_link` AJAX actions, routes, and a `comment_links.html.haml` panel in the work edit form, mirroring `title_links`.

## Tests

- `parse_person_work_spec`: plain comment with a person link → stored as text + preserved in `comment_links`; role-prefixed comment still becomes a `linked_person` (not duplicated into `comment_links`).
- `lexicon_helper_spec`: `render_person_work_comment` hyperlinks matched names, escapes HTML, handles nil links and missing entries.
- `person_works_spec` (request): GET/add/remove `comment_link` endpoints incl. blank/non-person validation.
- `person_work_comment_links_spec` (system): link renders on the verification page and the existing link shows in the edit modal.

All new specs pass (78 examples). Pre-existing full-suite failures are an environment artifact (disk space → Elasticsearch read-only) unrelated to this change; every affected spec passes in isolation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)