### PR TITLE
Substitute img alt text (or filename fallback) in link descriptions during migration

### DIFF
--- a/app/services/lexicon/ingest_person.rb
+++ b/app/services/lexicon/ingest_person.rb
@@ -8,6 +8,21 @@ module Lexicon
     WORKS_HEADER = 'Books'
     CITATIONS_HEADER = 'Bib.'
 
+    # Maps 00000_files logo filenames to Hebrew site names for img tags that lack alt text.
+    IMG_LOGO_TEXT = {
+      'Ben-Yehuda-s.jpg' => 'פרויקט בן יהודה',
+      'dafdaf.gif' => 'דפדף',
+      'icast-free.png' => 'icast',
+      'icast-logo.png' => 'icast',
+      'icast-od.jpg' => 'icast',
+      'nli.png' => 'הספרייה הלאומית',
+      'onesh.jpg' => 'עונג שבת',
+      'pdf_icon.gif' => 'PDF',
+      'text.gif' => 'טקסט',
+      'ynet.gif' => 'Ynet',
+      'youtube.jpg' => 'YouTube'
+    }.freeze
+
     def call(lex_file)
       raw = File.read(lex_file.full_path, encoding: 'UTF-8')
       @female = raw.include?('על המחברת ויצירתה')
@@ -145,9 +160,20 @@ module Lexicon
 
         person.links.build(
           url: ::Regexp.last_match(2),
-          description: "#{html2txt(::Regexp.last_match(1))} #{html2txt(::Regexp.last_match(3))} " \
-                       "#{html2txt(::Regexp.last_match(4))}"
+          description: "#{html2txt(img_to_text(::Regexp.last_match(1)))} " \
+                       "#{html2txt(img_to_text(::Regexp.last_match(3)))} " \
+                       "#{html2txt(img_to_text(::Regexp.last_match(4)))}"
         )
+      end
+    end
+
+    def img_to_text(html)
+      html.gsub(/<img\b[^>]*>/i) do |img_tag|
+        alt = img_tag[/\balt="([^"]*)"/i, 1].to_s.strip
+        next alt if alt.present?
+
+        filename = File.basename(img_tag[/\bsrc="([^"]*)"/i, 1].to_s)
+        IMG_LOGO_TEXT[filename].to_s
       end
     end
   end

--- a/spec/fixtures/files/lexicon/links_with_img.php
+++ b/spec/fixtures/files/lexicon/links_with_img.php
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>test person with img tags in links</title>
+</head>
+<body dir="rtl">
+<table border="0" width="100%">
+  <tr>
+    <td><p align="center"><font size="5" color="#FF0000">ישראלי, ישראל</font><font size="4" color="#FF0000">(1970)</font></p></td>
+  </tr>
+</table>
+<p>פרטים ביוגרפיים.</p>
+<p><font size="4" color="#0000FF"><a name="Books">ספריו:</a></font></p>
+<ul>
+  <li>ספר לדוגמה (תל אביב : הוצאה לדוגמה, 1990)</li>
+</ul>
+<p><font size="4" color="#0000FF"><a name="Bib.">על המחבר ויצירתו:</a></font></p>
+<p>לא נמצאו מקורות.</p>
+<font size="4" color="#0000FF"><a name="links">קישורים:</a></font>
+<ul>
+  <li><i><a target="_blank" href="http://www.text.org.il/index.php?book=123">כותרת הספר</a></i> באתר <img border="0" src="00000_files/text.gif" width="50" height="28" alt="טקסט"></li>
+  <li><i><a target="_blank" href="http://www.text.org.il/index.php?book=456">ספר אחר</a></i> באתר <img border="0" src="00000_files/text.gif" width="50" height="28"></li>
+  <li><i><a target="_blank" href="http://example.com/article">כתבה כלשהי</a></i> <img border="0" src="00000_files/unknown-logo.gif" width="50" height="28"></li>
+</ul>
+</body>
+</html>

--- a/spec/services/lexicon/ingest_person_spec.rb
+++ b/spec/services/lexicon/ingest_person_spec.rb
@@ -387,7 +387,7 @@ describe Lexicon::IngestPerson do
       # img with no alt and unknown filename → no logo text appended
       unknown_link = descriptions.find { |d| d.include?('כתבה כלשהי') }
       expect(unknown_link).to be_present
-      expect(unknown_link).not_to match(/[^\s]{5,}$/) # no unexpected trailing token
+      expect(unknown_link.strip).to eq('כתבה כלשהי')
     end
   end
 

--- a/spec/services/lexicon/ingest_person_spec.rb
+++ b/spec/services/lexicon/ingest_person_spec.rb
@@ -356,6 +356,41 @@ describe Lexicon::IngestPerson do
     end
   end
 
+  context 'when link descriptions contain img tags' do
+    let!(:file) do
+      create(
+        :lex_file,
+        {
+          entrytype: :person,
+          status: :classified,
+          title: 'ישראלי, ישראל',
+          fname: 'links_with_img.php',
+          full_path: Rails.root.join('spec/fixtures/files/lexicon/links_with_img.php')
+        }
+      )
+    end
+
+    it 'substitutes img with alt text when present, falls back to filename lookup, and omits unknown logos' do
+      expect { call }.to change(LexPerson, :count).by(1)
+
+      person = file.lex_entry.lex_item
+      expect(person.links.count).to eq(3)
+
+      descriptions = person.links.map(&:description)
+
+      # img with alt="טקסט" → alt text is used
+      expect(descriptions).to include(a_string_including('כותרת הספר', 'באתר', 'טקסט'))
+
+      # img with no alt but filename text.gif → lookup resolves to טקסט
+      expect(descriptions).to include(a_string_including('ספר אחר', 'באתר', 'טקסט'))
+
+      # img with no alt and unknown filename → no logo text appended
+      unknown_link = descriptions.find { |d| d.include?('כתבה כלשהי') }
+      expect(unknown_link).to be_present
+      expect(unknown_link).not_to match(/[^\s]{5,}$/) # no unexpected trailing token
+    end
+  end
+
   context 'when the date of manual update is wrapped in square brackets' do
     let!(:file) do
       create(


### PR DESCRIPTION
## Summary

- `parse_person_links` in `IngestPerson` was calling `html2txt` directly on HTML fragments that could contain `<img>` tags (site logos). `strip_tags` discarded the images entirely, truncating descriptions like "אגמים באתר" instead of "אגמים באתר טקסט".
- Added private `img_to_text(html)` that replaces each `<img>` with its `alt` attribute value. When `alt` is absent, it falls back to the `IMG_LOGO_TEXT` lookup table (keyed on the logo filename, e.g. `text.gif → טקסט`).
- The method is applied to all three captured groups before `html2txt` is called.
- `IMG_LOGO_TEXT` covers all 11 logo filenames found to appear in links sections without alt text across the lexicon corpus.

## Test plan

- [x] New spec context: `links_with_img.php` fixture exercises all three cases: img with alt, img without alt (in lookup table), img without alt and not in lookup (→ no token appended)
- [x] All 14 examples in `ingest_person_spec.rb` pass
- [x] RuboCop clean

Closes beads_by-u6i