### PR TITLE
Show locked-by-me/others/other sections in verification queue

### DIFF
--- a/app/controllers/lexicon/verification_controller.rb
+++ b/app/controllers/lexicon/verification_controller.rb
@@ -16,18 +16,19 @@ module Lexicon
 
     # GET /lexicon/verification/queue
     def index
-      @entries = LexEntry.needs_verification
-                         .includes(:lex_item, :lex_file)
-                         .order(updated_at: :desc)
-                         .page(params[:page])
+      scope = LexEntry.needs_verification.includes(:lex_item, :lex_file)
 
-      # Filter by status if provided
-      @entries = @entries.where(status: params[:status]) if params[:status].present?
+      scope = scope.where(status: params[:status]) if params[:status].present?
+      scope = scope.where(lex_item_type: params[:type]) if params[:type].present?
 
-      # Filter by type if provided
-      return if params[:type].blank?
+      locked_scope = scope.where('locked_at > ?', LexEntry::LOCK_TIMEOUT_IN_SECONDS.seconds.ago)
+                          .includes(:locked_by_user)
+      @my_locked_entries = locked_scope.where(locked_by_user_id: current_user.id).order(updated_at: :desc)
+      @locked_by_others_entries = locked_scope.where.not(locked_by_user_id: current_user.id).order(updated_at: :desc)
 
-      @entries = @entries.where(lex_item_type: params[:type])
+      @entries = scope.where.not(id: locked_scope.select(:id))
+                      .order(updated_at: :desc)
+                      .page(params[:page])
     end
 
     # GET /lexicon/verification/:id

--- a/app/views/lexicon/verification/_queue_table.html.haml
+++ b/app/views/lexicon/verification/_queue_table.html.haml
@@ -1,0 +1,47 @@
+%table.table.table-striped.verification-queue-table
+  %thead
+    %tr
+      %th= t('lexicon.verification.queue.columns.title')
+      %th= t('lexicon.verification.queue.columns.type')
+      %th= t('lexicon.verification.queue.columns.status')
+      %th= t('lexicon.verification.queue.columns.progress')
+      %th= t('lexicon.verification.queue.columns.last_updated')
+      %th= t('lexicon.verification.queue.columns.actions')
+  %tbody
+    - entries.each do |entry|
+      %tr{ class: "status-#{entry.status}" }
+        %td= entry.title
+        - type_filter_key = { 'LexPerson' => 'person', 'LexPublication' => 'publication' }[entry.lex_item_type]
+        %td
+          - if type_filter_key
+            = t("lexicon.verification.queue.filters.#{type_filter_key}")
+          - else
+            = entry.lex_item_type&.demodulize.presence || t('unknown')
+        %td
+          %span.badge{ class: badge_class_for_status(entry.status) }
+            = t("lexicon.verification.queue.filters.#{entry.status}", default: entry.status.humanize)
+        %td
+          - if entry.status_verifying? || entry.status_verified? || entry.status_escalated?
+            - percentage = entry.verification_percentage
+            .progress{ style: 'width: 150px; height: 20px;' }
+              .progress-bar{ role: 'progressbar', style: "width: #{percentage}%", 'aria-valuenow': percentage, 'aria-valuemin': '0', 'aria-valuemax': '100' }
+                #{percentage}%
+          - else
+            %span.text-muted 0%
+        %td
+          = t('lexicon.verification.queue.time_updated', time: time_ago_in_words(entry.updated_at))
+        %td
+          - if entry.locked? && entry.locked_by_user != current_user
+            .label.label-warning= entry.locked_by_human
+            %span.text-sm-left.text-muted= entry.locked_at_human
+          - else
+            - if entry.status_verifying? || entry.status_escalated?
+              = link_to t('lexicon.verification.queue.actions.continue'), lexicon_verification_path(entry),
+                        class: 'btn btn-sm btn-primary'
+            - else
+              = link_to t('lexicon.verification.queue.actions.start'), lexicon_verification_path(entry),
+                        class: 'btn btn-sm btn-success'
+            - if entry.redo_migration_eligible?
+              = link_to t('lexicon.files.redo_migrate.title'), redo_migration_lexicon_file_path(entry.lex_file),
+                        remote: true, method: :post, class: 'btn btn-sm btn-outline-warning ms-1',
+                        data: { confirm: t('lexicon.files.redo_migrate.confirm') }

--- a/app/views/lexicon/verification/index.html.haml
+++ b/app/views/lexicon/verification/index.html.haml
@@ -14,54 +14,16 @@
 
     = submit_tag t('lexicon.entries.index.filter'), class: 'btn btn-sm btn-primary'
 
-%table.table.table-striped.verification-queue-table
-  %thead
-    %tr
-      %th= t('lexicon.verification.queue.columns.title')
-      %th= t('lexicon.verification.queue.columns.type')
-      %th= t('lexicon.verification.queue.columns.status')
-      %th= t('lexicon.verification.queue.columns.progress')
-      %th= t('lexicon.verification.queue.columns.last_updated')
-      %th= t('lexicon.verification.queue.columns.actions')
-  %tbody
-    - @entries.each do |entry|
-      %tr{class: "status-#{entry.status}"}
-        %td= entry.title
-        - type_filter_key = { 'LexPerson' => 'person', 'LexPublication' => 'publication' }[entry.lex_item_type]
-        %td
-          - if type_filter_key
-            = t("lexicon.verification.queue.filters.#{type_filter_key}")
-          - else
-            = entry.lex_item_type&.demodulize.presence || t('unknown')
-        %td
-          %span.badge{class: badge_class_for_status(entry.status)}
-            = t("lexicon.verification.queue.filters.#{entry.status}", default: entry.status.humanize)
-        %td
-          - if entry.status_verifying? || entry.status_verified? || entry.status_escalated?
-            - percentage = entry.verification_percentage
-            .progress{style: 'width: 150px; height: 20px;'}
-              .progress-bar{role: 'progressbar', style: "width: #{percentage}%", 'aria-valuenow': percentage, 'aria-valuemin': '0', 'aria-valuemax': '100'}
-                = "#{percentage}%"
-          - else
-            %span.text-muted 0%
-        %td
-          = t('lexicon.verification.queue.time_updated', time: time_ago_in_words(entry.updated_at))
-        %td
-          - if entry.locked? && entry.locked_by_user != current_user
-            -# locked by another user
-            .label.label-warning= entry.locked_by_human
-            %span.text-sm-left.text-muted= entry.locked_at_human
-          - else
-            - if entry.status_verifying? || entry.status_escalated?
-              = link_to t('lexicon.verification.queue.actions.continue'), lexicon_verification_path(entry),
-                        class: 'btn btn-sm btn-primary'
-            - else
-              = link_to t('lexicon.verification.queue.actions.start'), lexicon_verification_path(entry),
-                        class: 'btn btn-sm btn-success'
-            - if entry.redo_migration_eligible?
-              = link_to t('lexicon.files.redo_migrate.title'), redo_migration_lexicon_file_path(entry.lex_file),
-                        remote: true, method: :post, class: 'btn btn-sm btn-outline-warning ms-1',
-                        data: { confirm: t('lexicon.files.redo_migrate.confirm') }
+- if @my_locked_entries.any?
+  %h3= t('lexicon.verification.queue.my_locked_title')
+  = render partial: 'queue_table', locals: { entries: @my_locked_entries }
+
+- if @locked_by_others_entries.any?
+  %h3= t('lexicon.verification.queue.locked_by_others_title')
+  = render partial: 'queue_table', locals: { entries: @locked_by_others_entries }
+
+%h3= t('lexicon.verification.queue.other_title')
+= render partial: 'queue_table', locals: { entries: @entries }
 
 = paginate @entries
 

--- a/config/locales/lexicon.en.yml
+++ b/config/locales/lexicon.en.yml
@@ -187,6 +187,9 @@ en:
           person: Person
           publication: Publication
         time_updated: "%{time} ago"
+        my_locked_title: Entries locked by me
+        locked_by_others_title: Entries locked by other editors
+        other_title: Other entries
       show:
         title: "Verifying: %{entry_title}"
         back_to_queue: Back to Queue

--- a/config/locales/lexicon.he.yml
+++ b/config/locales/lexicon.he.yml
@@ -187,7 +187,7 @@ he:
           person: יוצר/ת
           publication: פרסום
         time_updated: "לפני %{time}"
-        my_locked_title: ערכים נעולים על ידי
+        my_locked_title: ערכים שנעלתי
         locked_by_others_title: ערכים נעולים על ידי עורכים אחרים
         other_title: ערכים אחרים
       show:

--- a/config/locales/lexicon.he.yml
+++ b/config/locales/lexicon.he.yml
@@ -187,6 +187,9 @@ he:
           person: יוצר/ת
           publication: פרסום
         time_updated: "לפני %{time}"
+        my_locked_title: ערכים נעולים על ידי
+        locked_by_others_title: ערכים נעולים על ידי עורכים אחרים
+        other_title: ערכים אחרים
       show:
         title: "אימות: %{entry_title}"
         back_to_queue: חזור לרשימה

--- a/spec/requests/lexicon/verification_spec.rb
+++ b/spec/requests/lexicon/verification_spec.rb
@@ -465,6 +465,124 @@ RSpec.describe 'Lexicon::Verification', type: :request do
         expect(response.body).not_to include(redo_migration_lexicon_file_path(error_file))
       end
     end
+
+    context 'with locked entries' do
+      let(:other_editor) do
+        user = create(:user, editor: true)
+        ListItem.create!(listkey: 'edit_lexicon', item: user)
+        user
+      end
+
+      describe 'my-locked section' do
+        context 'when the current editor has a locked entry' do
+          let!(:mine) do
+            entry = create(:lex_entry, :person, status: :draft)
+            entry.update_columns(locked_at: 5.minutes.ago, locked_by_user_id: create_lexicon_editor.id)
+            entry
+          end
+
+          it 'shows the "Entries locked by me" heading' do
+            get '/lex/verification/queue'
+            expect(response.body).to include(I18n.t('lexicon.verification.queue.my_locked_title'))
+          end
+
+          it 'excludes the locked entry from the other-entries section (appears exactly once)' do
+            get '/lex/verification/queue'
+            expect(response.body.scan(mine.title).size).to eq(1)
+          end
+        end
+
+        it 'omits the my-locked heading when no entries are locked by the current editor' do
+          get '/lex/verification/queue'
+          expect(response.body).not_to include(I18n.t('lexicon.verification.queue.my_locked_title'))
+        end
+      end
+
+      describe 'locked-by-others section' do
+        context 'when another editor has a locked entry' do
+          let!(:theirs) do
+            entry = create(:lex_entry, :person, status: :draft)
+            entry.update_columns(locked_at: 5.minutes.ago, locked_by_user_id: other_editor.id)
+            entry
+          end
+
+          it 'shows the "Entries locked by other editors" heading' do
+            get '/lex/verification/queue'
+            expect(response.body).to include(I18n.t('lexicon.verification.queue.locked_by_others_title'))
+          end
+
+          it "shows the locking editor's name in the row" do
+            get '/lex/verification/queue'
+            expect(response.body).to include(I18n.t('lockable.locked_by_human', name: other_editor.name))
+          end
+
+          it 'excludes the locked entry from the other-entries section (appears exactly once)' do
+            get '/lex/verification/queue'
+            expect(response.body.scan(theirs.title).size).to eq(1)
+          end
+        end
+
+        it 'omits the locked-by-others heading when no entries are locked by other editors' do
+          get '/lex/verification/queue'
+          expect(response.body).not_to include(I18n.t('lexicon.verification.queue.locked_by_others_title'))
+        end
+      end
+
+      describe 'expired locks' do
+        let!(:expired) do
+          entry = create(:lex_entry, :person, status: :draft)
+          entry.update_columns(
+            locked_at: (Lockable::LOCK_TIMEOUT_IN_SECONDS + 60).seconds.ago,
+            locked_by_user_id: create_lexicon_editor.id
+          )
+          entry
+        end
+
+        it 'treats an expired lock as unlocked (no my-locked heading shown)' do
+          get '/lex/verification/queue'
+          expect(response.body).not_to include(I18n.t('lexicon.verification.queue.my_locked_title'))
+        end
+
+        it 'includes an expired-lock entry in the other-entries section' do
+          get '/lex/verification/queue'
+          expect(response.body).to include(expired.title)
+        end
+      end
+
+      describe 'filter consistency across sections' do
+        let!(:draft_mine) do
+          entry = create(:lex_entry, :person, status: :draft)
+          entry.update_columns(locked_at: 5.minutes.ago, locked_by_user_id: create_lexicon_editor.id)
+          entry
+        end
+
+        let!(:verifying_mine) do
+          entry = create(:lex_entry, :person, status: :verifying)
+          entry.update_columns(locked_at: 5.minutes.ago, locked_by_user_id: create_lexicon_editor.id)
+          entry
+        end
+
+        it 'status filter applies to the my-locked section' do
+          get '/lex/verification/queue', params: { status: 'draft' }
+          expect(response.body).to include(draft_mine.title)
+          expect(response.body).not_to include(verifying_mine.title)
+        end
+
+        context 'with a publication also locked by me' do
+          let!(:pub_mine) do
+            entry = create(:lex_entry, :publication, status: :draft)
+            entry.update_columns(locked_at: 5.minutes.ago, locked_by_user_id: create_lexicon_editor.id)
+            entry
+          end
+
+          it 'type filter applies to the my-locked section' do
+            get '/lex/verification/queue', params: { type: 'LexPerson' }
+            expect(response.body).to include(draft_mine.title)
+            expect(response.body).not_to include(pub_mine.title)
+          end
+        end
+      end
+    end
   end
 
   describe 'POST /lex/verification/:id/escalate' do


### PR DESCRIPTION
## Summary

- Splits the `/lex/verification/queue` view into three sections — **Entries locked by me**, **Entries locked by other editors**, and **Other entries** — matching the layout already used in `/lex/files` and `/lex/entries`.
- Refactors the table rendering into a `_queue_table` partial to avoid repeating the table markup three times.
- Applies filters before splitting into groups so status/type filters work correctly across all three sections.
- Adds `my_locked_title`, `locked_by_others_title`, and `other_title` i18n keys under `lexicon.verification.queue` in both `lexicon.en.yml` and `lexicon.he.yml`.

## Test plan

- [ ] Visit `/lex/verification/queue` with no locked entries: only "Other entries" section appears
- [ ] Lock an entry (open it for verification) and return to the queue: verify it appears under "Entries locked by me"
- [ ] As a second user, lock an entry: verify it appears under "Entries locked by other editors" for the first user
- [ ] Verify status/type filters apply to all three sections (locked entries respect the filter)
- [ ] Verify pagination still works on the main "Other entries" section

🤖 Generated with [Claude Code](https://claude.com/claude-code)