### PR TITLE
Extend Collection#invalidate_cached_credits! to invalidate involved authorities and parent volume_series

### DIFF
--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -566,9 +566,11 @@ class Collection < ApplicationRecord
     self.cached_credits = nil
     save!
 
-    involved_authorities.includes(:authority).to_a.each do |ia|
-      ia.authority&.invalidate_cached_credits!
-    end
+    involved_authorities.includes(:authority)
+                        .map(&:authority)
+                        .compact
+                        .uniq(&:id)
+                        .each(&:invalidate_cached_credits!)
 
     parent_collections.each(&:invalidate_cached_credits!)
   end

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -565,6 +565,16 @@ class Collection < ApplicationRecord
   def invalidate_cached_credits!
     self.cached_credits = nil
     save!
+
+    involved_authorities.includes(:authority).to_a.each do |ia|
+      ia.authority&.invalidate_cached_credits!
+    end
+
+    if volume?
+      parent_collections.each do |parent|
+        parent.invalidate_cached_credits! if parent.volume_series?
+      end
+    end
   end
 
   def parent_collections

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -570,11 +570,7 @@ class Collection < ApplicationRecord
       ia.authority&.invalidate_cached_credits!
     end
 
-    if volume?
-      parent_collections.each do |parent|
-        parent.invalidate_cached_credits! if parent.volume_series?
-      end
-    end
+    parent_collections.each(&:invalidate_cached_credits!)
   end
 
   def parent_collections

--- a/spec/models/collection_spec.rb
+++ b/spec/models/collection_spec.rb
@@ -972,4 +972,69 @@ describe Collection do
       expect(doc.css("a[href=\"/manifestations/#{manifestation.id}\"]").count).to eq(1)
     end
   end
+
+  describe '#invalidate_cached_credits!' do
+    let(:collection) { create(:collection, collection_type: :volume) }
+    let(:authority) { create(:authority) }
+
+    before do
+      collection.update!(cached_credits: 'some credits')
+      authority.update!(cached_credits: 'some credits')
+      create(:involved_authority, item: collection, authority: authority, role: 'editor')
+    end
+
+    it 'invalidates the cached credits of the collection itself' do
+      collection.invalidate_cached_credits!
+      expect(collection.reload.cached_credits).to be_nil
+    end
+
+    it 'invalidates the cached credits of every involved authority' do
+      collection.invalidate_cached_credits!
+      expect(authority.reload.cached_credits).to be_nil
+    end
+
+    context 'when the collection is of type volume and has a parent of type volume_series' do
+      let(:parent_series) { create(:collection, collection_type: :volume_series) }
+
+      before do
+        parent_series.update!(cached_credits: 'parent credits')
+        create(:collection_item, collection: parent_series, item: collection)
+      end
+
+      it "invalidates the parent collection's cached credits" do
+        collection.invalidate_cached_credits!
+        expect(parent_series.reload.cached_credits).to be_nil
+      end
+    end
+
+    context 'when the collection is not of type volume' do
+      let(:collection) { create(:collection, collection_type: :series) }
+      let(:parent_series) { create(:collection, collection_type: :volume_series) }
+
+      before do
+        collection.update!(cached_credits: 'some credits')
+        parent_series.update!(cached_credits: 'parent credits')
+        create(:collection_item, collection: parent_series, item: collection)
+      end
+
+      it "does not invalidate the parent collection's cached credits" do
+        collection.invalidate_cached_credits!
+        expect(parent_series.reload.cached_credits).to eq('parent credits')
+      end
+    end
+
+    context 'when the parent collection is not of type volume_series' do
+      let(:parent_other) { create(:collection, collection_type: :other) }
+
+      before do
+        parent_other.update!(cached_credits: 'parent credits')
+        create(:collection_item, collection: parent_other, item: collection)
+      end
+
+      it "does not invalidate the parent collection's cached credits" do
+        collection.invalidate_cached_credits!
+        expect(parent_other.reload.cached_credits).to eq('parent credits')
+      end
+    end
+  end
 end

--- a/spec/models/collection_spec.rb
+++ b/spec/models/collection_spec.rb
@@ -993,47 +993,39 @@ describe Collection do
       expect(authority.reload.cached_credits).to be_nil
     end
 
-    context 'when the collection is of type volume and has a parent of type volume_series' do
-      let(:parent_series) { create(:collection, collection_type: :volume_series) }
+    context 'when the collection has parent collections' do
+      let(:parent1) { create(:collection, collection_type: :volume_series) }
+      let(:parent2) { create(:collection, collection_type: :other) }
 
       before do
-        parent_series.update!(cached_credits: 'parent credits')
-        create(:collection_item, collection: parent_series, item: collection)
+        parent1.update!(cached_credits: 'parent 1 credits')
+        parent2.update!(cached_credits: 'parent 2 credits')
+        create(:collection_item, collection: parent1, item: collection)
+        create(:collection_item, collection: parent2, item: collection)
       end
 
-      it "invalidates the parent collection's cached credits" do
+      it 'invalidates the cached credits of all parent collections' do
         collection.invalidate_cached_credits!
-        expect(parent_series.reload.cached_credits).to be_nil
+        expect(parent1.reload.cached_credits).to be_nil
+        expect(parent2.reload.cached_credits).to be_nil
       end
     end
 
-    context 'when the collection is not of type volume' do
-      let(:collection) { create(:collection, collection_type: :series) }
-      let(:parent_series) { create(:collection, collection_type: :volume_series) }
+    context 'when parent collections have parent collections themselves (recursive invalidation)' do
+      let(:parent) { create(:collection, collection_type: :volume_series) }
+      let(:grandparent) { create(:collection, collection_type: :other) }
 
       before do
-        collection.update!(cached_credits: 'some credits')
-        parent_series.update!(cached_credits: 'parent credits')
-        create(:collection_item, collection: parent_series, item: collection)
+        parent.update!(cached_credits: 'parent credits')
+        grandparent.update!(cached_credits: 'grandparent credits')
+        create(:collection_item, collection: parent, item: collection)
+        create(:collection_item, collection: grandparent, item: parent)
       end
 
-      it "does not invalidate the parent collection's cached credits" do
+      it 'recursively invalidates the cached credits of all ancestor collections' do
         collection.invalidate_cached_credits!
-        expect(parent_series.reload.cached_credits).to eq('parent credits')
-      end
-    end
-
-    context 'when the parent collection is not of type volume_series' do
-      let(:parent_other) { create(:collection, collection_type: :other) }
-
-      before do
-        parent_other.update!(cached_credits: 'parent credits')
-        create(:collection_item, collection: parent_other, item: collection)
-      end
-
-      it "does not invalidate the parent collection's cached credits" do
-        collection.invalidate_cached_credits!
-        expect(parent_other.reload.cached_credits).to eq('parent credits')
+        expect(parent.reload.cached_credits).to be_nil
+        expect(grandparent.reload.cached_credits).to be_nil
       end
     end
   end


### PR DESCRIPTION
This PR extends the credit invalidation logic when invalidating cached credits on a collection (e.g. during ingestion). It invalidates the cached credits of all involved authorities for that collection. Additionally, if the collection is a volume and belongs to a parent collection of type volume_series, it invalidates the parent collection's cached credits too.