### PR TITLE
Restore scroll positions after LexCitation and LexLink edits in verification view

### DIFF
--- a/app/views/lexicon/citations/update.js.erb
+++ b/app/views/lexicon/citations/update.js.erb
@@ -12,5 +12,5 @@ if ($('#citations').length) {
   sessionStorage.setItem('link-check-toast-message', <%= @link_toast_message.to_json %>);
 <% end %>
   // Reload is triggered by the openModal onSuccess callback; setTimeout is a safety fallback.
-  setTimeout(function() { location.reload(); }, 300);
+  setTimeout(function() { reloadPage(); }, 300);
 }

--- a/app/views/lexicon/links/update.js.erb
+++ b/app/views/lexicon/links/update.js.erb
@@ -12,5 +12,5 @@ if ($('#links').length) {
   sessionStorage.setItem('link-check-toast-message', <%= @link_toast_message.to_json %>);
 <% end %>
   // Reload is triggered by the edit-button onSuccess callback; setTimeout is a safety fallback.
-  setTimeout(function() { location.reload(); }, 300);
+  setTimeout(function() { reloadPage(); }, 300);
 }

--- a/app/views/lexicon/verification/_person_sections.html.haml
+++ b/app/views/lexicon/verification/_person_sections.html.haml
@@ -78,7 +78,7 @@
   $('#authority-form').on('ajax:success', function(event) {
     const [data, status, xhr] = event.detail;
     cancelAuthorityEdit();
-    location.reload();
+    reloadPage();
   });
 
 -# Section 1: Title and Life Years
@@ -245,7 +245,7 @@
                     = t('lexicon.verification.sections.citation_backup_file')
                     = link_to File.basename(citation.backup_url), citation.backup_url, target: '_blank', rel: 'noopener'
               .citation-actions.mt-2
-                %button.btn.btn-sm.btn-outline-primary{onclick: "openModal('#{edit_lexicon_citation_path(citation)}', function() { location.reload(); })"}
+                %button.btn.btn-sm.btn-outline-primary{onclick: "openModal('#{edit_lexicon_citation_path(citation)}', function() { reloadPage(); })"}
                   ✏️
                   = t('lexicon.verification.migrated.edit')
                 %button.btn.btn-sm{class: checklist['citations']&.dig('items', citation.id.to_s, 'verified') ? 'btn-success' : 'btn-outline-success', data: {action: 'click->verification#quickVerify', path: "citations.items.#{citation.id}"}}
@@ -306,7 +306,7 @@
               %br
               %span.text-muted= link.description
           .link-actions.mt-2
-            %button.btn.btn-sm.btn-outline-primary{onclick: "openModal('#{edit_lexicon_link_path(link)}', function() { location.reload(); })"}
+            %button.btn.btn-sm.btn-outline-primary{onclick: "openModal('#{edit_lexicon_link_path(link)}', function() { reloadPage(); })"}
               ✏️
               = t('lexicon.verification.migrated.edit')
             %button.btn.btn-sm{class: checklist['links']&.dig('items', link.id.to_s, 'verified') ? 'btn-success' : 'btn-outline-success', data: {action: 'click->verification#quickVerify', path: "links.items.#{link.id}"}}
@@ -315,7 +315,7 @@
     - else
       %p.text-muted= t('lexicon.verification.sections.no_links')
   .section-actions
-    = link_to t('lexicon.verification.migrated.add_link'), new_lexicon_entry_link_path(entry), class: 'btn btn-sm btn-success', onclick: "event.preventDefault(); openModal(this.href, function() { location.reload(); });"
+    = link_to t('lexicon.verification.migrated.add_link'), new_lexicon_entry_link_path(entry), class: 'btn btn-sm btn-success', onclick: "event.preventDefault(); openModal(this.href, function() { reloadPage(); });"
 
 -# Section 7: Attachments
 .section.verification-section{id: 'section-attachments', class: checklist['attachments']&.dig('verified') ? 'verified' : 'not-verified'}

--- a/app/views/lexicon/verification/_person_sections.html.haml
+++ b/app/views/lexicon/verification/_person_sections.html.haml
@@ -245,7 +245,7 @@
                     = t('lexicon.verification.sections.citation_backup_file')
                     = link_to File.basename(citation.backup_url), citation.backup_url, target: '_blank', rel: 'noopener'
               .citation-actions.mt-2
-                %button.btn.btn-sm.btn-outline-primary{onclick: "openModal('#{edit_lexicon_citation_path(citation)}', function() { reloadPage(); })"}
+                %button.btn.btn-sm.btn-outline-primary{ onclick: "openModal('#{edit_lexicon_citation_path(citation)}', function() { reloadPage(); })" }
                   ✏️
                   = t('lexicon.verification.migrated.edit')
                 %button.btn.btn-sm{class: checklist['citations']&.dig('items', citation.id.to_s, 'verified') ? 'btn-success' : 'btn-outline-success', data: {action: 'click->verification#quickVerify', path: "citations.items.#{citation.id}"}}
@@ -306,7 +306,7 @@
               %br
               %span.text-muted= link.description
           .link-actions.mt-2
-            %button.btn.btn-sm.btn-outline-primary{onclick: "openModal('#{edit_lexicon_link_path(link)}', function() { reloadPage(); })"}
+            %button.btn.btn-sm.btn-outline-primary{ onclick: "openModal('#{edit_lexicon_link_path(link)}', function() { reloadPage(); })" }
               ✏️
               = t('lexicon.verification.migrated.edit')
             %button.btn.btn-sm{class: checklist['links']&.dig('items', link.id.to_s, 'verified') ? 'btn-success' : 'btn-outline-success', data: {action: 'click->verification#quickVerify', path: "links.items.#{link.id}"}}
@@ -315,7 +315,7 @@
     - else
       %p.text-muted= t('lexicon.verification.sections.no_links')
   .section-actions
-    = link_to t('lexicon.verification.migrated.add_link'), new_lexicon_entry_link_path(entry), class: 'btn btn-sm btn-success', onclick: "event.preventDefault(); openModal(this.href, function() { reloadPage(); });"
+    = link_to t('lexicon.verification.migrated.add_link'), new_lexicon_entry_link_path(entry), class: 'btn btn-sm btn-success', onclick: 'event.preventDefault(); openModal(this.href, function() { reloadPage(); });'
 
 -# Section 7: Attachments
 .section.verification-section{id: 'section-attachments', class: checklist['attachments']&.dig('verified') ? 'verified' : 'not-verified'}

--- a/app/views/lexicon/verification/_publication_sections.html.haml
+++ b/app/views/lexicon/verification/_publication_sections.html.haml
@@ -124,7 +124,7 @@
               %br
               %span.text-muted= link.description
           .link-actions.mt-2
-            %button.btn.btn-sm.btn-outline-primary{onclick: "openModal('#{edit_lexicon_link_path(link)}', function() { reloadPage(); })"}
+            %button.btn.btn-sm.btn-outline-primary{ onclick: "openModal('#{edit_lexicon_link_path(link)}', function() { reloadPage(); })" }
               ✏️
               = t('lexicon.verification.migrated.edit')
             %button.btn.btn-sm{class: checklist['links']&.dig('items', link.id.to_s, 'verified') ? 'btn-success' : 'btn-outline-success', data: {action: 'click->verification#quickVerify', path: "links.items.#{link.id}"}}
@@ -133,7 +133,7 @@
     - else
       %p.text-muted= t('lexicon.verification.sections.no_links')
   .section-actions
-    = link_to t('lexicon.verification.migrated.add_link'), new_lexicon_entry_link_path(entry), class: 'btn btn-sm btn-success', onclick: "event.preventDefault(); openModal(this.href, function() { reloadPage(); });"
+    = link_to t('lexicon.verification.migrated.add_link'), new_lexicon_entry_link_path(entry), class: 'btn btn-sm btn-success', onclick: 'event.preventDefault(); openModal(this.href, function() { reloadPage(); });'
 
 -# Section 7: Attachments
 .section.verification-section{id: 'section-attachments', class: checklist['attachments']&.dig('verified') ? 'verified' : 'not-verified'}

--- a/app/views/lexicon/verification/_publication_sections.html.haml
+++ b/app/views/lexicon/verification/_publication_sections.html.haml
@@ -124,7 +124,7 @@
               %br
               %span.text-muted= link.description
           .link-actions.mt-2
-            %button.btn.btn-sm.btn-outline-primary{onclick: "openModal('#{edit_lexicon_link_path(link)}', function() { location.reload(); })"}
+            %button.btn.btn-sm.btn-outline-primary{onclick: "openModal('#{edit_lexicon_link_path(link)}', function() { reloadPage(); })"}
               ✏️
               = t('lexicon.verification.migrated.edit')
             %button.btn.btn-sm{class: checklist['links']&.dig('items', link.id.to_s, 'verified') ? 'btn-success' : 'btn-outline-success', data: {action: 'click->verification#quickVerify', path: "links.items.#{link.id}"}}
@@ -133,7 +133,7 @@
     - else
       %p.text-muted= t('lexicon.verification.sections.no_links')
   .section-actions
-    = link_to t('lexicon.verification.migrated.add_link'), new_lexicon_entry_link_path(entry), class: 'btn btn-sm btn-success', onclick: "event.preventDefault(); openModal(this.href, function() { location.reload(); });"
+    = link_to t('lexicon.verification.migrated.add_link'), new_lexicon_entry_link_path(entry), class: 'btn btn-sm btn-success', onclick: "event.preventDefault(); openModal(this.href, function() { reloadPage(); });"
 
 -# Section 7: Attachments
 .section.verification-section{id: 'section-attachments', class: checklist['attachments']&.dig('verified') ? 'verified' : 'not-verified'}

--- a/spec/requests/lexicon/verification_spec.rb
+++ b/spec/requests/lexicon/verification_spec.rb
@@ -475,6 +475,35 @@ RSpec.describe 'Lexicon::Verification', type: :request do
     end
   end
 
+  describe 'GET /lex/verification/:id (show) - citation and link edit buttons use reloadPage' do
+    let(:person) { create(:lex_person) }
+    let(:entry) do
+      e = create(:lex_entry, :person, status: :verifying, lex_item: person)
+      e.start_verification!('editor@example.com')
+      e
+    end
+    let!(:citation) { create(:lex_citation, person: person, title: 'Test Citation', from_publication: 'Test Pub') }
+    let!(:link) { create(:lex_link, item: person) }
+
+    it 'citation edit button callback uses reloadPage() not location.reload()' do
+      get "/lex/verification/#{entry.id}"
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("/lex/citations/#{citation.id}/edit")
+      expect(response.body).to include('reloadPage()')
+      expect(response.body).not_to include('location.reload()')
+    end
+
+    it 'link edit button callback uses reloadPage() not location.reload()' do
+      get "/lex/verification/#{entry.id}"
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("/lex/links/#{link.id}/edit")
+      expect(response.body).to include('reloadPage()')
+      expect(response.body).not_to include('location.reload()')
+    end
+  end
+
   describe 'GET /lex/verification/:id (show) - per-work cards' do
     let(:person) { create(:lex_person) }
     let(:entry) do

--- a/spec/system/lexicon/verification_scroll_preservation_spec.rb
+++ b/spec/system/lexicon/verification_scroll_preservation_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe 'Verification Scroll Position Preservation', type: :system, js: true do
+RSpec.describe 'Verification Scroll Position Preservation', :js, type: :system do
   let!(:person) do
     create(:lex_person,
            birthdate: '1138',


### PR DESCRIPTION
## Summary

- All `location.reload()` calls on citation/link edit buttons in the verification view bypassed `saveScrollPositions()`, so neither pane's scroll was preserved after saving
- Replaced with `reloadPage()` (which calls `saveScrollPositions()` first) in `_person_sections.html.haml`, `_publication_sections.html.haml`, and the fallback `setTimeout` reloads in `citations/update.js.erb` and `links/update.js.erb`
- Behaviour is now consistent with LexPersonWork edits, which already used `reloadScrollingToSection()` (also saves scroll before reloading)
- The restore logic on page load was already correct; this was purely a save-side omission

## Test plan

- [ ] Edit a LexCitation in the verification view — both panes should return to their previous scroll positions after save
- [ ] Edit a LexLink in the verification view — both panes should return to their previous scroll positions after save
- [ ] Add a new LexLink via "add link" button — scroll should be preserved
- [ ] Verify LexPersonWork edits still preserve scroll (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)