### PR TITLE
Optimize admin report actions: eliminate N+1 queries and fix Person→Authority bugs

### DIFF
--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -97,7 +97,7 @@ class AdminController < ApplicationController
   ##############################################
   ## Reports
   def raw_tocs
-    scope = Authority.joins(:toc).where('tocs.status = 0')
+    scope = Authority.joins(:toc).merge(Toc.raw)
     @authors = scope.page(params[:page]).per(15)
     @total = @authors.total_count
     @page_title = t(:raw_tocs)
@@ -154,10 +154,8 @@ class AdminController < ApplicationController
   def similar_titles
     prefixes = {}
     @similarities = {}
-    whitelisted_ids = ListItem.where(listkey: 'similar_title_whitelist').pluck(:item_id)
-    Manifestation.select(:id, :title, :cached_people).find_each do |m|
-      next if whitelisted_ids.include?(m.id) # skip whitelisted works
-
+    whitelisted_ids = ListItem.where(listkey: 'similar_title_whitelist', item_type: 'Manifestation').pluck(:item_id)
+    Manifestation.select(:id, :title, :cached_people).where.not(id: whitelisted_ids).find_each do |m|
       prefix = [m.cached_people, m.title[0..(m.title.length > 8 ? 8 : -1)]]
       if prefixes[prefix].nil?
         prefixes[prefix] = [m]

--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -97,15 +97,16 @@ class AdminController < ApplicationController
   ##############################################
   ## Reports
   def raw_tocs
-    @authors = Person.joins(:toc).where('tocs.status = 0').page(params[:page]).per(15)
-    @total = Person.joins(:toc).where('tocs.status = 0').count
+    scope = Authority.joins(:toc).where('tocs.status = 0')
+    @authors = scope.page(params[:page]).per(15)
+    @total = @authors.total_count
     @page_title = t(:raw_tocs)
     Rails.cache.write('report_raw_tocs', @total)
   end
 
   def messy_tocs
     @authors = []
-    Person.has_toc.joins(:toc).includes(:toc).find_each do |p|
+    Authority.has_toc.includes(:toc).find_each do |p|
       unless p.toc.structure_okay?
         @authors << p
       end
@@ -114,14 +115,17 @@ class AdminController < ApplicationController
   end
 
   def missing_languages
-    ex = Expression.joins(%i(involved_authorities work))
-                   .where(works: { orig_lang: :he })
-                   .merge(InvolvedAuthority.role_translator)
-    mans = ex.map { |e| e.manifestations[0] }
-    @total = mans.length
-    @mans = Kaminari.paginate_array(mans).page(params[:page]).per(50)
+    mans = Manifestation
+           .joins(expression: %i(work involved_authorities))
+           .where(works: { orig_lang: :he })
+           .merge(InvolvedAuthority.role_translator)
+           .distinct
+    @total = mans.count
+    @mans = mans.preload(expression: { work: { involved_authorities: :authority },
+                                       involved_authorities: :authority })
+                .page(params[:page]).per(50)
     @page_title = t(:missing_language_report)
-    Rails.cache.write('report_missing_languages', mans.length)
+    Rails.cache.write('report_missing_languages', @total)
   end
 
   def missing_genres
@@ -133,13 +137,13 @@ class AdminController < ApplicationController
   end
 
   def missing_images
-    @authors = Person.where(profile_image_file_name: nil).order(:name)
+    @authors = Authority.where(profile_image_file_name: nil).select(:id, :name).order(:name).to_a
     @page_title = t(:missing_images)
     Rails.cache.write('report_missing_images', @authors.count)
   end
 
   def missing_copyright
-    @authors = Authority.intellectual_property_unknown
+    @authors = Authority.intellectual_property_unknown.includes(:person)
     records = Manifestation.joins(:expression).merge(Expression.intellectual_property_unknown)
     @total = records.count
     @mans = records.page(params[:page]).per(50)
@@ -151,7 +155,7 @@ class AdminController < ApplicationController
     prefixes = {}
     @similarities = {}
     whitelisted_ids = ListItem.where(listkey: 'similar_title_whitelist').pluck(:item_id)
-    Manifestation.find_each do |m|
+    Manifestation.select(:id, :title, :cached_people).find_each do |m|
       next if whitelisted_ids.include?(m.id) # skip whitelisted works
 
       prefix = [m.cached_people, m.title[0..(m.title.length > 8 ? 8 : -1)]]
@@ -198,7 +202,9 @@ class AdminController < ApplicationController
                              InvolvedAuthority.roles[:translator]
                            )
     @total = records.count
-    @mans = records.page(params[:page])
+    @mans = records.preload(expression: { work: { involved_authorities: :authority },
+                                          involved_authorities: :authority })
+                   .page(params[:page])
     @page_title = t(:suspicious_translations_report)
     Rails.cache.write('report_suspicious_translations', @total)
   end
@@ -240,13 +246,9 @@ class AdminController < ApplicationController
       translator_sets.length > 1
     end
 
-    # Sort by author name for consistent display
-    # Cache author names to avoid N+1 queries
-    author_names = {}
-    @duplicate_clusters.each_key do |key|
-      author_id = key[0]
-      author_names[author_id] ||= Authority.find(author_id).name
-    end
+    # Sort by author name for consistent display - batch load names to avoid N+1
+    author_ids = @duplicate_clusters.keys.map(&:first).uniq
+    author_names = Authority.where(id: author_ids).pluck(:id, :name).to_h
 
     @duplicate_clusters = @duplicate_clusters.sort_by do |key, _expressions|
       author_names[key[0]]
@@ -355,14 +357,44 @@ class AdminController < ApplicationController
   end
 
   def periodless
-    @authors = Authority.joins(:person).merge(Person.where(period: nil)).select(&:any_hebrew_works?)
+    @authors = Authority
+               .joins(:person)
+               .where(people: { period: nil })
+               .where(
+                 <<~SQL.squish,
+                   EXISTS (
+                     SELECT 1 FROM manifestations m
+                     JOIN expressions e ON m.expression_id = e.id
+                     JOIN works w ON e.work_id = w.id
+                     JOIN involved_authorities ia ON ia.item_id = w.id AND ia.item_type = 'Work'
+                     WHERE ia.authority_id = authorities.id
+                       AND ia.role = ?
+                       AND m.status = ?
+                       AND w.orig_lang = 'he'
+                   )
+                   OR EXISTS (
+                     SELECT 1 FROM manifestations m
+                     JOIN expressions e ON m.expression_id = e.id
+                     JOIN involved_authorities ia ON ia.item_id = e.id AND ia.item_type = 'Expression'
+                     WHERE ia.authority_id = authorities.id
+                       AND ia.role = ?
+                       AND m.status = ?
+                       AND e.language = 'he'
+                   )
+                 SQL
+                 InvolvedAuthority.roles[:author],
+                 Manifestation.statuses[:published],
+                 InvolvedAuthority.roles[:translator],
+                 Manifestation.statuses[:published]
+               )
+               .includes(:person)
     Rails.cache.write('report_periodless', @authors.length)
   end
 
   def authors_without_works
     @authors = Authority.where(
       'not exists (select 1 from involved_authorities ia where ia.authority_id = authorities.id)'
-    ).order(:name)
+    ).includes(:publications).order(:name)
     Rails.cache.write('report_authors_without_works', @authors.length)
   end
 
@@ -588,46 +620,54 @@ class AdminController < ApplicationController
     from_date = Date.parse(params[:from])
     to_date = Date.parse(params[:to])
 
-    # Step 1: Get all published manifestations within the date range
-    manifestations_in_range = Manifestation.published
-                                           .where(created_at: from_date..to_date)
-                                           .includes(expression: { work: :involved_authorities,
-                                                                   involved_authorities: :authority })
+    # Single GROUP BY query: find authority_id => first_published_date pairs
+    # where the authority's all-time first published manifestation falls in the date range.
+    # Avoids loading all manifestations in range into memory.
+    authority_first_dates = Manifestation
+                            .joins(expression: { work: :involved_authorities })
+                            .all_published
+                            .group('involved_authorities.authority_id')
+                            .having(
+                              'MIN(manifestations.created_at) > ? AND MIN(manifestations.created_at) < ?',
+                              from_date, to_date
+                            )
+                            .pluck(Arel.sql('involved_authorities.authority_id, MIN(manifestations.created_at)'))
 
-    # Step 2: Extract unique authorities from these manifestations
-    authority_ids_in_range = []
-    manifestations_in_range.each do |m|
-      authority_ids_in_range.concat(m.involved_authorities.map(&:authority_id))
-    end
-    authority_ids_in_range.uniq!
+    authority_ids = authority_first_dates.map(&:first)
+    authorities_by_id = Authority.where(id: authority_ids).index_by(&:id)
 
-    # Step 3: For each authority, check if the manifestation in range is their first
-    authorities_with_first_manifestations = []
+    # Bounded N+1: number of qualifying authorities is small (new authors in a date range)
+    @authorities = authority_first_dates.filter_map do |authority_id, _|
+      authority = authorities_by_id[authority_id]
+      next unless authority
 
-    Authority.where(id: authority_ids_in_range).find_each do |authority|
-      first_manifestation = authority.published_manifestations.order(:created_at).first
-      next if first_manifestation.nil?
+      manifestation = Manifestation
+                      .joins(expression: { work: :involved_authorities })
+                      .all_published
+                      .where(involved_authorities: { authority_id: authority_id })
+                      .select(:id, :title, :created_at)
+                      .order('manifestations.created_at')
+                      .first
+      next unless manifestation
 
-      # Check if first manifestation was created within the date range (using exclusive bounds for consistency)
-      if first_manifestation.created_at > from_date && first_manifestation.created_at < to_date
-        authorities_with_first_manifestations << [authority, first_manifestation]
-      end
-    end
+      [authority, manifestation]
+    end.sort_by { |_, m| m.created_at }
 
-    # Sort by first manifestation date
-    @authorities = authorities_with_first_manifestations.sort_by do |_authority, manifestation|
-      manifestation.created_at
-    end
     @total = @authorities.count
   end
 
   def suspicious_titles
-    @suspicious = Manifestation.where('(title like "%קבוצה %") OR (title like "%.")').reject { |x| x.title =~ /\.\.\./ }
+    @suspicious = Manifestation
+                  .where('(title like ?) OR (title like ?)', '%קבוצה %', '%.')
+                  .where('title NOT LIKE ?', '%...%')
+                  .preload(expression: { work: { involved_authorities: :authority } })
     Rails.cache.write('report_suspicious_titles', @suspicious.length)
   end
 
   def suspicious_headings
-    mm = Manifestation.where('length(cached_heading_lines)>3')
+    mm = Manifestation
+         .where('length(cached_heading_lines)>3')
+         .preload(expression: { work: { involved_authorities: :authority } })
     @suspicious = []
     mm.each do |m|
       suspicious = false

--- a/app/views/admin/authors_without_works.html.haml
+++ b/app/views/admin/authors_without_works.html.haml
@@ -13,6 +13,6 @@
     - @authors.each do |au|
       %tr
         %td= link_to au.name, authors_show_path(id: au.id)
-        %td= link_to au.publications.length.to_s, bib_authority_path(authority_id: au.id)
-        %td= au.publications.where(status: 'uploaded').length
-        %td= au.publications.where(status: 'todo').length
+        %td= link_to au.publications.size.to_s, bib_authority_path(authority_id: au.id)
+        %td= au.publications.count(&:uploaded?)
+        %td= au.publications.count(&:todo?)

--- a/spec/controllers/admin_controller_spec.rb
+++ b/spec/controllers/admin_controller_spec.rb
@@ -1205,8 +1205,8 @@ describe AdminController do
 
     include_context 'Admin user logged in'
 
-    let!(:raw_toc) { create(:toc, status: 0) }
-    let!(:processed_toc) { create(:toc, status: 1) }
+    let!(:raw_toc) { create(:toc, status: :raw) }
+    let!(:processed_toc) { create(:toc, status: :ready) }
     let!(:authority_with_raw) { create(:authority, toc: raw_toc) }
     let!(:authority_with_processed) { create(:authority, toc: processed_toc) }
 

--- a/spec/controllers/admin_controller_spec.rb
+++ b/spec/controllers/admin_controller_spec.rb
@@ -1199,4 +1199,181 @@ describe AdminController do
       end
     end
   end
+
+  describe '#raw_tocs' do
+    subject(:call) { get :raw_tocs }
+
+    include_context 'Admin user logged in'
+
+    let!(:raw_toc) { create(:toc, status: 0) }
+    let!(:processed_toc) { create(:toc, status: 1) }
+    let!(:authority_with_raw) { create(:authority, toc: raw_toc) }
+    let!(:authority_with_processed) { create(:authority, toc: processed_toc) }
+
+    before { allow(Rails.cache).to receive(:write) }
+
+    it 'is successful' do
+      expect(call).to be_successful
+    end
+
+    it 'assigns only authorities with raw (status=0) tocs' do
+      call
+      expect(assigns(:authors)).to include(authority_with_raw)
+      expect(assigns(:authors)).not_to include(authority_with_processed)
+    end
+
+    it 'assigns total count and writes to cache' do
+      call
+      expect(assigns(:total)).to eq(1)
+      expect(Rails.cache).to have_received(:write).with('report_raw_tocs', 1)
+    end
+  end
+
+  describe '#missing_images' do
+    subject(:call) { get :missing_images }
+
+    include_context 'Admin user logged in'
+
+    let!(:authority_without_image) { create(:authority) }
+    let!(:authority_with_image) { create(:authority, :with_image) }
+
+    before { allow(Rails.cache).to receive(:write) }
+
+    it 'is successful' do
+      expect(call).to be_successful
+    end
+
+    it 'assigns only authorities without a profile image' do
+      call
+      author_ids = assigns(:authors).map(&:id)
+      expect(author_ids).to include(authority_without_image.id)
+      expect(author_ids).not_to include(authority_with_image.id)
+    end
+
+    it 'writes count to cache' do
+      call
+      expect(Rails.cache).to have_received(:write).with('report_missing_images', anything)
+    end
+  end
+
+  describe '#similar_titles' do
+    subject(:call) { get :similar_titles }
+
+    include_context 'Admin user logged in'
+
+    # Use the same author and orig_lang='he' (no translator) to ensure identical cached_people
+    let(:shared_author) { create(:authority) }
+    let!(:man1) { create(:manifestation, title: 'שירים נבחרים', author: shared_author, orig_lang: 'he') }
+    let!(:man2) { create(:manifestation, title: 'שירים נבחרים', author: shared_author, orig_lang: 'he') }
+    let!(:unique_man) { create(:manifestation, title: 'כותרת ייחודית', author: shared_author, orig_lang: 'he') }
+
+    before { allow(Rails.cache).to receive(:write) }
+
+    it 'is successful' do
+      expect(call).to be_successful
+    end
+
+    it 'groups manifestations with similar title prefix and author into similarities' do
+      call
+      similarities = assigns(:similarities)
+      all_similar_works = similarities.values.flatten
+      expect(all_similar_works).to include(man1, man2)
+      expect(all_similar_works).not_to include(unique_man)
+    end
+
+    it 'writes count to cache' do
+      call
+      expect(Rails.cache).to have_received(:write).with('report_similar_titles', anything)
+    end
+
+    context 'when a manifestation is whitelisted' do
+      before { ListItem.create!(listkey: 'similar_title_whitelist', item: man1) }
+
+      it 'excludes whitelisted manifestations from results' do
+        call
+        all_similar_works = assigns(:similarities).values.flatten
+        expect(all_similar_works).not_to include(man1)
+      end
+    end
+  end
+
+  describe '#texts_between_dates' do
+    subject(:call) { get :texts_between_dates, params: { from: from_date.to_s, to: to_date.to_s } }
+
+    include_context 'when editor logged in'
+
+    let(:from_date) { Date.new(2023, 1, 1) }
+    let(:to_date) { Date.new(2023, 12, 31) }
+
+    let!(:in_range_text) do
+      travel_to(Date.new(2023, 6, 1)) { create(:manifestation) }
+    end
+    let!(:before_range_text) do
+      travel_to(Date.new(2022, 6, 1)) { create(:manifestation) }
+    end
+    let!(:after_range_text) do
+      travel_to(Date.new(2024, 6, 1)) { create(:manifestation) }
+    end
+
+    it 'is successful' do
+      expect(call).to be_successful
+    end
+
+    it 'returns only manifestations created within the date range' do
+      call
+      expect(assigns(:texts)).to include(in_range_text)
+      expect(assigns(:texts)).not_to include(before_range_text, after_range_text)
+      expect(assigns(:total)).to eq(1)
+    end
+
+    context 'when no date params given' do
+      subject(:call) { get :texts_between_dates }
+
+      it 'is successful and returns no results' do
+        expect(call).to be_successful
+        expect(assigns(:texts)).to be_nil
+      end
+    end
+  end
+
+  describe '#authority_records_between_dates' do
+    subject(:call) do
+      get :authority_records_between_dates, params: { from: from_date.to_s, to: to_date.to_s }
+    end
+
+    include_context 'when editor logged in'
+
+    let(:from_date) { Date.new(2023, 1, 1) }
+    let(:to_date) { Date.new(2023, 12, 31) }
+
+    let!(:in_range_authority) do
+      travel_to(Date.new(2023, 6, 1)) { create(:authority) }
+    end
+    let!(:before_range_authority) do
+      travel_to(Date.new(2022, 6, 1)) { create(:authority) }
+    end
+    let!(:after_range_authority) do
+      travel_to(Date.new(2024, 6, 1)) { create(:authority) }
+    end
+
+    it 'is successful' do
+      expect(call).to be_successful
+    end
+
+    it 'returns only authority records created within the date range' do
+      call
+      expect(assigns(:records)).to include(in_range_authority)
+      expect(assigns(:records)).not_to include(before_range_authority, after_range_authority)
+      expect(assigns(:total)).to eq(1)
+    end
+
+    context 'when no date params given' do
+      subject(:call) { get :authority_records_between_dates }
+
+      it 'is successful and returns no results' do
+        expect(call).to be_successful
+        expect(assigns(:records)).to be_nil
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Summary

- **Fixed pre-existing bug** in `raw_tocs`, `messy_tocs`, `missing_images`: all were querying `Person` instead of `Authority`. The `people` table has only `birthdate/deathdate/gender/period` columns — `name`, `profile_image_file_name`, and the `:toc` association all live on `authorities`.
- **`periodless`**: replaced per-authority Ruby call to `any_hebrew_works?` (3-6 queries each) with a single SQL query using EXISTS subqueries for both author-of-Hebrew-work and translator-of-Hebrew-expression cases.
- **`missing_languages`**: replaced Ruby-level `ex.map { |e| e.manifestations[0] }` N+1 with a direct `Manifestation` JOIN query + `preload` for nested associations.
- **`first_manifestations_between_dates`**: replaced full table scan of all published manifestations with a `GROUP BY / HAVING MIN(created_at)` query that finds qualifying (authority_id, first_date) pairs directly in SQL.
- **`similar_titles`**: added `select(:id, :title, :cached_people)` to avoid loading all columns for every manifestation.
- **`suspicious_translations`, `suspicious_headings`, `suspicious_titles`**: added `preload` for author association chains to eliminate per-manifestation queries in views.
- **`authors_without_works`**: added `includes(:publications)` to eliminate N+1 in the view's `.size`/`.count` calls.
- **`duplicate_works`**: batch-pluck authority names with a single `Authority.where(id: ...).pluck(:id, :name)` instead of one `Authority.find` per cluster.
- **`missing_copyright`**: added `includes(:person)`.

## Test plan

- [ ] All 88 existing `admin_controller_spec.rb` examples pass (`bundle exec rspec spec/controllers/admin_controller_spec.rb`)
- [ ] New specs added for: `#raw_tocs`, `#missing_images`, `#similar_titles`, `#texts_between_dates`, `#authority_records_between_dates`
- [ ] No new RuboCop offenses introduced in modified files

🤖 Generated with [Claude Code](https://claude.ai/claude-code)