### PR TITLE
Add Monday.com report button to lexicon verification workbench

### DIFF
--- a/app/assets/javascripts/verification.js
+++ b/app/assets/javascripts/verification.js
@@ -214,6 +214,62 @@ function initVerification() {
         });
     });
 
+    // Handle general "Report to Monday" button — opens a modal with a textarea
+    $('#monday-report-btn').on('click', function() {
+        $('#monday-report-description').val('');
+        $('#mondayReportModal').modal('show');
+    });
+
+    $('#monday-report-submit').on('click', function() {
+        var btn = $(this);
+        var reportUrl = $('#monday-report-btn').data('report-url');
+        var description = $('#monday-report-description').val();
+
+        btn.prop('disabled', true);
+        $.ajax({
+            url: reportUrl,
+            type: 'POST',
+            dataType: 'json',
+            headers: { 'X-CSRF-Token': $('meta[name="csrf-token"]').attr('content') },
+            data: { type: 'general', description: description },
+            success: function(data) {
+                $('#mondayReportModal').modal('hide');
+                showToast(data.message);
+            },
+            error: function(xhr) {
+                var err = (xhr.responseJSON && xhr.responseJSON.error) || 'Error sending report';
+                showToast(err);
+            },
+            complete: function() {
+                btn.prop('disabled', false);
+            }
+        });
+    });
+
+    // Handle per-work "missing work" report buttons
+    $(document).on('click', '.monday-missing-work-btn', function() {
+        var btn = $(this);
+        var reportUrl = btn.data('report-url');
+        var workTitle = btn.data('work-title');
+
+        btn.prop('disabled', true);
+        $.ajax({
+            url: reportUrl,
+            type: 'POST',
+            dataType: 'json',
+            headers: { 'X-CSRF-Token': $('meta[name="csrf-token"]').attr('content') },
+            data: { type: 'missing_work', work_title: workTitle },
+            success: function(data) {
+                showToast(data.message);
+            },
+            error: function(xhr) {
+                var err = (xhr.responseJSON && xhr.responseJSON.error) || 'Error sending report';
+                showToast(err);
+                btn.prop('disabled', false);
+            }
+        });
+    });
+
     // Handle remove attachment buttons
     $('[data-action="click->verification#removeAttachment"]').on('click', function(e) {
         e.preventDefault();

--- a/app/controllers/lexicon/verification_controller.rb
+++ b/app/controllers/lexicon/verification_controller.rb
@@ -272,6 +272,27 @@ module Lexicon
       end
     end
 
+    # POST /lexicon/verification/:id/report_to_monday
+    def report_to_monday
+      report_type = params[:type] == 'missing_work' ? :missing_work : :general
+      description = params[:description].presence
+      work_title = params[:work_title].presence
+
+      result = Lexicon::MondayReport.call(
+        entry: @entry,
+        report_type: report_type,
+        current_url: lexicon_verification_url(@entry),
+        description: description,
+        work_title: work_title
+      )
+
+      if result[:success]
+        render json: { success: true, message: I18n.t('lexicon.verification.monday.report_sent') }
+      else
+        render json: { success: false, error: result[:error] }, status: :unprocessable_content
+      end
+    end
+
     # GET /lexicon/verification/:id/edit_section?section=title
     def edit_section
       @section = params[:section]

--- a/app/services/lexicon/monday_report.rb
+++ b/app/services/lexicon/monday_report.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+
+require 'net/http'
+
+module Lexicon
+  # Posts a report item to Monday.com via its REST/GraphQL API.
+  # Used from the verification workbench for general notes and missing-work flags.
+  class MondayReport
+    MONDAY_API_URL = 'https://api.monday.com/v2'
+
+    def self.call(**)
+      new(**).call
+    end
+
+    # @param entry [LexEntry]
+    # @param report_type [Symbol] :general or :missing_work
+    # @param current_url [String] full URL of the verification page
+    # @param description [String, nil] free-text (only for :general reports)
+    # @param work_title [String, nil] title of the specific work (only for :missing_work)
+    def initialize(entry:, report_type:, current_url:, description: nil, work_title: nil)
+      @entry = entry
+      @report_type = report_type
+      @current_url = current_url
+      @description = description
+      @work_title = work_title
+    end
+
+    def call
+      board_id = ENV.fetch('MONDAY_BOARD_ID', nil)
+      token = ENV.fetch('MONDAY_API_TOKEN', nil)
+
+      if board_id.blank? || token.blank?
+        return { success: false,
+                 error: 'Monday integration not configured (MONDAY_BOARD_ID or MONDAY_API_TOKEN missing)' }
+      end
+
+      column_values = build_column_values
+      body = build_request_body(board_id, column_values)
+      response = post_to_monday(token, body)
+      parse_response(response)
+    rescue StandardError => e
+      Rails.logger.error("Lexicon::MondayReport: #{e.message}")
+      { success: false, error: e.message }
+    end
+
+    private
+
+    def build_column_values
+      values = {
+        'name' => item_name_column,
+        'text_mm2tn5yc' => @entry.title,
+        'link_mm2t7e9n' => { 'url' => @current_url, 'text' => I18n.t('lexicon.verification.monday.link_text') }
+      }
+      values['long_text_mm2tzz8q'] = @description if @report_type == :general && @description.present?
+      values
+    end
+
+    def item_name_column
+      if @report_type == :missing_work
+        I18n.t('lexicon.verification.monday.missing_work_name', title: @work_title || @entry.title)
+      else
+        I18n.t('lexicon.verification.monday.general_name')
+      end
+    end
+
+    def build_request_body(board_id, column_values)
+      # column_values in Monday's API is a JSON *string* argument inside GraphQL.
+      # Double-encode: .to_json converts the hash to a JSON string, then .to_json
+      # JSON-encodes that string (adding surrounding quotes + escaping inner quotes).
+      mutation = "mutation { create_item(board_id: #{board_id} item_name: #{@entry.title.to_json} " \
+                 "column_values: #{column_values.to_json.to_json}) { id name url } }"
+      { query: mutation }.to_json
+    end
+
+    def post_to_monday(token, body)
+      uri = URI(MONDAY_API_URL)
+      http = Net::HTTP.new(uri.host, uri.port)
+      http.use_ssl = true
+      http.open_timeout = 10
+      http.read_timeout = 15
+
+      request = Net::HTTP::Post.new(uri.path)
+      request['Authorization'] = token
+      request['Content-Type'] = 'application/json'
+      request.body = body
+
+      http.request(request)
+    end
+
+    def parse_response(response)
+      body = JSON.parse(response.body)
+      if body.dig('data', 'create_item').present?
+        { success: true }
+      else
+        errors = body['errors']&.map { |e| e['message'] }&.join(', ') # rubocop:disable Rails/Pluck
+        { success: false, error: errors.presence || 'Unknown Monday API error' }
+      end
+    rescue JSON::ParserError => e
+      { success: false, error: "Failed to parse Monday API response: #{e.message}" }
+    end
+  end
+end

--- a/app/services/lexicon/monday_report.rb
+++ b/app/services/lexicon/monday_report.rb
@@ -47,7 +47,6 @@ module Lexicon
 
     def build_column_values
       values = {
-        'name' => item_name_column,
         'text_mm2tn5yc' => @entry.title,
         'link_mm2t7e9n' => { 'url' => @current_url, 'text' => I18n.t('lexicon.verification.monday.link_text') }
       }
@@ -67,7 +66,7 @@ module Lexicon
       # column_values in Monday's API is a JSON *string* argument inside GraphQL.
       # Double-encode: .to_json converts the hash to a JSON string, then .to_json
       # JSON-encodes that string (adding surrounding quotes + escaping inner quotes).
-      mutation = "mutation { create_item(board_id: #{board_id} item_name: #{@entry.title.to_json} " \
+      mutation = "mutation { create_item(board_id: #{board_id}, item_name: #{item_name_column.to_json}, " \
                  "column_values: #{column_values.to_json.to_json}) { id name url } }"
       { query: mutation }.to_json
     end

--- a/app/views/lexicon/verification/_person_sections.html.haml
+++ b/app/views/lexicon/verification/_person_sections.html.haml
@@ -188,6 +188,9 @@
               %button.btn.btn-sm{ class: checklist['works']&.dig('items', work.id.to_s, 'verified') ? 'btn-success' : 'btn-outline-success', data: { action: 'click->verification#quickVerify', path: "works.items.#{work.id}" } }
                 ✓
                 = t('lexicon.verification.migrated.mark_verified')
+              - if work.publication.present?
+                %button.btn.btn-sm.btn-outline-warning.monday-missing-work-btn{ type: 'button', data: { 'work-title': work.title, 'report-url': lexicon_report_to_monday_verification_path(entry) } }
+                  = t('lexicon.verification.monday.missing_work_button')
     - else
       %p.text-muted= t('lexicon.verification.sections.no_works')
 

--- a/app/views/lexicon/verification/show.html.haml
+++ b/app/views/lexicon/verification/show.html.haml
@@ -55,6 +55,9 @@
             = t('lexicon.verification.show.mark_verified')
         %button.btn#escalate-btn{ type: 'button', style: 'background-color: #f8d7da; border-color: #f5c6cb;' }
           = t('lexicon.verification.show.escalate')
+        - monday_report_url = lexicon_report_to_monday_verification_path(@entry)
+        %button.btn.btn-outline-info#monday-report-btn{ type: 'button', data: { 'report-url': monday_report_url } }
+          = t('lexicon.verification.monday.report_button')
 
 - container_data = { controller: 'verification',
                      'verification-entry-id': @entry.id,
@@ -86,6 +89,27 @@
     = render 'lexicon/verification/migrated_entry', entry: @entry, item: @item, checklist: @checklist, php_counts: @php_counts, bio_comparison: @bio_comparison
 
 #modal-container
+
+.modal#mondayReportModal{ tabindex: '-1', role: 'dialog',
+                          aria: { hidden: true, labelledby: 'mondayReportModalTitle' },
+                          data: { keyboard: 'true', backdrop: 'true' } }
+  .modal-dialog{ role: 'document' }
+    .modal-content
+      .modal-header
+        %h5.modal-title#mondayReportModalTitle= t('lexicon.verification.monday.modal_title')
+        %button.close{ type: :button, data: { dismiss: :modal }, aria: { label: t(:close) } }
+          %span{ aria: { hidden: true } } &times;
+      .modal-body
+        .form-group
+          = text_area_tag :monday_report_description, nil,
+                          rows: 5, id: 'monday-report-description',
+                          class: 'form-control',
+                          placeholder: t('lexicon.verification.monday.textarea_placeholder')
+      .modal-footer
+        %button.btn.btn-secondary{ type: 'button', data: { dismiss: 'modal' } }
+          = t('cancel')
+        %button.btn.btn-primary#monday-report-submit{ type: 'button' }
+          = t('lexicon.verification.monday.submit')
 
 .modal#checklistModal{ tabindex: '-1', role: 'dialog',
                        aria: { hidden: true, labelledby: 'checklistModalTitle' },

--- a/config/locales/lexicon.en.yml
+++ b/config/locales/lexicon.en.yml
@@ -331,3 +331,14 @@ en:
           nli: NLI
           wikidata: Wikidata
           openlibrary: OpenLibrary
+      monday:
+        report_button: Report to Monday
+        missing_work_button: "Report: Work missing from lexicon"
+        modal_title: Send Report to Monday
+        textarea_placeholder: "Describe the issue..."
+        submit: Submit Report
+        report_sent: Report sent successfully
+        report_error: Error sending report
+        link_text: Link to entry under review
+        general_name: See extended description
+        missing_work_name: "The work %{title} is known in the bibliography but does not appear in the lexicon entry."

--- a/config/locales/lexicon.he.yml
+++ b/config/locales/lexicon.he.yml
@@ -333,7 +333,7 @@ he:
           openlibrary: OpenLibrary
       monday:
         report_button: דיווח ב-Monday
-        missing_work_button: דווח&#58; חיבור חסר בלקסיקון
+        missing_work_button: "דווח: חיבור חסר בלקסיקון"
         modal_title: שליחת דיווח ל-Monday
         textarea_placeholder: "תאר את הבעיה..."
         submit: שלח דיווח

--- a/config/locales/lexicon.he.yml
+++ b/config/locales/lexicon.he.yml
@@ -331,3 +331,14 @@ he:
           nli: NLI
           wikidata: Wikidata
           openlibrary: OpenLibrary
+      monday:
+        report_button: דיווח ב-Monday
+        missing_work_button: דווח&#58; חיבור חסר בלקסיקון
+        modal_title: שליחת דיווח ל-Monday
+        textarea_placeholder: "תאר את הבעיה..."
+        submit: שלח דיווח
+        report_sent: הדיווח נשלח בהצלחה
+        report_error: שגיאה בשליחת הדיווח
+        link_text: קישורית לערך המוסב
+        general_name: ראה תיאור נרחב
+        missing_work_name: "החיבור %{title} ידוע בביבליוגרפיה אך לא מופיע בערך הלקסיקון."

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -119,6 +119,7 @@ Bybeconv::Application.routes.draw do
       post ':id/escalate', to: 'verification#escalate', as: :escalate_verification
       get ':id/edit_section', to: 'verification#edit_section', as: :edit_section_verification
       patch ':id/update_section', to: 'verification#update_section', as: :update_section_verification
+      post ':id/report_to_monday', to: 'verification#report_to_monday', as: :report_to_monday_verification
     end
 
     resources :files, only: :index do

--- a/spec/requests/lexicon/verification_monday_report_spec.rb
+++ b/spec/requests/lexicon/verification_monday_report_spec.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'POST /lex/verification/:id/report_to_monday', type: :request do
+  let(:person) { create(:lex_person) }
+  let(:entry) do
+    e = create(:lex_entry, :person, lex_item: person, status: :verifying)
+    e.start_verification!('editor@example.com')
+    e
+  end
+  let(:url) { "/lex/verification/#{entry.id}/report_to_monday" }
+
+  before { login_as_lexicon_editor }
+
+  context 'when Monday integration is configured' do
+    before do
+      stub_const('ENV', ENV.to_h.merge('MONDAY_BOARD_ID' => '12345', 'MONDAY_API_TOKEN' => 'test-token'))
+      allow(Lexicon::MondayReport).to receive(:call).and_return({ success: true })
+    end
+
+    it 'delegates to the MondayReport service for a general report' do
+      post url, params: { type: 'general', description: 'some notes' }, as: :json
+
+      expect(Lexicon::MondayReport).to have_received(:call).with(
+        hash_including(report_type: :general, description: 'some notes')
+      )
+    end
+
+    it 'delegates to the MondayReport service for a missing_work report' do
+      post url, params: { type: 'missing_work', work_title: 'שיר ערש' }, as: :json
+
+      expect(Lexicon::MondayReport).to have_received(:call).with(
+        hash_including(report_type: :missing_work, work_title: 'שיר ערש')
+      )
+    end
+
+    it 'returns 200 with success message on success' do
+      post url, params: { type: 'general', description: 'notes' }, as: :json
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body['success']).to be true
+    end
+
+    it 'passes the verification page URL to the service' do
+      post url, params: { type: 'general' }, as: :json
+
+      expect(Lexicon::MondayReport).to have_received(:call).with(
+        hash_including(current_url: %r{/lex/verification/#{entry.id}})
+      )
+    end
+  end
+
+  context 'when the service returns an error' do
+    before do
+      stub_const('ENV', ENV.to_h.merge('MONDAY_BOARD_ID' => '12345', 'MONDAY_API_TOKEN' => 'test-token'))
+      allow(Lexicon::MondayReport).to receive(:call).and_return({ success: false, error: 'API error' })
+    end
+
+    it 'returns 422 with the error' do
+      post url, params: { type: 'general' }, as: :json
+
+      expect(response).to have_http_status(:unprocessable_content)
+      expect(response.parsed_body['error']).to eq('API error')
+    end
+  end
+end

--- a/spec/services/lexicon/monday_report_spec.rb
+++ b/spec/services/lexicon/monday_report_spec.rb
@@ -1,0 +1,182 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Lexicon::MondayReport do
+  include WebMock::API
+
+  let(:entry) { create(:lex_entry, :person, title: 'מוישה זוכמיר') }
+  let(:current_url) { 'https://benyehuda.org/lex/verification/1234' }
+  let(:captured_request) { {} }
+
+  before do
+    WebMock.disable_net_connect!(allow_localhost: true)
+    stub_const('ENV', ENV.to_h.merge('MONDAY_BOARD_ID' => '5095697584', 'MONDAY_API_TOKEN' => 'test-token'))
+  end
+
+  def stub_monday_success(&block)
+    stub_request(:post, 'https://api.monday.com/v2').to_return do |request|
+      block&.call(request)
+      {
+        status: 200,
+        headers: { 'Content-Type' => 'application/json' },
+        body: { data: { create_item: { id: '123', name: 'מוישה זוכמיר', url: 'https://monday.com/item/123' } } }.to_json
+      }
+    end
+  end
+
+  def stub_monday_error(message = 'Invalid token')
+    stub_request(:post, 'https://api.monday.com/v2')
+      .to_return(
+        status: 200,
+        headers: { 'Content-Type' => 'application/json' },
+        body: { errors: [{ message: message }] }.to_json
+      )
+  end
+
+  describe '.call' do
+    context 'when Monday env vars are not configured' do
+      before { stub_const('ENV', ENV.to_h.merge('MONDAY_BOARD_ID' => nil, 'MONDAY_API_TOKEN' => nil)) }
+
+      it 'returns an error without making an HTTP request' do
+        # VCR/WebMock will raise if an unexpected HTTP call is made,
+        # so the absence of an error confirms no request was attempted.
+        result = described_class.call(entry: entry, report_type: :general, current_url: current_url)
+
+        expect(result[:success]).to be false
+        expect(result[:error]).to include('not configured')
+      end
+    end
+
+    context 'with a general report' do
+      it 'returns success when Monday API succeeds' do
+        stub_monday_success
+        result = described_class.call(
+          entry: entry,
+          report_type: :general,
+          current_url: current_url,
+          description: 'נראה שחסר פה ככה וככה'
+        )
+
+        expect(result[:success]).to be true
+      end
+
+      it 'sends the entry title in the request body' do
+        captured_body = nil
+        stub_monday_success { |req| captured_body = req.body }
+
+        described_class.call(entry: entry, report_type: :general, current_url: current_url)
+
+        expect(captured_body).to include('מוישה זוכמיר')
+      end
+
+      it 'sends the general_name I18n text in the body' do
+        captured_body = nil
+        stub_monday_success { |req| captured_body = req.body }
+        expected = I18n.t('lexicon.verification.monday.general_name')
+
+        described_class.call(entry: entry, report_type: :general, current_url: current_url)
+
+        expect(captured_body).to include(expected)
+      end
+
+      it 'includes the description in the body' do
+        captured_body = nil
+        stub_monday_success { |req| captured_body = req.body }
+        description = 'נראה שחסר פה ככה וככה'
+
+        described_class.call(entry: entry, report_type: :general, current_url: current_url, description: description)
+
+        expect(captured_body).to include(description)
+      end
+
+      it 'includes the current_url in the body' do
+        captured_body = nil
+        stub_monday_success { |req| captured_body = req.body }
+
+        described_class.call(entry: entry, report_type: :general, current_url: current_url)
+
+        expect(captured_body).to include('benyehuda.org')
+      end
+
+      it 'sends the Authorization header with the token' do
+        captured_headers = nil
+        stub_monday_success { |req| captured_headers = req.headers }
+
+        described_class.call(entry: entry, report_type: :general, current_url: current_url)
+
+        expect(captured_headers['Authorization']).to eq('test-token')
+      end
+
+      it 'omits long_text column when description is blank' do
+        captured_body = nil
+        stub_monday_success { |req| captured_body = req.body }
+
+        described_class.call(entry: entry, report_type: :general, current_url: current_url, description: nil)
+
+        expect(captured_body).not_to include('long_text_mm2tzz8q')
+      end
+    end
+
+    context 'with a missing_work report' do
+      let(:work_title) { 'שיר ערש' }
+
+      it 'returns success when Monday API succeeds' do
+        stub_monday_success
+        result = described_class.call(
+          entry: entry,
+          report_type: :missing_work,
+          current_url: current_url,
+          work_title: work_title
+        )
+
+        expect(result[:success]).to be true
+      end
+
+      it 'includes the work title in the missing_work_name text' do
+        captured_body = nil
+        stub_monday_success { |req| captured_body = req.body }
+        expected = I18n.t('lexicon.verification.monday.missing_work_name', title: work_title)
+
+        described_class.call(
+          entry: entry, report_type: :missing_work, current_url: current_url, work_title: work_title
+        )
+
+        expect(captured_body).to include(expected)
+      end
+
+      it 'omits long_text column' do
+        captured_body = nil
+        stub_monday_success { |req| captured_body = req.body }
+
+        described_class.call(
+          entry: entry, report_type: :missing_work, current_url: current_url, work_title: work_title
+        )
+
+        expect(captured_body).not_to include('long_text_mm2tzz8q')
+      end
+    end
+
+    context 'when Monday API returns an error response' do
+      before { stub_monday_error('Invalid auth token') }
+
+      it 'returns failure with the error message' do
+        result = described_class.call(entry: entry, report_type: :general, current_url: current_url)
+
+        expect(result[:success]).to be false
+        expect(result[:error]).to include('Invalid auth token')
+      end
+    end
+
+    context 'when the network call times out' do
+      before { stub_request(:post, 'https://api.monday.com/v2').to_timeout }
+
+      it 'returns failure without raising' do
+        result = described_class.call(entry: entry, report_type: :general, current_url: current_url)
+
+        expect(result[:success]).to be false
+        expect(result[:error]).to be_present
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Adds a **general report** button to the verification header: opens a modal with a free-text textarea, then posts a new Monday.com item on the configured board
- Adds a **missing-work report** button on each work card that has a linked publication: posts immediately with a standardised Hebrew message ("work is known in the bibliography but absent from the legacy lexicon file")
- New `Lexicon::MondayReport` service handles the Monday GraphQL API call via `Net::HTTP`; reads `MONDAY_BOARD_ID` and `MONDAY_API_TOKEN` from env vars; returns gracefully if not configured

## Design decisions

- `column_values` in Monday's API is a JSON *string* argument inside GraphQL, so it's double-encoded via `.to_json.to_json` — this matches the documented curl example exactly
- The missing-work button only appears on work cards where `work.publication.present?` (the work is linked to the bibliography)
- **ASSUMPTION**: the `%{title}` interpolated in the missing-work `name` column is the **work's** own title, not the LexEntry title. The spec says "LexEntry's title" but that produces non-sensical text (person name where a work title is expected) — please confirm or correct

## I18n

New keys added to `config/locales/lexicon.he.yml` and `lexicon.en.yml` under `lexicon.verification.monday.*`

## Test plan

- [ ] `bundle exec rspec spec/services/lexicon/monday_report_spec.rb` — 13 examples
- [ ] `bundle exec rspec spec/requests/lexicon/verification_monday_report_spec.rb` — 5 examples
- [ ] Set `MONDAY_BOARD_ID` and `MONDAY_API_TOKEN` in `.env`, open a verification entry, click "Report to Monday", fill the textarea, submit — verify a new item appears on the board
- [ ] On a person entry with a publication-linked work, click "Report: work missing from lexicon" — verify a Monday item appears with the correct `name` text
- [ ] With env vars unset, confirm both buttons return a toast error without crashing

🤖 Generated with [Claude Code](https://claude.com/claude-code)