### PR TITLE
Fix items removal

### DIFF
--- a/app/controllers/collections_controller.rb
+++ b/app/controllers/collections_controller.rb
@@ -255,7 +255,8 @@ class CollectionsController < ApplicationController
   # DELETE /collections/1 or /collections/1.json
   def destroy
     @destroyed_id = @collection.id
-    @collection.destroy
+    @collection_item_ids = @collection.parent_collection_items.pluck(:id)
+    @collection.destroy!
 
     respond_to do |format|
       format.html { redirect_to collections_url, notice: t(:deleted_successfully) }

--- a/app/views/collection_items/destroy.js.erb
+++ b/app/views/collection_items/destroy.js.erb
@@ -1,3 +1,3 @@
-ele = $('div[id*="<%= 'collitem_'+@deleted_id.to_s %>"]');
+let ele = $('div[id*="<%= 'collitem_'+@deleted_id.to_s %>"]');
 ele.find('.by-card-v02').css('background-color', 'orangered');
-ele.fadeOut(1500);
+ele.fadeOut(1500, function() { $(this).remove(); });

--- a/app/views/collection_items/destroy.js.erb
+++ b/app/views/collection_items/destroy.js.erb
@@ -1,3 +1,3 @@
-let ele = $('div[id*="<%= 'collitem_'+@deleted_id.to_s %>"]');
+ele = $('div[id*="<%= 'collitem_'+@deleted_id.to_s %>"]');
 ele.find('.by-card-v02').css('background-color', 'orangered');
 ele.fadeOut(1500, function() { $(this).remove(); });

--- a/app/views/collections/destroy.js.erb
+++ b/app/views/collections/destroy.js.erb
@@ -1,4 +1,3 @@
-$('*[id*=_coll_container_<%= @destroyed_id %>]:visible').each(function() {
-    $(this).remove();
-});
-$('#cwrapper_<%= @destroyed_id %>').remove();
+<%= @collection_item_ids.each do |item_id| %>
+  $('div[id*=_collitem_<%= item_id %>]').remove();
+<% end %>

--- a/app/views/shared/_editable_collection.html.haml
+++ b/app/views/shared/_editable_collection.html.haml
@@ -13,73 +13,72 @@
           %b.white= '⇇'
         .collection_focus_button.by-button-v02{ title: t('.focus_on_this_collection') }
           %b= link_to '⤝', collection_manage_path(collection.id), class: 'white'
-  - if collection
-    .container-fluid{ style: 'position:relative;', id: "#{nonce}_coll_container_#{collection.id}" }
-      .collection-mask{ style: 'display:none;position:absolute;top:0;left:0;width:100%;height:100%;background:rgba(255,255,255,0.7);z-index:1000;' }
-      .collection.connectable.collapse.show{ id: "#{nonce}_coll_#{collection.id}", style: 'min-height:40px;background-color: #e0e0e0;', 'data-nonce': nonce, 'data-collection-id': collection.id }
-        - collection.collection_items.each do |ci|
-          - should_focus_on_fresh_item = (fresh.present? && fresh.id == ci.id) ? 'true' : 'false'
-          .collection_draggable_item{ id: "#{nonce}_collitem_#{ci.id}", 'data-focus-on-me': should_focus_on_fresh_item }
-            .by-card-v02
-              .drag-handle{ title: t(:coll_drag_tt) }
-                .handle
-              .draggable-content{ 'data-collection-id': (ci.item.kind_of?(Collection) ? ci.item_id : collection.id) }
-                - if ci.paratext # a paratext (with markdown)
-                  .editable{ id: "#{nonce}_editable_#{ci.id}" }
-                    %b #{t(:paratext)}:
-                    %span{ id: "#{nonce}_ci_title_#{ci.id}" }= ci.alt_title
-                    = link_to t(:remove), collection_item_path(ci.id), method: :delete, remote: true, data: { confirm: t(:confirm_delete_collection_item) }, class: 'collection-btn', style: 'float: left;z-index:5;'
-                    .paramarkdown!= MultiMarkdown.new(ci.markdown).to_html
-                  .editable_edit{ style: 'display:none;' }
-                    = form_for ci, url: collection_item_path(ci.id), method: :put, remote: true do |f|
-                      = f.label :alt_title, t(:title_only_if_needed)
-                      = f.text_field :alt_title, class: 'form-control'
-                      = f.text_area :markdown, class: 'form-control', rows: 4
-                      = f.hidden_field :nonce, value: nonce
-                      = f.submit t(:save), class: 'by-button-v02', style: 'display:inline-block;'
-                      .by-button-v02.cancel_editable_edit{ style: 'width:100px; display:inline-block;' }= t(:cancel)
+  .container-fluid{ style: 'position:relative;', id: "#{nonce}_coll_container_#{collection.id}" }
+    .collection-mask{ style: 'display:none;position:absolute;top:0;left:0;width:100%;height:100%;background:rgba(255,255,255,0.7);z-index:1000;' }
+    .collection.connectable.collapse.show{ id: "#{nonce}_coll_#{collection.id}", style: 'min-height:40px;background-color: #e0e0e0;', 'data-nonce': nonce, 'data-collection-id': collection.id }
+      - collection.collection_items.each do |ci|
+        - should_focus_on_fresh_item = (fresh.present? && fresh.id == ci.id) ? 'true' : 'false'
+        .collection_draggable_item{ id: "#{nonce}_collitem_#{ci.id}", 'data-focus-on-me': should_focus_on_fresh_item }
+          .by-card-v02
+            .drag-handle{ title: t(:coll_drag_tt) }
+              .handle
+            .draggable-content{ 'data-collection-id': (ci.item.kind_of?(Collection) ? ci.item_id : collection.id) }
+              - if ci.paratext # a paratext (with markdown)
+                .editable{ id: "#{nonce}_editable_#{ci.id}" }
+                  %b #{t(:paratext)}:
+                  %span{ id: "#{nonce}_ci_title_#{ci.id}" }= ci.alt_title
+                  = link_to t(:remove), collection_item_path(ci.id), method: :delete, remote: true, data: { confirm: t(:confirm_delete_collection_item) }, class: 'collection-btn', style: 'float: left;z-index:5;'
+                  .paramarkdown!= MultiMarkdown.new(ci.markdown).to_html
+                .editable_edit{ style: 'display:none;' }
+                  = form_for ci, url: collection_item_path(ci.id), method: :put, remote: true do |f|
+                    = f.label :alt_title, t(:title_only_if_needed)
+                    = f.text_field :alt_title, class: 'form-control'
+                    = f.text_area :markdown, class: 'form-control', rows: 4
+                    = f.hidden_field :nonce, value: nonce
+                    = f.submit t(:save), class: 'by-button-v02', style: 'display:inline-block;'
+                    .by-button-v02.cancel_editable_edit{ style: 'width:100px; display:inline-block;' }= t(:cancel)
 
-                - elsif ci.item.nil? # a placeholder or paratext (no markdown)
-                  .editable{ id: "#{nonce}_editable_#{ci.id}", style: 'margin-bottom: 10px;' }
-                    %b #{t(:placeholder_item)}:
-                    %span{ id: "#{nonce}_ci_title_#{ci.id}" }= ci.alt_title
-                    = link_to t(:remove), collection_item_path(ci.id), method: :delete, remote: true, data: { confirm: t(:confirm_delete_collection_item) }, class: 'collection-btn', style: 'float: left;'
-                  .editable_edit{ style: 'display:none;' }
-                    = form_for ci, url: collection_item_path(ci.id), method: :put, remote: true do |f|
-                      = f.label :alt_title, t(:title)
-                      - if ci.paratext
-                        = f.text_area :markdown, class: 'form-control', rows: 4
-                      - else
-                        = f.text_field :alt_title, class: 'form-control'
-                      = f.hidden_field :nonce, value: nonce
-                      = f.submit t(:save), class: 'by-button-v02', style: 'display:inline-block;'
-                      .by-button-v02.cancel_editable_edit{ style: 'width:100px; display:inline-block;' }= t(:cancel)
-                - elsif ci.item.kind_of?(Collection)
-                  - if ci.item.collection_type != 'series' # what is the reason for this exception?
-                    = link_to t(:remove), collection_item_path(ci.id), method: :delete, remote: true, data: { confirm: t(:confirm_delete_collection_item) }, class: 'collection-btn', style: 'float: left;'
-                  %div.cwrapper{id: "cwrapper_#{ci.item.id}", 'data-nonce': nonce, 'data-collection-id': ci.item.id}
-                    .headline-2-v02{ 'data-nonce': nonce }
-                      #{textify_collection_type(ci.item.collection_type)}:
-                      = collection_item_string(ci)
-                      - if ci.item.collection_type == 'volume' && ci.item.publication.present?
-                        %br
-                        #{ci.item.publication.publisher_line} #{ci.item.publication.pub_year}
-                      .button_series
-                        .collection_insert_button.by-button-v02
-                          %b.white= '+'
-                        .coll_toggle.by-button-v02{ data: { target: "##{nonce}_coll_#{ci.item_id}", toggle: :collapse }, title: t(:collapse_collection) }
-                          %b.white= '↕'
-                    %div.subcollection{ style: 'margin-right: 25px;' }
-                      - if @colls_traversed.include?(ci.item.id)
-                        %b= t(:collection_circular_reference)
-                      - else
-                        - @colls_traversed << ci.item.id
-                        = render partial: 'shared/editable_collection', locals: { collection: ci.item, focused: false, nonce: nonce, fresh: fresh }
-                - else
+              - elsif ci.item.nil? # a placeholder or paratext (no markdown)
+                .editable{ id: "#{nonce}_editable_#{ci.id}", style: 'margin-bottom: 10px;' }
+                  %b #{t(:placeholder_item)}:
+                  %span{ id: "#{nonce}_ci_title_#{ci.id}" }= ci.alt_title
                   = link_to t(:remove), collection_item_path(ci.id), method: :delete, remote: true, data: { confirm: t(:confirm_delete_collection_item) }, class: 'collection-btn', style: 'float: left;'
-                  .headline-3-v02
-                    #{t(:text)}:
-                    = link_to collection_item_string(ci), default_link_by_class(ci.item.class, ci.item.id)
+                .editable_edit{ style: 'display:none;' }
+                  = form_for ci, url: collection_item_path(ci.id), method: :put, remote: true do |f|
+                    = f.label :alt_title, t(:title)
+                    - if ci.paratext
+                      = f.text_area :markdown, class: 'form-control', rows: 4
+                    - else
+                      = f.text_field :alt_title, class: 'form-control'
+                    = f.hidden_field :nonce, value: nonce
+                    = f.submit t(:save), class: 'by-button-v02', style: 'display:inline-block;'
+                    .by-button-v02.cancel_editable_edit{ style: 'width:100px; display:inline-block;' }= t(:cancel)
+              - elsif ci.item.kind_of?(Collection)
+                - if ci.item.collection_type != 'series' # what is the reason for this exception?
+                  = link_to t(:remove), collection_item_path(ci.id), method: :delete, remote: true, data: { confirm: t(:confirm_delete_collection_item) }, class: 'collection-btn', style: 'float: left;'
+                %div.cwrapper{id: "cwrapper_#{ci.item.id}", 'data-nonce': nonce, 'data-collection-id': ci.item.id}
+                  .headline-2-v02{ 'data-nonce': nonce }
+                    #{textify_collection_type(ci.item.collection_type)}:
+                    = collection_item_string(ci)
+                    - if ci.item.collection_type == 'volume' && ci.item.publication.present?
+                      %br
+                      #{ci.item.publication.publisher_line} #{ci.item.publication.pub_year}
+                    .button_series
+                      .collection_insert_button.by-button-v02
+                        %b.white= '+'
+                      .coll_toggle.by-button-v02{ data: { target: "##{nonce}_coll_#{ci.item_id}", toggle: :collapse }, title: t(:collapse_collection) }
+                        %b.white= '↕'
+                  %div.subcollection{ style: 'margin-right: 25px;' }
+                    - if @colls_traversed.include?(ci.item.id)
+                      %b= t(:collection_circular_reference)
+                    - else
+                      - @colls_traversed << ci.item.id
+                      = render partial: 'shared/editable_collection', locals: { collection: ci.item, focused: false, nonce: nonce, fresh: fresh }
+              - else
+                = link_to t(:remove), collection_item_path(ci.id), method: :delete, remote: true, data: { confirm: t(:confirm_delete_collection_item) }, class: 'collection-btn', style: 'float: left;'
+                .headline-3-v02
+                  #{t(:text)}:
+                  = link_to collection_item_string(ci), default_link_by_class(ci.item.class, ci.item.id)
 
 :javascript
   $(document).ready(function(){


### PR DESCRIPTION
This PR fixes couple of errors, causing 'Wrong Index' errors on manage collection page.

1. When we pressed 'Delete' button on collection (to remove Collection itself) it returned javascript callback which removed collection-related items from page. But! It must also delete html element which is considered by Sortable.js as 'draggable item' and this is not the Collection wrapped, but CollectionItem wrapper. As CollectionItem wrapper stayed on page, Sortable.js assumed this element is still present and 'allocated' index position for it. As result all items below removed Collection got wrong index.

2. Very similar error, but for CollectionItem removal ('remove' link on a left part of item). It also returned Js callback, but this callback did not removed item. Instead it called 'fadeOut' method on it. FadeOut only makes item invisible, but it stays on the page. As result all item below it also got index increased by 1. I've updated callback to actually remove item after fadeOut complete.


P.S. I've ignored linter warnings in haml file to keep PR short