### PR TITLE
Add date_of_manual_update field to LexEntry

### DIFF
--- a/app/controllers/lexicon/people_controller.rb
+++ b/app/controllers/lexicon/people_controller.rb
@@ -58,7 +58,7 @@ module Lexicon
           :birthdate,
           :deathdate,
           :bio,
-          { entry_attributes: %i(title other_designation) }
+          { entry_attributes: %i(title other_designation date_of_manual_update) }
         ]
       )
     end

--- a/app/controllers/lexicon/person_works_controller.rb
+++ b/app/controllers/lexicon/person_works_controller.rb
@@ -11,7 +11,6 @@ module Lexicon
     before_action :set_work, only: %i(edit update destroy reorder title_links add_title_link remove_title_link
                                       comment_links add_comment_link remove_comment_link)
     before_action :set_person, only: %i(new create index)
-    after_action :sync_verification_checklist, only: %i(create update destroy reorder)
 
     layout false
 
@@ -34,7 +33,10 @@ module Lexicon
 
       @work.person = @person
 
-      return if @work.save
+      if @work.save
+        @person.entry&.add_work_to_checklist!(@work.id)
+        return
+      end
 
       render :new, status: :unprocessable_content
     end
@@ -55,7 +57,9 @@ module Lexicon
     end
 
     def destroy
+      work_id = @work.id
       @work.destroy!
+      @person.entry&.remove_work_from_checklist!(work_id)
     end
 
     def title_links
@@ -192,15 +196,6 @@ module Lexicon
           title work_type publisher publication_date publication_place comment publication_id collection_id
         )
       )
-    end
-
-    # Sync verification checklist when works are added/updated/deleted
-    def sync_verification_checklist
-      # Get the entry for this person if it exists and is being verified
-      entry = @person.entry
-      return if entry&.verification_progress.blank?
-
-      entry.sync_works_checklist!
     end
   end
 end

--- a/app/controllers/lexicon/publications_controller.rb
+++ b/app/controllers/lexicon/publications_controller.rb
@@ -52,7 +52,7 @@ module Lexicon
           :description,
           :toc,
           :az_navbar,
-          { entry_attributes: %i(title other_designation) }
+          { entry_attributes: %i(title other_designation date_of_manual_update) }
         ]
       )
     end

--- a/app/controllers/lexicon/verification_controller.rb
+++ b/app/controllers/lexicon/verification_controller.rb
@@ -323,6 +323,10 @@ module Lexicon
       # For english_title we check key presence rather than value presence so that
       # submitting an empty string will clear the field instead of being ignored.
       entry_updates[:english_title] = params[:english_title] if params.key?(:english_title)
+      # date_of_manual_update: allow blank so editors can clear the field
+      if params.key?(:entry_date_of_manual_update)
+        entry_updates[:date_of_manual_update] = params[:entry_date_of_manual_update]&.strip.presence
+      end
 
       # Update external_identifiers if submitted: blank values are removed, nil if all blank
       if params.key?(:external_identifiers)

--- a/app/models/lex_entry.rb
+++ b/app/models/lex_entry.rb
@@ -246,6 +246,7 @@ class LexEntry < ApplicationRecord
 
       checklist['works']['items'] ||= {}
       checklist['works']['items'][work_id.to_s] ||= { 'verified' => false, 'notes' => '' }
+      auto_verify_collections!(checklist)
       progress['last_updated_at'] = Time.current.iso8601
       update!(verification_progress: progress)
     end

--- a/app/models/lex_entry.rb
+++ b/app/models/lex_entry.rb
@@ -199,92 +199,102 @@ class LexEntry < ApplicationRecord
 
   # Update a specific checklist item
   def update_checklist_item(path, verified, notes = '')
-    progress = verification_progress.deep_dup
-    checklist = progress['checklist']
+    with_lock do
+      progress = verification_progress.deep_dup
+      checklist = progress['checklist']
 
-    # Navigate to nested key and update
-    keys = path.split('.')
+      # Navigate to nested key and update
+      keys = path.split('.')
 
-    if keys.length > 1
-      # For nested paths like "works.items.123", navigate to parent and update child
-      parent_keys = keys[0..-2]
-      last_key = keys.last
+      if keys.length > 1
+        # For nested paths like "works.items.123", navigate to parent and update child
+        parent_keys = keys[0..-2]
+        last_key = keys.last
 
-      # Navigate to the parent hash, ensuring it exists
-      target = checklist
-      parent_keys.each do |key|
-        target[key] ||= {}
-        target = target[key]
+        # Navigate to the parent hash, ensuring it exists
+        target = checklist
+        parent_keys.each do |key|
+          target[key] ||= {}
+          target = target[key]
+        end
+
+        # Set the value on the target
+        target[last_key] = { 'verified' => verified, 'notes' => notes }
+      else
+        # For top-level paths like "title"
+        checklist[keys.first] = { 'verified' => verified, 'notes' => notes }
       end
 
-      # Set the value on the target
-      target[last_key] = { 'verified' => verified, 'notes' => notes }
-    else
-      # For top-level paths like "title"
-      checklist[keys.first] = { 'verified' => verified, 'notes' => notes }
+      # Auto-verify parent collections when all items are verified
+      auto_verify_collections!(checklist)
+
+      progress['last_updated_at'] = Time.current.iso8601
+      update!(verification_progress: progress)
     end
-
-    # Auto-verify parent collections when all items are verified
-    auto_verify_collections!(checklist)
-
-    progress['last_updated_at'] = Time.current.iso8601
-    update!(verification_progress: progress)
   end
 
   # Sync works collection in verification checklist when works are added/deleted
   def sync_works_checklist!
-    return unless verification_progress.present? && lex_item_type == 'LexPerson'
+    return unless lex_item_type == 'LexPerson'
 
-    progress = verification_progress.deep_dup
-    checklist = progress['checklist']
-    return unless checklist
+    with_lock do
+      return if verification_progress.blank?
 
-    # Get current works from database
-    works = lex_item&.works
-    current_work_ids = works ? works.pluck(:id).map(&:to_s) : []
-    existing_items = checklist.dig('works', 'items') || {}
+      progress = verification_progress.deep_dup
+      checklist = progress['checklist']
+      return unless checklist
 
-    # Add new works
-    current_work_ids.each do |work_id|
-      existing_items[work_id] ||= { 'verified' => false, 'notes' => '' }
+      # Get current works from database
+      works = lex_item&.works
+      current_work_ids = works ? works.pluck(:id).map(&:to_s) : []
+      existing_items = checklist.dig('works', 'items') || {}
+
+      # Add new works
+      current_work_ids.each do |work_id|
+        existing_items[work_id] ||= { 'verified' => false, 'notes' => '' }
+      end
+
+      # Remove deleted works
+      existing_items.select! { |work_id, _| current_work_ids.include?(work_id) }
+
+      checklist['works']['items'] = existing_items
+
+      # Auto-verify parent collection if all items verified
+      auto_verify_collections!(checklist)
+
+      progress['last_updated_at'] = Time.current.iso8601
+      update!(verification_progress: progress)
     end
-
-    # Remove deleted works
-    existing_items.select! { |work_id, _| current_work_ids.include?(work_id) }
-
-    checklist['works']['items'] = existing_items
-
-    # Auto-verify parent collection if all items verified
-    auto_verify_collections!(checklist)
-
-    progress['last_updated_at'] = Time.current.iso8601
-    update!(verification_progress: progress)
   end
 
   # Mark all works as verified (called when marking entire works section as verified)
   def mark_all_works_verified!(notes = '')
-    return unless verification_progress.present? && lex_item_type == 'LexPerson'
+    return unless lex_item_type == 'LexPerson'
 
-    progress = verification_progress.deep_dup
-    checklist = progress['checklist']
-    return unless checklist && checklist['works']
+    with_lock do
+      return if verification_progress.blank?
 
-    # Get all current work IDs from database
-    works = lex_item&.works
-    work_ids = works ? works.pluck(:id).map(&:to_s) : []
+      progress = verification_progress.deep_dup
+      checklist = progress['checklist']
+      return unless checklist && checklist['works']
 
-    # Mark each individual work as verified
-    work_ids.each do |work_id|
-      checklist['works']['items'] ||= {}
-      checklist['works']['items'][work_id] = { 'verified' => true, 'notes' => notes }
+      # Get all current work IDs from database
+      works = lex_item&.works
+      work_ids = works ? works.pluck(:id).map(&:to_s) : []
+
+      # Mark each individual work as verified
+      work_ids.each do |work_id|
+        checklist['works']['items'] ||= {}
+        checklist['works']['items'][work_id] = { 'verified' => true, 'notes' => notes }
+      end
+
+      # Mark the works section itself as verified
+      checklist['works']['verified'] = true
+      checklist['works']['notes'] = notes
+
+      progress['last_updated_at'] = Time.current.iso8601
+      update!(verification_progress: progress)
     end
-
-    # Mark the works section itself as verified
-    checklist['works']['verified'] = true
-    checklist['works']['notes'] = notes
-
-    progress['last_updated_at'] = Time.current.iso8601
-    update!(verification_progress: progress)
   end
 
   private

--- a/app/models/lex_entry.rb
+++ b/app/models/lex_entry.rb
@@ -233,8 +233,8 @@ class LexEntry < ApplicationRecord
     end
   end
 
-  # Sync works collection in verification checklist when works are added/deleted
-  def sync_works_checklist!
+  # Add a single work to the verification checklist (called synchronously when a work is created)
+  def add_work_to_checklist!(work_id)
     return unless lex_item_type == 'LexPerson'
 
     with_lock do
@@ -242,26 +242,28 @@ class LexEntry < ApplicationRecord
 
       progress = verification_progress.deep_dup
       checklist = progress['checklist']
-      return unless checklist
+      return unless checklist&.dig('works')
 
-      # Get current works from database
-      works = lex_item&.works
-      current_work_ids = works ? works.pluck(:id).map(&:to_s) : []
-      existing_items = checklist.dig('works', 'items') || {}
+      checklist['works']['items'] ||= {}
+      checklist['works']['items'][work_id.to_s] ||= { 'verified' => false, 'notes' => '' }
+      progress['last_updated_at'] = Time.current.iso8601
+      update!(verification_progress: progress)
+    end
+  end
 
-      # Add new works
-      current_work_ids.each do |work_id|
-        existing_items[work_id] ||= { 'verified' => false, 'notes' => '' }
-      end
+  # Remove a single work from the verification checklist (called synchronously when a work is destroyed)
+  def remove_work_from_checklist!(work_id)
+    return unless lex_item_type == 'LexPerson'
 
-      # Remove deleted works
-      existing_items.select! { |work_id, _| current_work_ids.include?(work_id) }
+    with_lock do
+      return if verification_progress.blank?
 
-      checklist['works']['items'] = existing_items
+      progress = verification_progress.deep_dup
+      checklist = progress['checklist']
+      return unless checklist&.dig('works', 'items')&.key?(work_id.to_s)
 
-      # Auto-verify parent collection if all items verified
+      checklist['works']['items'].delete(work_id.to_s)
       auto_verify_collections!(checklist)
-
       progress['last_updated_at'] = Time.current.iso8601
       update!(verification_progress: progress)
     end

--- a/app/models/lex_entry.rb
+++ b/app/models/lex_entry.rb
@@ -149,7 +149,8 @@ class LexEntry < ApplicationRecord
     verified = 0
 
     # Count top-level items (excluding collections)
-    %w(title life_years bio description toc az_navbar external_identifiers attachments).each do |key|
+    %w(title life_years bio description toc az_navbar
+       external_identifiers attachments date_of_manual_update).each do |key|
       next unless checklist[key]
 
       total += 1
@@ -373,6 +374,9 @@ class LexEntry < ApplicationRecord
 
     # Attachments
     checklist['attachments'] = { 'verified' => false, 'notes' => '' }
+
+    # Date of manual update (common to both)
+    checklist['date_of_manual_update'] = { 'verified' => false, 'notes' => '' }
 
     checklist
   end

--- a/app/services/lexicon/ingest_base.rb
+++ b/app/services/lexicon/ingest_base.rb
@@ -29,13 +29,14 @@ module Lexicon
 
     private
 
-    # Extract the "עודכן לאחרונה:" date string from the PHP footer area
+    # Extract the "עודכן לאחרונה:" date string from the PHP footer area.
+    # The label may be surrounded by brackets (e.g. "[עודכן לאחרונה: DATE]").
     def extract_date_of_manual_update(html_doc)
       html_doc.css('font[size="2"]').each do |node|
         text = node.text.strip
-        next unless text.start_with?('עודכן לאחרונה:')
+        next unless text.include?('עודכן לאחרונה:')
 
-        return text.sub('עודכן לאחרונה:', '').strip.presence
+        return text.sub(/.*עודכן לאחרונה:\s*/, '').gsub(/\]$/, '').strip.presence
       end
       nil
     end

--- a/app/services/lexicon/ingest_base.rb
+++ b/app/services/lexicon/ingest_base.rb
@@ -13,6 +13,7 @@ module Lexicon
       @lex_entry.lex_item = create_lex_item(html_doc)
       @lex_entry.english_title = extract_english_title(html_doc)
       @lex_entry.external_identifiers = extract_external_identifiers(html_doc)
+      @lex_entry.date_of_manual_update = extract_date_of_manual_update(html_doc)
       @lex_entry.status_draft!
 
       lex_file.status_ingested!
@@ -27,6 +28,17 @@ module Lexicon
     end
 
     private
+
+    # Extract the "עודכן לאחרונה:" date string from the PHP footer area
+    def extract_date_of_manual_update(html_doc)
+      html_doc.css('font[size="2"]').each do |node|
+        text = node.text.strip
+        next unless text.start_with?('עודכן לאחרונה:')
+
+        return text.sub('עודכן לאחרונה:', '').strip.presence
+      end
+      nil
+    end
 
     # Extract English title from the header table
     def extract_english_title(html_doc)

--- a/app/views/lexicon/entries/show.html.haml
+++ b/app/views/lexicon/entries/show.html.haml
@@ -5,7 +5,8 @@
   - elsif lex_item.is_a?(LexPublication)
     = render partial: 'show_publication', locals: { lex_publication: lex_item }
   .lexicon-last-updated
-    = t('lexicon.entries.show.last_updated', date: l(@lex_entry.last_content_update.to_date))
+    - date_str = @lex_entry.date_of_manual_update.presence || l(@lex_entry.last_content_update.to_date)
+    = t('lexicon.entries.show.last_updated', date: date_str)
 
 -# found mistake popup
 = render partial: 'shared/proof'

--- a/app/views/lexicon/people/_form.html.haml
+++ b/app/views/lexicon/people/_form.html.haml
@@ -3,6 +3,7 @@
   = f.simple_fields_for :entry do |ef|
     = ef.input :title
     = ef.input :other_designation
+    = ef.input :date_of_manual_update
     = ef.input :status do
       .form-control
         %span.badge.badge-primary= LexEntry.human_enum_name(:status, @lex_person.entry.status)

--- a/app/views/lexicon/publications/_form.html.haml
+++ b/app/views/lexicon/publications/_form.html.haml
@@ -3,6 +3,7 @@
   = f.simple_fields_for :entry do |ef|
     = ef.input :title
     = ef.input :other_designation
+    = ef.input :date_of_manual_update
     = ef.input :status do
       .form-control
         %span.badge.badge-primary= LexEntry.human_enum_name(:status, @lex_publication.entry.status)

--- a/app/views/lexicon/verification/_checklist.html.haml
+++ b/app/views/lexicon/verification/_checklist.html.haml
@@ -106,6 +106,14 @@
         %input{type: 'checkbox', checked: checklist['attachments']&.dig('verified'), disabled: true, data: {path: 'attachments', 'section-id': 'section-attachments'}}
         = t('lexicon.verification.checklist.person.attachments')
 
+    -# Date of Manual Update
+    %li.checklist-item
+      %label
+        -# haml-lint:disable LineLength
+        %input{ type: 'checkbox', checked: checklist['date_of_manual_update']&.dig('verified'), disabled: true, data: { path: 'date_of_manual_update', 'section-id': 'section-date-of-manual-update' } }
+        -# haml-lint:enable LineLength
+        = t('lexicon.verification.checklist.person.date_of_manual_update')
+
   .overall-notes.mt-3
     %label.form-label
       %strong= t('lexicon.verification.checklist.overall_notes')

--- a/app/views/lexicon/verification/_edit_date_of_manual_update.html.haml
+++ b/app/views/lexicon/verification/_edit_date_of_manual_update.html.haml
@@ -1,0 +1,19 @@
+-# haml-lint:disable LineLength
+= form_with url: lexicon_update_section_verification_path(@entry), method: :patch, local: false, html: { class: 'verification-edit-form' } do |f|
+  = hidden_field_tag :section, 'date_of_manual_update'
+
+  %p.text-muted= t('lexicon.verification.edit.date_of_manual_update.instructions')
+
+  .mb-3
+    = label_tag :entry_date_of_manual_update, t('activerecord.attributes.lex_entry.date_of_manual_update'), class: 'form-label'
+    = text_field_tag :entry_date_of_manual_update, @entry.date_of_manual_update, class: 'form-control'
+
+  .form-check.mt-3
+    - already_verified = @entry.verification_progress&.dig('checklist', 'date_of_manual_update', 'verified') || false
+    = check_box_tag :mark_verified, '1', already_verified, class: 'form-check-input'
+    = label_tag :mark_verified, t('lexicon.verification.edit.mark_as_verified'), class: 'form-check-label'
+
+  .modal-footer
+    %button.btn.btn-secondary{ type: 'button', data: { dismiss: 'modal' } }
+      = t('cancel')
+    = f.submit t('save'), class: 'btn btn-primary'

--- a/app/views/lexicon/verification/_person_sections.html.haml
+++ b/app/views/lexicon/verification/_person_sections.html.haml
@@ -367,11 +367,20 @@
       = t('lexicon.verification.migrated.mark_verified')
 
 -# Section 8: Date of Manual Update
-.section.verification-section{ id: 'section-date-of-manual-update' }
+.section.verification-section{ id: 'section-date-of-manual-update', class: checklist['date_of_manual_update']&.dig('verified') ? 'verified' : 'not-verified' }
   .section-header
     %h5= t('lexicon.verification.sections.date_of_manual_update_section')
+    .verification-badge{ class: checklist['date_of_manual_update']&.dig('verified') ? 'verified' : 'not-verified' }
+      = checklist['date_of_manual_update']&.dig('verified') ? '✓ ' + t('lexicon.verification.migrated.verified') : t('lexicon.verification.migrated.not_verified')
   .section-content
     - if entry.date_of_manual_update.present?
       %p= entry.date_of_manual_update
     - else
       %p.text-muted= t('lexicon.verification.sections.no_date_of_manual_update')
+  .section-actions
+    %button.btn.btn-sm.btn-outline-primary{ onclick: "openModal('#{lexicon_edit_section_verification_path(entry, section: 'date_of_manual_update')}', onSectionEditSuccess('section-date-of-manual-update'))" }
+      ✏️
+      = t('lexicon.verification.migrated.edit')
+    %button.btn.btn-sm{ class: checklist['date_of_manual_update']&.dig('verified') ? 'btn-success' : 'btn-outline-success', data: { action: 'click->verification#quickVerify', path: 'date_of_manual_update' } }
+      ✓
+      = t('lexicon.verification.migrated.mark_verified')

--- a/app/views/lexicon/verification/_person_sections.html.haml
+++ b/app/views/lexicon/verification/_person_sections.html.haml
@@ -381,3 +381,6 @@
     %button.btn.btn-sm.btn-outline-primary{ onclick: "openModal('#{lexicon_edit_section_verification_path(entry, section: 'date_of_manual_update')}', onSectionEditSuccess('section-date-of-manual-update'))" }
       ✏️
       = t('lexicon.verification.migrated.edit')
+    %button.btn.btn-sm{ class: checklist['date_of_manual_update']&.dig('verified') ? 'btn-success' : 'btn-outline-success', data: { action: 'click->verification#quickVerify', path: 'date_of_manual_update' } }
+      ✓
+      = t('lexicon.verification.migrated.mark_verified')

--- a/app/views/lexicon/verification/_person_sections.html.haml
+++ b/app/views/lexicon/verification/_person_sections.html.haml
@@ -381,6 +381,3 @@
     %button.btn.btn-sm.btn-outline-primary{ onclick: "openModal('#{lexicon_edit_section_verification_path(entry, section: 'date_of_manual_update')}', onSectionEditSuccess('section-date-of-manual-update'))" }
       ✏️
       = t('lexicon.verification.migrated.edit')
-    %button.btn.btn-sm{ class: checklist['date_of_manual_update']&.dig('verified') ? 'btn-success' : 'btn-outline-success', data: { action: 'click->verification#quickVerify', path: 'date_of_manual_update' } }
-      ✓
-      = t('lexicon.verification.migrated.mark_verified')

--- a/app/views/lexicon/verification/_person_sections.html.haml
+++ b/app/views/lexicon/verification/_person_sections.html.haml
@@ -365,3 +365,13 @@
     %button.btn.btn-sm{class: checklist['attachments']&.dig('verified') ? 'btn-success' : 'btn-outline-success', data: {action: 'click->verification#quickVerify', path: 'attachments'}}
       ✓
       = t('lexicon.verification.migrated.mark_verified')
+
+-# Section 8: Date of Manual Update
+.section.verification-section{ id: 'section-date-of-manual-update' }
+  .section-header
+    %h5= t('lexicon.verification.sections.date_of_manual_update_section')
+  .section-content
+    - if entry.date_of_manual_update.present?
+      %p= entry.date_of_manual_update
+    - else
+      %p.text-muted= t('lexicon.verification.sections.no_date_of_manual_update')

--- a/app/views/lexicon/verification/_publication_sections.html.haml
+++ b/app/views/lexicon/verification/_publication_sections.html.haml
@@ -186,6 +186,3 @@
     %button.btn.btn-sm.btn-outline-primary{ onclick: "openModal('#{lexicon_edit_section_verification_path(entry, section: 'date_of_manual_update')}', onSectionEditSuccess('section-date-of-manual-update'))" }
       ✏️
       = t('lexicon.verification.migrated.edit')
-    %button.btn.btn-sm{ class: checklist['date_of_manual_update']&.dig('verified') ? 'btn-success' : 'btn-outline-success', data: { action: 'click->verification#quickVerify', path: 'date_of_manual_update' } }
-      ✓
-      = t('lexicon.verification.migrated.mark_verified')

--- a/app/views/lexicon/verification/_publication_sections.html.haml
+++ b/app/views/lexicon/verification/_publication_sections.html.haml
@@ -172,11 +172,20 @@
       = t('lexicon.verification.migrated.mark_verified')
 
 -# Section 8: Date of Manual Update
-.section.verification-section{ id: 'section-date-of-manual-update' }
+.section.verification-section{ id: 'section-date-of-manual-update', class: checklist['date_of_manual_update']&.dig('verified') ? 'verified' : 'not-verified' }
   .section-header
     %h5= t('lexicon.verification.sections.date_of_manual_update_section')
+    .verification-badge{ class: checklist['date_of_manual_update']&.dig('verified') ? 'verified' : 'not-verified' }
+      = checklist['date_of_manual_update']&.dig('verified') ? '✓ ' + t('lexicon.verification.migrated.verified') : t('lexicon.verification.migrated.not_verified')
   .section-content
     - if entry.date_of_manual_update.present?
       %p= entry.date_of_manual_update
     - else
       %p.text-muted= t('lexicon.verification.sections.no_date_of_manual_update')
+  .section-actions
+    %button.btn.btn-sm.btn-outline-primary{ onclick: "openModal('#{lexicon_edit_section_verification_path(entry, section: 'date_of_manual_update')}', onSectionEditSuccess('section-date-of-manual-update'))" }
+      ✏️
+      = t('lexicon.verification.migrated.edit')
+    %button.btn.btn-sm{ class: checklist['date_of_manual_update']&.dig('verified') ? 'btn-success' : 'btn-outline-success', data: { action: 'click->verification#quickVerify', path: 'date_of_manual_update' } }
+      ✓
+      = t('lexicon.verification.migrated.mark_verified')

--- a/app/views/lexicon/verification/_publication_sections.html.haml
+++ b/app/views/lexicon/verification/_publication_sections.html.haml
@@ -170,3 +170,13 @@
     %button.btn.btn-sm{class: checklist['attachments']&.dig('verified') ? 'btn-success' : 'btn-outline-success', data: {action: 'click->verification#quickVerify', path: 'attachments'}}
       ✓
       = t('lexicon.verification.migrated.mark_verified')
+
+-# Section 8: Date of Manual Update
+.section.verification-section{ id: 'section-date-of-manual-update' }
+  .section-header
+    %h5= t('lexicon.verification.sections.date_of_manual_update_section')
+  .section-content
+    - if entry.date_of_manual_update.present?
+      %p= entry.date_of_manual_update
+    - else
+      %p.text-muted= t('lexicon.verification.sections.no_date_of_manual_update')

--- a/app/views/lexicon/verification/_publication_sections.html.haml
+++ b/app/views/lexicon/verification/_publication_sections.html.haml
@@ -186,3 +186,6 @@
     %button.btn.btn-sm.btn-outline-primary{ onclick: "openModal('#{lexicon_edit_section_verification_path(entry, section: 'date_of_manual_update')}', onSectionEditSuccess('section-date-of-manual-update'))" }
       ✏️
       = t('lexicon.verification.migrated.edit')
+    %button.btn.btn-sm{ class: checklist['date_of_manual_update']&.dig('verified') ? 'btn-success' : 'btn-outline-success', data: { action: 'click->verification#quickVerify', path: 'date_of_manual_update' } }
+      ✓
+      = t('lexicon.verification.migrated.mark_verified')

--- a/config/locales/active_record.en.yml
+++ b/config/locales/active_record.en.yml
@@ -146,6 +146,7 @@ en:
         title: Title
         english_title: English Title
         other_designation: Other Designation
+        date_of_manual_update: Date of Last Manual Update
         statuses:
           draft: Draft
           deprecated: Deprecated

--- a/config/locales/active_record.he.yml
+++ b/config/locales/active_record.he.yml
@@ -152,6 +152,7 @@ he:
         title: כותרת
         english_title: English title
         other_designation: כינויים אחרים
+        date_of_manual_update: תאריך עדכון ידני אחרון
         statuses:
           draft: טיוטה
           deprecated: מבוטל

--- a/config/locales/lexicon.en.yml
+++ b/config/locales/lexicon.en.yml
@@ -210,6 +210,7 @@ en:
           links: Links
           attachments: Attachments
           external_identifiers: Authority Control Identifiers
+          date_of_manual_update: Date of Last Manual Update
         publication:
           title: Title
           description: Description
@@ -218,6 +219,7 @@ en:
           links: Links
           attachments: Attachments
           external_identifiers: Authority Control Identifiers
+          date_of_manual_update: Date of Last Manual Update
       source:
         header: Source File
         file_not_found: "⚠️ Source file not found"
@@ -325,6 +327,8 @@ en:
         confirm_match: Confirm match
         reject_match: Reject match
         proposed_collection: "(proposed: %{title})"
+        date_of_manual_update:
+          instructions: "Enter the date of the last manual update as it appears in the source file. You may correct it if it was parsed incorrectly."
         external_identifiers:
           instructions: "Enter identifier values for authority control systems. Leave a field blank to remove that identifier."
           leave_blank_to_remove: "Leave blank to remove"

--- a/config/locales/lexicon.en.yml
+++ b/config/locales/lexicon.en.yml
@@ -250,6 +250,8 @@ en:
         no_citations: "(No citations)"
         no_links: "(No links)"
         no_attachments: "(No attachments)"
+        date_of_manual_update_section: Date of Last Manual Update
+        no_date_of_manual_update: "(No manual update date)"
         no_description: "(No description)"
         no_toc: "(No table of contents)"
         no_az_navbar: "(No A-Z navigation)"

--- a/config/locales/lexicon.he.yml
+++ b/config/locales/lexicon.he.yml
@@ -250,6 +250,8 @@ he:
         no_citations: "(אין מראי מקום)"
         no_links: "(אין קישוריוֹת)"
         no_attachments: "(אין קבצים מצורפים)"
+        date_of_manual_update_section: תאריך עדכון ידני אחרון
+        no_date_of_manual_update: "(אין תאריך עדכון ידני)"
         no_description: "(אין תיאור)"
         no_toc: "(אין תוכן עניינים)"
         no_az_navbar: "(אין ניווט א-ב)"

--- a/config/locales/lexicon.he.yml
+++ b/config/locales/lexicon.he.yml
@@ -210,6 +210,7 @@ he:
           links: קישוריוֹת
           attachments: קבצים מצורפים
           external_identifiers: מזהים חיצוניים
+          date_of_manual_update: תאריך עדכון ידני אחרון
         publication:
           title: כותרת
           description: תיאור
@@ -218,6 +219,7 @@ he:
           links: קישוריוֹת
           attachments: קבצים מצורפים
           external_identifiers: מזהים חיצוניים
+          date_of_manual_update: תאריך עדכון ידני אחרון
       source:
         header: קובץ מקור
         file_not_found: "⚠️ קובץ מקור לא נמצא"
@@ -325,6 +327,8 @@ he:
         confirm_match: אשר התאמה
         reject_match: דחה התאמה
         proposed_collection: "(הצעה: %{title})"
+        date_of_manual_update:
+          instructions: "הכנס את תאריך העדכון הידני האחרון כפי שמופיע בקובץ המקור. ניתן לתקן אם נקלט בצורה שגויה."
         external_identifiers:
           instructions: "הכנס ערכי מזהה עבור מערכות בקרת סמכות. השאר שדה ריק כדי להסיר את המזהה."
           leave_blank_to_remove: "השאר ריק כדי להסיר"

--- a/db/migrate/20260622233652_add_date_of_manual_update_to_lex_entries.rb
+++ b/db/migrate/20260622233652_add_date_of_manual_update_to_lex_entries.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddDateOfManualUpdateToLexEntries < ActiveRecord::Migration[8.1]
+  def change
+    add_column :lex_entries, :date_of_manual_update, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_12_000000) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_22_233652) do
   create_table "aboutnesses", id: :integer, charset: "utf8mb4", collation: "utf8mb4_bin", force: :cascade do |t|
     t.integer "aboutable_id"
     t.string "aboutable_type"
@@ -590,6 +590,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_12_000000) do
     t.index ["originating_task"], name: "index_ingestibles_on_originating_task"
     t.index ["project_id"], name: "index_ingestibles_on_project_id"
     t.index ["status"], name: "index_ingestibles_on_status"
+    t.index ["tasks_project_id"], name: "index_ingestibles_on_tasks_project_id"
     t.index ["title"], name: "index_ingestibles_on_title"
     t.index ["user_id"], name: "index_ingestibles_on_user_id"
     t.index ["volume_id"], name: "index_ingestibles_on_volume_id"
@@ -668,6 +669,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_12_000000) do
 
   create_table "lex_entries", charset: "utf8mb4", collation: "utf8mb4_bin", force: :cascade do |t|
     t.datetime "created_at", precision: nil, null: false
+    t.string "date_of_manual_update"
     t.string "english_title"
     t.json "external_identifiers"
     t.integer "last_editor_id"
@@ -727,7 +729,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_12_000000) do
     t.string "new_path", null: false
     t.string "old_path", null: false
     t.index ["lex_entry_id"], name: "index_lex_legacy_links_on_lex_entry_id"
-    t.index ["old_path"], name: "index_lex_legacy_links_on_old_path", unique: true
+    t.index ["old_path"], name: "index_lex_legacy_links_on_old_path"
   end
 
   create_table "lex_linked_people", charset: "utf8mb4", collation: "utf8mb4_bin", force: :cascade do |t|
@@ -917,6 +919,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_12_000000) do
     t.date "start_date"
     t.integer "tasks_project_id"
     t.datetime "updated_at", null: false
+    t.index ["tasks_project_id"], name: "index_projects_on_tasks_project_id", unique: true
   end
 
   create_table "proofs", id: :integer, charset: "utf8mb4", collation: "utf8mb4_bin", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -729,7 +729,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_22_233652) do
     t.string "new_path", null: false
     t.string "old_path", null: false
     t.index ["lex_entry_id"], name: "index_lex_legacy_links_on_lex_entry_id"
-    t.index ["old_path"], name: "index_lex_legacy_links_on_old_path"
+    t.index ["old_path"], name: "index_lex_legacy_links_on_old_path", unique: true
   end
 
   create_table "lex_linked_people", charset: "utf8mb4", collation: "utf8mb4_bin", force: :cascade do |t|

--- a/spec/fixtures/files/lexicon/bracketed_date.php
+++ b/spec/fixtures/files/lexicon/bracketed_date.php
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>test person bracketed date</title>
+</head>
+<body dir="rtl">
+<table border="0" width="100%">
+  <tr>
+    <td><p align="center"><font size="5" color="#FF0000">ישראלי, ישראל</font><font size="4" color="#FF0000">(1920-2000)</font></p></td>
+  </tr>
+</table>
+<p>פרטים ביוגרפיים.</p>
+<font size="4" color="#0000FF"><a name="links">קישורים:</a></font>
+<ul></ul>
+[<font size="2">עודכן לאחרונה: 15 במרץ 2024</font>]
+</body>
+</html>

--- a/spec/models/lex_entry_spec.rb
+++ b/spec/models/lex_entry_spec.rb
@@ -124,6 +124,27 @@ RSpec.describe LexEntry, type: :model do
           expect(entry.verification_progress.dig('checklist', 'works', 'verified')).to be true
         end
       end
+
+      context 'when called on a stale instance after a concurrent update_checklist_item' do
+        it 'does not overwrite the committed change (with_lock prevents lost update)' do
+          # Load stale_entry BEFORE update_checklist_item commits (simulates
+          # PersonWorksController reading the entry on an overlapping request)
+          stale_entry = described_class.find(entry.id)
+          expect(stale_entry.verification_progress.dig('checklist', 'date_of_manual_update', 'verified')).to be false
+
+          # quickVerify commits true to DB
+          entry.update_checklist_item('date_of_manual_update', true)
+
+          # stale_entry still has the old in-memory value
+          expect(stale_entry.verification_progress.dig('checklist', 'date_of_manual_update', 'verified')).to be false
+
+          # PersonWorksController after_action fires on the stale instance
+          stale_entry.sync_works_checklist!
+
+          # with_lock must have reloaded fresh data, so true must survive
+          expect(entry.reload.verification_progress.dig('checklist', 'date_of_manual_update', 'verified')).to be true
+        end
+      end
     end
 
     describe '#verification_percentage' do

--- a/spec/models/lex_entry_spec.rb
+++ b/spec/models/lex_entry_spec.rb
@@ -62,88 +62,81 @@ RSpec.describe LexEntry, type: :model do
       end
     end
 
-    describe '#sync_works_checklist!' do
+    describe '#add_work_to_checklist!' do
       before do
         entry.start_verification!('test@example.com')
       end
 
-      context 'when works are added' do
-        it 'adds new works to the checklist' do
-          initial_items = entry.verification_progress.dig('checklist', 'works', 'items')
-          expect(initial_items).to eq({})
+      it 'adds the work ID to checklist items' do
+        work = create(:lex_person_work, person: person, title: 'New Work')
+        entry.add_work_to_checklist!(work.id)
 
-          work = create(:lex_person_work, person: person, title: 'New Work')
-          entry.sync_works_checklist!
-
-          updated_items = entry.verification_progress.dig('checklist', 'works', 'items')
-          expect(updated_items.size).to eq(1)
-          expect(updated_items[work.id.to_s]).to eq({ 'verified' => false, 'notes' => '' })
-        end
+        items = entry.reload.verification_progress.dig('checklist', 'works', 'items')
+        expect(items[work.id.to_s]).to eq({ 'verified' => false, 'notes' => '' })
       end
 
-      context 'when works are deleted' do
-        let!(:work1) { create(:lex_person_work, person: person, title: 'Work 1') }
-        let!(:work2) { create(:lex_person_work, person: person, title: 'Work 2') }
+      it 'is idempotent when work already exists in checklist' do
+        work = create(:lex_person_work, person: person, title: 'Existing Work')
+        entry.add_work_to_checklist!(work.id)
+        entry.update_checklist_item("works.items.#{work.id}", true)
+        entry.add_work_to_checklist!(work.id)
 
-        before do
-          entry.sync_works_checklist!
-        end
-
-        it 'removes deleted works from the checklist' do
-          expect(entry.verification_progress.dig('checklist', 'works', 'items').size).to eq(2)
-
-          work1.destroy!
-          entry.reload.sync_works_checklist!
-
-          updated_items = entry.verification_progress.dig('checklist', 'works', 'items')
-          expect(updated_items.size).to eq(1)
-          expect(updated_items[work2.id.to_s]).to be_present
-          expect(updated_items[work1.id.to_s]).to be_nil
-        end
+        items = entry.reload.verification_progress.dig('checklist', 'works', 'items')
+        expect(items[work.id.to_s]['verified']).to be true
       end
 
-      context 'when works are verified and then deleted' do
-        let!(:work1) { create(:lex_person_work, person: person, title: 'Work 1') }
-        let!(:work2) { create(:lex_person_work, person: person, title: 'Work 2') }
-
-        before do
-          entry.sync_works_checklist!
-          entry.update_checklist_item("works.items.#{work1.id}", true, '')
-          entry.update_checklist_item("works.items.#{work2.id}", true, '')
-        end
-
-        it 'auto-verifies collection when all works verified' do
-          expect(entry.verification_progress.dig('checklist', 'works', 'verified')).to be true
-        end
-
-        it 'removes auto-verification when a verified work is deleted' do
-          work1.destroy!
-          entry.sync_works_checklist!
-
-          # Collection should still be verified if all remaining items are verified
-          expect(entry.verification_progress.dig('checklist', 'works', 'verified')).to be true
-        end
+      it 'does nothing when verification_progress is blank' do
+        entry.update_column(:verification_progress, nil)
+        work = create(:lex_person_work, person: person, title: 'New Work')
+        expect { entry.add_work_to_checklist!(work.id) }.not_to raise_error
       end
 
       context 'when called on a stale instance after a concurrent update_checklist_item' do
         it 'does not overwrite the committed change (with_lock prevents lost update)' do
-          # Load stale_entry BEFORE update_checklist_item commits (simulates
-          # PersonWorksController reading the entry on an overlapping request)
           stale_entry = described_class.find(entry.id)
-          expect(stale_entry.verification_progress.dig('checklist', 'date_of_manual_update', 'verified')).to be false
 
-          # quickVerify commits true to DB
           entry.update_checklist_item('date_of_manual_update', true)
 
-          # stale_entry still has the old in-memory value
           expect(stale_entry.verification_progress.dig('checklist', 'date_of_manual_update', 'verified')).to be false
 
-          # PersonWorksController after_action fires on the stale instance
-          stale_entry.sync_works_checklist!
+          work = create(:lex_person_work, person: person, title: 'New Work')
+          stale_entry.add_work_to_checklist!(work.id)
 
-          # with_lock must have reloaded fresh data, so true must survive
           expect(entry.reload.verification_progress.dig('checklist', 'date_of_manual_update', 'verified')).to be true
         end
+      end
+    end
+
+    describe '#remove_work_from_checklist!' do
+      let!(:work1) { create(:lex_person_work, person: person, title: 'Work 1') }
+      let!(:work2) { create(:lex_person_work, person: person, title: 'Work 2') }
+
+      before do
+        person.reload
+        entry.start_verification!('test@example.com')
+      end
+
+      it 'removes the work ID from checklist items' do
+        work1.destroy!
+        entry.remove_work_from_checklist!(work1.id)
+
+        items = entry.reload.verification_progress.dig('checklist', 'works', 'items')
+        expect(items[work1.id.to_s]).to be_nil
+        expect(items[work2.id.to_s]).to be_present
+      end
+
+      it 'does nothing when the work ID is not in the checklist' do
+        expect { entry.remove_work_from_checklist!(999_999) }.not_to raise_error
+      end
+
+      it 'auto-verifies collection when all remaining works are verified' do
+        entry.update_checklist_item("works.items.#{work1.id}", true)
+        entry.update_checklist_item("works.items.#{work2.id}", true)
+
+        work1.destroy!
+        entry.remove_work_from_checklist!(work1.id)
+
+        expect(entry.reload.verification_progress.dig('checklist', 'works', 'verified')).to be true
       end
     end
 

--- a/spec/requests/lexicon/verification_spec.rb
+++ b/spec/requests/lexicon/verification_spec.rb
@@ -66,6 +66,49 @@ RSpec.describe 'Lexicon::Verification', type: :request do
     end
   end
 
+  describe 'PATCH /lex/verification/:id/update_section – date_of_manual_update' do
+    let(:entry) do
+      e = create(:lex_entry, :person, status: :verifying, date_of_manual_update: '12 בינואר 2024')
+      e.start_verification!('editor@example.com')
+      e
+    end
+    let(:url) { "/lex/verification/#{entry.id}/update_section" }
+
+    it 'saves the updated date_of_manual_update value' do
+      patch url,
+            params: { section: 'date_of_manual_update',
+                      entry_date_of_manual_update: '15 במרץ 2024' },
+            as: :json
+
+      expect(response).to have_http_status(:success)
+      entry.reload
+      expect(entry.date_of_manual_update).to eq('15 במרץ 2024')
+    end
+
+    it 'clears date_of_manual_update when blank value is submitted' do
+      patch url,
+            params: { section: 'date_of_manual_update',
+                      entry_date_of_manual_update: '' },
+            as: :json
+
+      expect(response).to have_http_status(:success)
+      entry.reload
+      expect(entry.date_of_manual_update).to be_nil
+    end
+
+    it 'marks the section verified when mark_verified is set' do
+      patch url,
+            params: { section: 'date_of_manual_update',
+                      entry_date_of_manual_update: '12 בינואר 2024',
+                      mark_verified: '1' },
+            as: :json
+
+      expect(response).to have_http_status(:success)
+      entry.reload
+      expect(entry.verification_progress.dig('checklist', 'date_of_manual_update', 'verified')).to be true
+    end
+  end
+
   describe 'PATCH /lex/verification/:id/update_checklist' do
     context 'when verifying the title section for a LexPerson' do
       let(:entry) do
@@ -103,11 +146,31 @@ RSpec.describe 'Lexicon::Verification', type: :request do
         patch url, params: { path: 'bio', verified: 'true' }, as: :json
         patch url, params: { path: 'external_identifiers', verified: 'true' }, as: :json
         patch url, params: { path: 'attachments', verified: 'true' }, as: :json
+        patch url, params: { path: 'date_of_manual_update', verified: 'true' }, as: :json
 
         # Verify all collection items (citations, links, works are empty for this entry)
         entry.reload
         expect(entry.verification_percentage).to eq(100)
         expect(entry.verification_complete?).to be true
+      end
+
+      it 'persists date_of_manual_update verification to the database' do
+        patch url, params: { path: 'date_of_manual_update', verified: 'true' }, as: :json
+
+        expect(response).to have_http_status(:success)
+        expect(response.parsed_body['success']).to be true
+        entry.reload
+        expect(entry.verification_progress.dig('checklist', 'date_of_manual_update', 'verified')).to be true
+      end
+
+      it 'unverifies date_of_manual_update when verified: false is sent' do
+        entry.update_checklist_item('date_of_manual_update', true)
+
+        patch url, params: { path: 'date_of_manual_update', verified: 'false' }, as: :json
+
+        expect(response).to have_http_status(:success)
+        entry.reload
+        expect(entry.verification_progress.dig('checklist', 'date_of_manual_update', 'verified')).to be false
       end
     end
   end

--- a/spec/requests/lexicon/verification_spec.rb
+++ b/spec/requests/lexicon/verification_spec.rb
@@ -577,7 +577,10 @@ RSpec.describe 'Lexicon::Verification', type: :request do
     let!(:work1) { create(:lex_person_work, person: person, title: 'First Work', work_type: 'original', seqno: 1) }
     let!(:work2) { create(:lex_person_work, person: person, title: 'Second Work', work_type: 'original', seqno: 2) }
 
-    before { entry.sync_works_checklist! }
+    before do
+      entry.add_work_to_checklist!(work1.id)
+      entry.add_work_to_checklist!(work2.id)
+    end
 
     it 'renders individual work cards instead of a single works section' do
       get "/lex/verification/#{entry.id}"

--- a/spec/services/lexicon/ingest_person_spec.rb
+++ b/spec/services/lexicon/ingest_person_spec.rb
@@ -355,4 +355,23 @@ describe Lexicon::IngestPerson do
       end.not_to(change(ActiveStorage::Attachment, :count))
     end
   end
+
+  context 'when the date of manual update is wrapped in square brackets' do
+    let!(:file) do
+      create(
+        :lex_file,
+        {
+          entrytype: :person,
+          status: :classified,
+          title: 'ישראלי, ישראל',
+          fname: 'bracketed_date.php',
+          full_path: Rails.root.join('spec/fixtures/files/lexicon/bracketed_date.php')
+        }
+      )
+    end
+
+    it 'extracts the date without the brackets' do
+      expect(call.date_of_manual_update).to eq('15 במרץ 2024')
+    end
+  end
 end

--- a/spec/services/lexicon/ingest_person_spec.rb
+++ b/spec/services/lexicon/ingest_person_spec.rb
@@ -48,6 +48,7 @@ describe Lexicon::IngestPerson do
         'viaf' => '22255259'
       )
       expect(entry.external_identifiers).not_to have_key('j9u')
+      expect(entry.date_of_manual_update).to eq('12 ביולי 2023')
     end
   end
 
@@ -308,6 +309,7 @@ describe Lexicon::IngestPerson do
           'wikidata' => 'Q12409731'
         }
       )
+      expect(entry.date_of_manual_update).to eq('24 באפריל 2025')
     end
   end
 


### PR DESCRIPTION
## Summary

- Adds `date_of_manual_update` field to `LexEntry` (migration, model, verification sections for both person and publication entries)
- Adds quickVerify button for `date_of_manual_update` on all relevant verification workbench sections
- **Replaces async/racy checklist sync with synchronous targeted updates**: removes `PersonWorksController`'s `after_action :sync_verification_checklist` (which ran `sync_works_checklist!` — a full read-modify-write that could overwrite concurrent quickVerify changes). Instead, `create` and `destroy` now call `add_work_to_checklist!` / `remove_work_from_checklist!` inline — each targeting only the specific work's checklist entry under `with_lock`
- Protects all checklist update methods with `with_lock` to prevent lost-update races

## Test plan

- [x] Model specs: `add_work_to_checklist!`, `remove_work_from_checklist!`, `update_checklist_item`, `mark_all_works_verified!`, `verification_percentage`
- [x] Regression test: concurrent `update_checklist_item` + `add_work_to_checklist!` on stale instance does not overwrite committed change
- [x] Request specs: verification workbench renders per-work cards, verify buttons, correct checklist paths
- [x] Full suite: 388 examples, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)