### PR TITLE
Prepend RLM marker to title footnote reference in Manifestation#read

### DIFF
--- a/app/controllers/manifestation_controller.rb
+++ b/app/controllers/manifestation_controller.rb
@@ -441,6 +441,9 @@ class ManifestationController < ApplicationController
       redirect_to action: 'dict', id: @m.id
     else
       prep_for_read
+      if @title_footnote.present?
+        @title_footnote = "\u200F#{@title_footnote}"
+      end
       @proof = Proof.new
       @new_recommendation = Recommendation.new
       @tagging = Tagging.new

--- a/spec/controllers/manifestations_controller_spec.rb
+++ b/spec/controllers/manifestations_controller_spec.rb
@@ -381,6 +381,18 @@ describe ManifestationController do
         it { is_expected.to be_successful }
       end
 
+      context 'when there is a title footnote at the beginning of the markdown' do
+        let(:manifestation) do
+          create(:manifestation, markdown: "[^1]\r\nSome body text\r\n\r\n[^1]: This is the footnote.")
+        end
+
+        it 'prepends an RLM marker to the footnote reference' do
+          get :read, params: { id: manifestation.id }
+          expect(response).to be_successful
+          expect(assigns(:title_footnote)).to start_with("\u200F")
+        end
+      end
+
       context 'when it is a translation and work has other translations' do
         let(:orig_lang) { 'ru' }
 


### PR DESCRIPTION
## Summary

- In `Manifestation#read`, when a standalone footnote reference appears at the very beginning of the markdown (and is therefore displayed at the end of the title), prepend a Right-to-Left Mark (`U+200F`) to the footnote reference HTML.
- This ensures the footnote superscript is correctly positioned at the logical end of the title line even when the title ends in numerals or Latin characters, which would otherwise confuse the Unicode BiDi algorithm into clustering the footnote with the preceding LTR characters.

## Test plan

- [ ] Added a controller spec asserting that `@title_footnote` starts with `‏` when the markdown begins with a standalone footnote reference
- [ ] Run `bundle exec rspec spec/controllers/manifestations_controller_spec.rb -e "when there is a title footnote"` — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)