### PR TITLE
Fix lexicon migration failing to extract works for 00032.php (span nested inside Books header)

### DIFF
--- a/app/services/lexicon/extract_person_works.rb
+++ b/app/services/lexicon/extract_person_works.rb
@@ -16,6 +16,11 @@ module Lexicon
       next_elem = next_element_skipping_blank(works_header)
       if next_elem.present? && next_elem.name == 'span'
         next_elem = next_elem.first_element_child
+      elsif next_elem.nil?
+        # Works may be embedded inside a span within the works header element itself
+        # (e.g. when a <span dir="rtl"> wrapping the whole page is parsed as a child of the <p>)
+        inner_span = works_header.at_css('> span')
+        next_elem = inner_span&.first_element_child
       end
 
       index = 0
@@ -24,7 +29,8 @@ module Lexicon
         header_line = next_elem.text.strip
         if %w(p font).include?(next_elem.name)
           work_type = WORK_TYPE_HEADERS.keys.detect do |wt|
-            WORK_TYPE_HEADERS[wt].include?(header_line)
+            WORK_TYPE_HEADERS[wt].include?(header_line) ||
+              WORK_TYPE_HEADERS[wt].any? { |h| header_line.start_with?(h) }
           end
 
           if work_type.nil?

--- a/spec/services/lexicon/extract_person_works_spec.rb
+++ b/spec/services/lexicon/extract_person_works_spec.rb
@@ -123,6 +123,40 @@ describe Lexicon::ExtractPersonWorks do
     end
   end
 
+  context 'when all content is inside a span embedded within the works header paragraph' do
+    # Mirrors the structure produced by Nokogiri for files like 00032.php where the raw PHP has
+    # <span dir="rtl"> before <body>, so the parser nests everything inside that span, which itself
+    # ends up as a child of the <p><a name="Books"> element.
+    let(:html) do
+      <<~HTML
+        <p><font><a name="Books">ספריו:</a></font><span dir="rtl">
+          <ul>
+            <li>ספר ראשון (תל אביב : דביר, 1990)</li>
+            <li>ספר שני (ירושלים : כתר, 2000)</li>
+          </ul>
+          <p><font>עריכה:</font><font><a href="list.pdf">רשימה מפורטת</a></font></p>
+          <ul>
+            <li>ספר נערך (תל אביב : הוצאה, 2005)</li>
+          </ul>
+          <font><a name="Bib.">על המחבר:</a></font>
+        </span></p>
+      HTML
+    end
+
+    it 'extracts original works from the embedded span' do
+      expect(lex_person.works.select(&:work_type_original?).size).to eq(2)
+    end
+
+    it 'recognizes the edited section header even when paragraph contains extra content' do
+      expect(lex_person.works.select(&:work_type_edited?).size).to eq(1)
+    end
+
+    it 'stops at the citations header and returns it' do
+      expect(result).to be_present
+      expect(result.at_css('a[name="Bib."]')).to be_present
+    end
+  end
+
   context 'when citations header appears inside the works span (malformed)' do
     let(:html) do
       <<~HTML


### PR DESCRIPTION
## Summary

- **Root cause**: In `00032.php` (יגאל שוורץ), the raw PHP file has a `<span dir="rtl">` before `<body>`. Nokogiri/libxml2 parses this by nesting the entire page content inside that span, which ends up as a *child* of the `<p class="margin"><a name="Books">` element rather than a sibling. `ExtractPersonWorks` called `next_element_skipping_blank` on the works header `<p>`, found no non-blank siblings, and extracted zero works.
- **Fix 1** (`extract_person_works.rb`): when `next_element_skipping_blank` returns nil, look for a `<span>` directly inside the works header element and start iterating from its first child.
- **Fix 2** (`extract_person_works.rb`): match section type headers (`עריכה:`, `תרגום:`, etc.) using `start_with?` as a fallback, so a header paragraph that contains extra content (e.g. a PDF link appended to the "עריכה:" label) is still correctly recognized as the 'edited' section.

## Test plan

- [x] New spec context `'when all content is inside a span embedded within the works header paragraph'` covers the primary fix (embedded span) and the secondary fix (header with extra content)
- [x] All 10 examples in `spec/services/lexicon/extract_person_works_spec.rb` pass
- [x] All 12 examples in `spec/services/lexicon/ingest_person_spec.rb` pass
- [ ] Re-ingest `00032.php` via the verification UI at `/lex/verification/5025` and confirm works appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)