### PR TITLE
Show 'used in citation' for backup_url attachments in verification view

### DIFF
--- a/app/views/lexicon/verification/_person_sections.html.haml
+++ b/app/views/lexicon/verification/_person_sections.html.haml
@@ -323,8 +323,10 @@
       = checklist['attachments']&.dig('verified') ? '✓ ' + t('lexicon.verification.migrated.verified') : t('lexicon.verification.migrated.not_verified')
   .section-content
     - if entry.attachments.any?
-      - citations_by_link = item.citations.reject { |c| c.link.blank? }.group_by { |c| c.link.split('#').first }
-      - citations_by_backup_url = item.citations.reject { |c| c.backup_url.blank? }.group_by { |c| c.backup_url.split('#').first }
+      - citations_by_file = Hash.new { |h, k| h[k] = [] }
+      - item.citations.each do |c|
+        - citations_by_file[c.link.split('#').first] << c if c.link.present?
+        - citations_by_file[c.backup_url.split('#').first] << c if c.backup_url.present?
       - entry.attachments.each do |attachment|
         .attachment-item{id: "attachment-#{attachment.id}", class: entry.profile_image_id == attachment.id ? 'profile-image-selected' : ''}
           - if attachment.variable?
@@ -336,7 +338,7 @@
             - if entry.profile_image_id == attachment.id
               %span.badge.profile-image-badge.bg-primary.ms-2= t('lexicon.verification.migrated.profile_image_badge')
             - download_path = entry.download_path(attachment.filename.to_s)
-            - ((citations_by_link[download_path] || []) + (citations_by_backup_url[download_path] || [])).each do |citation|
+            - citations_by_file[download_path].each do |citation|
               %small.d-block.text-muted #{t('lexicon.verification.sections.attachment_used_in_citation')} #{citation.title}
           .attachment-actions.mt-2
             - if attachment.content_type.to_s.start_with?('image/')

--- a/app/views/lexicon/verification/_person_sections.html.haml
+++ b/app/views/lexicon/verification/_person_sections.html.haml
@@ -237,6 +237,11 @@
                     %span.broken-link-badge= broken_link_badge(citation.link_http_status)
                     = link_to t('lexicon.verification.broken_link.internet_archive'), "https://web.archive.org/web/*/#{citation.link}", target: '_blank', rel: 'noopener', class: 'btn btn-sm btn-outline-secondary ms-1'
                   = link_to citation.link, citation.link, target: '_blank', class: 'citation-link'
+                - if citation.backup_url.present?
+                  %br
+                  %span.text-muted
+                    = t('lexicon.verification.sections.citation_backup_file')
+                    = link_to File.basename(citation.backup_url), citation.backup_url, target: '_blank', rel: 'noopener'
               .citation-actions.mt-2
                 %button.btn.btn-sm.btn-outline-primary{onclick: "openModal('#{edit_lexicon_citation_path(citation)}', function() { location.reload(); })"}
                   ✏️

--- a/app/views/lexicon/verification/_person_sections.html.haml
+++ b/app/views/lexicon/verification/_person_sections.html.haml
@@ -319,6 +319,7 @@
   .section-content
     - if entry.attachments.any?
       - citations_by_link = item.citations.reject { |c| c.link.blank? }.group_by { |c| c.link.split('#').first }
+      - citations_by_backup_url = item.citations.reject { |c| c.backup_url.blank? }.group_by { |c| c.backup_url.split('#').first }
       - entry.attachments.each do |attachment|
         .attachment-item{id: "attachment-#{attachment.id}", class: entry.profile_image_id == attachment.id ? 'profile-image-selected' : ''}
           - if attachment.variable?
@@ -329,7 +330,8 @@
             %span.text-muted= "(#{number_to_human_size(attachment.byte_size)})"
             - if entry.profile_image_id == attachment.id
               %span.badge.profile-image-badge.bg-primary.ms-2= t('lexicon.verification.migrated.profile_image_badge')
-            - (citations_by_link[entry.download_path(attachment.filename.to_s)] || []).each do |citation|
+            - download_path = entry.download_path(attachment.filename.to_s)
+            - ((citations_by_link[download_path] || []) + (citations_by_backup_url[download_path] || [])).each do |citation|
               %small.d-block.text-muted #{t('lexicon.verification.sections.attachment_used_in_citation')} #{citation.title}
           .attachment-actions.mt-2
             - if attachment.content_type.to_s.start_with?('image/')

--- a/config/locales/lexicon.en.yml
+++ b/config/locales/lexicon.en.yml
@@ -257,6 +257,7 @@ en:
         no_external_identifiers: "(No authority control identifiers)"
         citation_from_publication: "From:"
         citation_pages: "Pages:"
+        citation_backup_file: "Backup:"
         attachment_used_in_citation: "Used in citation:"
         count_mismatch: "Count mismatch: %{php_count} item(s) in the source file, but %{migrated_count} migrated. The mismatch may be justified and does not block verification."
         bio_count_mismatch: "Word-count mismatch: the migrated biography has %{migrated_count} words, but the legacy source has %{legacy_count}. The mismatch may be justified and does not block verification."

--- a/config/locales/lexicon.he.yml
+++ b/config/locales/lexicon.he.yml
@@ -257,6 +257,7 @@ he:
         no_external_identifiers: "(אין מזהים חיצוניים)"
         citation_from_publication: "ממקור:"
         citation_pages: "עמ׳:"
+        citation_backup_file: "גיבוי:"
         attachment_used_in_citation: "בשימוש במ״מ:"
         count_mismatch: "אי-התאמה בספירה: %{php_count} פריט/ים בקובץ המקור, אך %{migrated_count} פריטים מועברים. ייתכן שאי-ההתאמה מוצדקת ואינה מונעת את אישור הערך."
         bio_count_mismatch: "אי-התאמה בספירת מילים: בביוגרפיה שהומרה %{migrated_count} מילים, אך במקור הישן %{legacy_count}. ייתכן שאי-ההתאמה מוצדקת ואינה מונעת את אישור הערך."

--- a/spec/system/lexicon/verification_workbench_spec.rb
+++ b/spec/system/lexicon/verification_workbench_spec.rb
@@ -589,27 +589,38 @@ describe 'Lexicon Verification Workbench' do
       skip 'WebDriver not available or misconfigured' unless webdriver_available?
     end
 
-    it 'shows "used in citation" label for attachments linked via backup_url' do
-      # Create a citation whose backup is a PDF attached to the entry
-      backup_filename = 'backup_doc.pdf'
-      backup_path = entry.download_path(backup_filename)
-      citation_with_backup = create(:lex_citation,
-                                    person: person,
-                                    title: 'Citation With Backup',
-                                    backup_url: backup_path,
-                                    link: nil)
+    let!(:backup_filename) { 'backup_doc.pdf' }
+    let!(:backup_path) { entry.download_path(backup_filename) }
+    let!(:citation_with_backup) do
+      create(:lex_citation,
+             person: person,
+             title: 'Citation With Backup',
+             backup_url: backup_path,
+             link: nil)
+    end
 
+    before do
       File.open(Rails.root.join('spec/fixtures/files/lexicon/attachments/lorem.pdf').to_s, 'rb') do |io|
         entry.attachments.attach(io: io, filename: backup_filename, content_type: 'application/pdf')
       end
-
       visit "/lex/verification/#{entry.id}"
+    end
 
+    it 'shows "used in citation" label for attachments linked via backup_url' do
       within('#section-attachments') do
         attachment = entry.attachments.find { |a| a.filename.to_s == backup_filename }
         within("#attachment-#{attachment.id}") do
           expect(page).to have_content(I18n.t('lexicon.verification.sections.attachment_used_in_citation'))
           expect(page).to have_content(citation_with_backup.title)
+        end
+      end
+    end
+
+    it 'shows backup_url as a link in the citation card' do
+      within('#section-citations') do
+        within("#citation-#{citation_with_backup.id}") do
+          expect(page).to have_content(I18n.t('lexicon.verification.sections.citation_backup_file'))
+          expect(page).to have_link(backup_filename, href: backup_path)
         end
       end
     end

--- a/spec/system/lexicon/verification_workbench_spec.rb
+++ b/spec/system/lexicon/verification_workbench_spec.rb
@@ -583,4 +583,35 @@ describe 'Lexicon Verification Workbench' do
       end
     end
   end
+
+  describe 'Attachment section shows backup citations', :js do
+    before do
+      skip 'WebDriver not available or misconfigured' unless webdriver_available?
+    end
+
+    it 'shows "used in citation" label for attachments linked via backup_url' do
+      # Create a citation whose backup is a PDF attached to the entry
+      backup_filename = 'backup_doc.pdf'
+      backup_path = entry.download_path(backup_filename)
+      citation_with_backup = create(:lex_citation,
+                                    person: person,
+                                    title: 'Citation With Backup',
+                                    backup_url: backup_path,
+                                    link: nil)
+
+      File.open(Rails.root.join('spec/fixtures/files/lexicon/attachments/lorem.pdf').to_s, 'rb') do |io|
+        entry.attachments.attach(io: io, filename: backup_filename, content_type: 'application/pdf')
+      end
+
+      visit "/lex/verification/#{entry.id}"
+
+      within('#section-attachments') do
+        attachment = entry.attachments.find { |a| a.filename.to_s == backup_filename }
+        within("#attachment-#{attachment.id}") do
+          expect(page).to have_content(I18n.t('lexicon.verification.sections.attachment_used_in_citation'))
+          expect(page).to have_content(citation_with_backup.title)
+        end
+      end
+    end
+  end
 end

--- a/spec/system/lexicon/verification_workbench_spec.rb
+++ b/spec/system/lexicon/verification_workbench_spec.rb
@@ -585,10 +585,6 @@ describe 'Lexicon Verification Workbench' do
   end
 
   describe 'Attachment section shows backup citations', :js do
-    before do
-      skip 'WebDriver not available or misconfigured' unless webdriver_available?
-    end
-
     let!(:backup_filename) { 'backup_doc.pdf' }
     let!(:backup_path) { entry.download_path(backup_filename) }
     let!(:citation_with_backup) do
@@ -600,6 +596,8 @@ describe 'Lexicon Verification Workbench' do
     end
 
     before do
+      skip 'WebDriver not available or misconfigured' unless webdriver_available?
+
       File.open(Rails.root.join('spec/fixtures/files/lexicon/attachments/lorem.pdf').to_s, 'rb') do |io|
         entry.attachments.attach(io: io, filename: backup_filename, content_type: 'application/pdf')
       end


### PR DESCRIPTION
## Summary

- The verification page's Attachments section shows which citations use each attached file, matching by the citation's `link` field. However, backup PDFs (linked via `*` in the source PHP) are stored in `citation.backup_url`, not `citation.link` — so the 'used in citation' label was never shown for these files even though `backup_url` was correctly populated.
- Fix: build a second mapping from `backup_url` → citations, and union it with the existing `citations_by_link` when looking up which citation owns each attachment.

## Test plan

- [ ] New system spec in `verification_workbench_spec.rb`: creates a citation with `backup_url` set, attaches the corresponding PDF to the entry, visits the verification page, and asserts that the attachment shows the "used in citation" label and citation title.
- [ ] All 37 tests in the workbench spec pass.
- [ ] Manual: visit `/lex/verification/6487` in dev — the `01150200.pdf` attachment now shows "בשימוש במ״מ: החיים בעטיפת צלופן".

🤖 Generated with [Claude Code](https://claude.com/claude-code)