### PR TITLE
Add credits field to collection edit form

### DIFF
--- a/app/controllers/collections_controller.rb
+++ b/app/controllers/collections_controller.rb
@@ -448,7 +448,7 @@ class CollectionsController < ApplicationController
   def collection_params
     params.require(:collection).permit(:title, :sort_title, :subtitle, :issn, :collection_type, :inception,
                                        :inception_year, :publisher_line, :pub_year, :publication_id, :toc_id, :toc_strategy, :alternate_titles, :description,
-                                       :cover_image, :cover_text)
+                                       :credits, :cover_image, :cover_text)
   end
 
   # Generate and send file directly without caching (for selective downloads)

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -14,6 +14,7 @@ class Collection < ApplicationRecord
   before_save :norm_dates
   before_save :prevent_uncollected_type_change
   before_save :update_alternate_titles, if: :title_changed?
+  before_save :clear_cached_credits, if: :credits_changed?
 
   validates :collection_type, presence: true
 
@@ -609,6 +610,10 @@ class Collection < ApplicationRecord
     else
       CollectionItem.new(collection: self, item: item)
     end
+  end
+
+  def clear_cached_credits
+    self.cached_credits = nil
   end
 
   def norm_dates

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -614,6 +614,7 @@ class Collection < ApplicationRecord
 
   def clear_cached_credits
     self.cached_credits = nil
+    parent_collections.each { |pc| pc.update_column(:cached_credits, nil) }
   end
 
   def norm_dates

--- a/app/views/shared/_manage_collection.html.haml
+++ b/app/views/shared/_manage_collection.html.haml
@@ -33,6 +33,8 @@
     = f.text_field :alternate_titles, class: 'form-control', style: 'width: 75%;'
     = f.label :description, t(:description)
     = f.text_area :description, class: 'form-control', style: 'width: 75%;', rows: 4
+    = f.label :credits, t('ingestible.credits')
+    = f.text_area :credits, class: 'form-control', style: 'width: 75%;', rows: 3
     %br
     = f.label :publisher, t(:edition_details)
     = f.text_field :publisher_line, class: 'form-control', style: 'width: 65%;'

--- a/app/views/shared/_manage_collection.html.haml
+++ b/app/views/shared/_manage_collection.html.haml
@@ -33,7 +33,7 @@
     = f.text_field :alternate_titles, class: 'form-control', style: 'width: 75%;'
     = f.label :description, t(:description)
     = f.text_area :description, class: 'form-control', style: 'width: 75%;', rows: 4
-    = f.label :credits, t('ingestible.credits')
+    = f.label :credits, t('activerecord.attributes.collection.credits')
     = f.text_area :credits, class: 'form-control', style: 'width: 75%;', rows: 3
     %br
     = f.label :publisher, t(:edition_details)

--- a/spec/controllers/collections_controller_spec.rb
+++ b/spec/controllers/collections_controller_spec.rb
@@ -405,6 +405,24 @@ describe CollectionsController do
           expect(collection.description).to eq 'This is a test description for the collection'
         end
       end
+
+      context 'when updating credits' do
+        let(:title) { Faker::Book.title }
+        let(:collection_params) do
+          {
+            title: title,
+            credits: 'Translated by Jane Doe'
+          }
+        end
+
+        it 'updates the credits field and clears cached_credits' do
+          collection.update_column(:cached_credits, 'stale cache')
+          expect(call).to redirect_to collection
+          collection.reload
+          expect(collection.credits).to eq 'Translated by Jane Doe'
+          expect(collection.cached_credits).to be_nil
+        end
+      end
     end
 
     describe '#destroy' do

--- a/spec/models/collection_spec.rb
+++ b/spec/models/collection_spec.rb
@@ -156,6 +156,24 @@ describe Collection do
     expect(c.publication).to eq p
   end
 
+  describe 'credits cache invalidation' do
+    it 'clears cached_credits when credits changes' do
+      c = create(:collection, credits: 'Original credits')
+      c.update_column(:cached_credits, 'Cached value')
+      c.reload
+      c.update!(credits: 'Updated credits')
+      expect(c.reload.cached_credits).to be_nil
+    end
+
+    it 'does not clear cached_credits when credits is unchanged' do
+      c = create(:collection, credits: 'Some credits')
+      c.update_column(:cached_credits, 'Cached value')
+      c.reload
+      c.update!(title: 'New Title')
+      expect(c.reload.cached_credits).to eq 'Cached value'
+    end
+  end
+
   pending 'lists people associated with it, optionally filtered by role'
 
   it 'lists tags associated with it' do


### PR DESCRIPTION
## Summary

- Adds a `credits` textarea to the collection details edit form in `_manage_collection.html.haml`, positioned after the description field
- Adds `:credits` to the permitted params in `CollectionsController#collection_params`
- Adds a `before_save :clear_cached_credits` callback in `Collection` that nullifies `cached_credits` whenever `credits` changes, preventing stale cache from being served

## Test plan

- [ ] New controller spec asserts that updating `credits` via PATCH persists the value and clears `cached_credits`
- [ ] New model specs assert cache is cleared when credits changes and not cleared when an unrelated field changes
- [ ] Manually visit the manage-collection page, click Edit, update the Credits field, and confirm the value is saved
- [ ] Verify `fetch_credits` returns fresh data after editing credits (no stale cache)

Closes by-89j