### PR TITLE
Fix lexicon iframe displaying LTR instead of RTL

### DIFF
--- a/app/controllers/lexicon/verification_controller.rb
+++ b/app/controllers/lexicon/verification_controller.rb
@@ -412,6 +412,12 @@ module Lexicon
       Rails.cache.fetch(cache_key, expires_in: 1.hour) do
         html_doc = File.open(file_path) { |f| Nokogiri::HTML(f) }
 
+        # libxml2 drops dir="rtl" from <body> when an implicit body is created before
+        # the explicit <body dir="rtl"> tag (e.g. when a <span> precedes the body tag).
+        # Explicitly restore RTL since all lexicon files are Hebrew.
+        html_doc.at('html')&.set_attribute('dir', 'rtl')
+        html_doc.at('body')&.set_attribute('dir', 'rtl')
+
         html_doc.css('img').each do |img|
           src = img['src']
           if src =~ %r{^\d+[_-]{1}files/}


### PR DESCRIPTION
## Summary

- Legacy PHP files occasionally rendered LTR (left-aligned) in the verification workbench iframe, even though they display RTL when opened directly in a browser.

## Root Cause

Some PHP files contain an inline element (e.g. `<span dir="rtl">`) *before* the explicit `<body dir="rtl">` tag:

```html
<!-- PHP include --><span dir="rtl">
<body dir="rtl">
```

Nokogiri uses libxml2's HTML parser, which implicitly opens a bare `<body>` (no attributes) to hold the inline element. When the explicit `<body dir="rtl">` tag is later encountered, body is already open — libxml2 silently discards the duplicate start tag's attributes, including `dir="rtl"`. The serialised document ends up with no `dir` attribute anywhere, so the browser defaults to LTR.

## Fix

After Nokogiri parses the file, explicitly set `dir="rtl"` on both `<html>` and `<body>`. This is always correct since every lexicon file is Hebrew content.

## Test Plan

- [ ] Open a known-affected file (e.g. entry for 00758.php) in the verification workbench and confirm the iframe renders RTL / right-aligned
- [ ] Check several other entries to confirm no regression in files that already rendered correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)