### PR TITLE
Make LexPersonWork edit non-modal so PHP source pane stays accessible

### DIFF
--- a/app/assets/javascripts/verification.js
+++ b/app/assets/javascripts/verification.js
@@ -556,6 +556,33 @@ function restoreScrollWithRetry(el, scrollVal) {
     requestAnimationFrame(tryScroll);
 }
 
+// Open the per-work edit form as a non-modal panel.
+// Unlike openModal(), this version uses backdrop:false and makes the overlay
+// transparent to pointer events so the source (PHP) pane remains interactive.
+// Esc still dismisses the panel via Bootstrap's keyboard:true option.
+function openWorkEditPanel(path, onSuccess) {
+    $('#generalDlg').data('onSuccess', onSuccess);
+
+    $.get(path).done(function(htmlContent) {
+        setupModalContent(htmlContent);
+
+        // Apply non-modal class before show so CSS takes effect from the first frame.
+        $('#generalDlg').addClass('no-modal-mode');
+
+        $('#generalDlg').modal({ show: true, keyboard: true, backdrop: false });
+
+        // Bootstrap 4 adds 'modal-open' to <body> synchronously inside show().
+        // Remove it immediately so background scrolling/interaction stays available.
+        $('body').removeClass('modal-open');
+
+        $('#generalDlg').one('hidden.bs.modal', function() {
+            $(this).removeClass('no-modal-mode');
+        });
+    }).fail(function(xhr, status, error) {
+        alert('Failed to load: ' + status + ' - ' + error);
+    });
+}
+
 // Reload the page, preserving source pane scroll position
 function reloadPage() {
     saveScrollPositions();

--- a/app/assets/javascripts/verification.js
+++ b/app/assets/javascripts/verification.js
@@ -569,8 +569,7 @@ function openWorkEditPanel(path, onSuccess) {
         // Apply non-modal class before show so CSS takes effect from the first frame.
         $('#generalDlg').addClass('no-modal-mode');
 
-        $('#generalDlg').modal({ show: true, keyboard: true, backdrop: false });
-
+        $('#generalDlg').modal({ show: true, keyboard: true, backdrop: false, focus: false });
         // Bootstrap 4 adds 'modal-open' to <body> synchronously inside show().
         // Remove it immediately so background scrolling/interaction stays available.
         $('body').removeClass('modal-open');

--- a/app/assets/stylesheets/verification.scss
+++ b/app/assets/stylesheets/verification.scss
@@ -407,6 +407,17 @@ body:has(.verification-container) {
   }
 }
 
+// Per-work edit panel: non-modal mode.
+// pointer-events:none on the overlay lets clicks pass through to the source (PHP) pane;
+// pointer-events:auto restores interaction for the dialog itself.
+#generalDlg.no-modal-mode {
+  pointer-events: none;
+}
+
+#generalDlg.no-modal-mode .modal-dialog {
+  pointer-events: auto;
+}
+
 // Per-work edit modal: full height, anchored to left (migrated data) pane.
 // margin-left:0 + margin-right:auto anchors to physical-left (= visual-left in RTL grid).
 // Both dialog and content use 100vh directly — avoids Bootstrap 4 percentage-height resolution

--- a/app/views/lexicon/verification/_person_sections.html.haml
+++ b/app/views/lexicon/verification/_person_sections.html.haml
@@ -182,7 +182,7 @@
                 %br
                 %span.text-muted!= render_person_work_comment(work.comment, work.comment_links)
             .work-actions.mt-2
-              %button.btn.btn-sm.btn-outline-primary{ onclick: "openModal('#{edit_lexicon_work_path(work)}', function() { reloadScrollingToSection('section-works'); })" }
+              %button.btn.btn-sm.btn-outline-primary{ onclick: "openWorkEditPanel('#{edit_lexicon_work_path(work)}', function() { reloadScrollingToSection('section-works'); })" }
                 ✏️
                 = t('lexicon.verification.migrated.edit')
               %button.btn.btn-sm{ class: checklist['works']&.dig('items', work.id.to_s, 'verified') ? 'btn-success' : 'btn-outline-success', data: { action: 'click->verification#quickVerify', path: "works.items.#{work.id}" } }

--- a/spec/system/lexicon/verification_works_modal_spec.rb
+++ b/spec/system/lexicon/verification_works_modal_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe 'Verification Works Modal UX', :js do
+describe 'Verification Works Edit Panel UX', :js do
   before do
     skip 'WebDriver not available or misconfigured' unless webdriver_available?
     login_as_lexicon_editor
@@ -34,7 +34,7 @@ describe 'Verification Works Modal UX', :js do
 
   after { FileUtils.rm_f(lex_file.full_path) }
 
-  describe 'per-work edit modal positioning and draggability' do
+  describe 'per-work edit panel positioning and draggability' do
     before do
       visit "/lex/verification/#{entry.id}"
       within "#work-#{work.id}" do
@@ -45,24 +45,24 @@ describe 'Verification Works Modal UX', :js do
       # rubocop:enable RSpec/ExpectInHook
     end
 
-    it 'modal appears at the top of the viewport' do
+    it 'panel appears at the top of the viewport' do
       modal_top = page.evaluate_script(
         "document.querySelector('#generalDlg .modal-dialog').getBoundingClientRect().top"
       )
-      # Per-work edit modal has margin-top: 0 (full-height side panel)
+      # Per-work edit panel has margin-top: 0 (full-height side panel)
       expect(modal_top).to be < 10
     end
 
-    it 'modal content fills the viewport height as a full-height side panel' do
+    it 'panel content fills the viewport height as a full-height side panel' do
       modal_height = page.evaluate_script(
         "document.querySelector('#generalDlg .modal-content').getBoundingClientRect().height"
       )
       viewport_height = page.evaluate_script('window.innerHeight')
-      # Per-work edit modal uses height: 100vh
+      # Per-work edit panel uses height: 100vh
       expect(modal_height).to be >= (viewport_height * 0.9)
     end
 
-    it 'modal header shows move cursor indicating draggability' do
+    it 'panel header shows move cursor indicating draggability' do
       cursor = page.evaluate_script(
         "window.getComputedStyle(document.querySelector('#generalDlg .modal-header')).cursor"
       )
@@ -78,7 +78,7 @@ describe 'Verification Works Modal UX', :js do
       end
     end
 
-    it 'dragging the SE corner handle increases modal size' do
+    it 'dragging the SE corner handle increases panel size' do
       initial_w = page.evaluate_script(
         "document.querySelector('#generalDlg .modal-dialog').getBoundingClientRect().width"
       )
@@ -108,7 +108,7 @@ describe 'Verification Works Modal UX', :js do
       expect(new_h).to be > initial_h
     end
 
-    it 'dragging the modal header repositions the dialog' do
+    it 'dragging the panel header repositions the dialog' do
       initial_top = page.evaluate_script(
         "document.querySelector('#generalDlg .modal-dialog').getBoundingClientRect().top"
       )
@@ -130,6 +130,23 @@ describe 'Verification Works Modal UX', :js do
         "document.querySelector('#generalDlg .modal-dialog').getBoundingClientRect().top"
       )
       expect(new_top).to be > initial_top
+    end
+
+    it 'does not show a modal backdrop so the source pane remains accessible' do
+      expect(page).not_to have_css('.modal-backdrop')
+    end
+
+    it 'removes modal-open from body so background interaction is not blocked' do
+      expect(page).not_to have_css('body.modal-open')
+    end
+
+    it 'marks the overlay as no-modal-mode for pointer-event passthrough' do
+      expect(page).to have_css('#generalDlg.no-modal-mode', wait: 5)
+    end
+
+    it 'closes when Esc is pressed' do
+      find('body').send_keys(:escape)
+      expect(page).not_to have_css('#generalDlg.show', wait: 5)
     end
   end
 end


### PR DESCRIPTION
## Summary

- Introduces `openWorkEditPanel()` in `verification.js` alongside the existing `openModal()`. The new function opens the same `#generalDlg` panel (preserving its left-side full-height layout and drag/resize behavior) but with:
  - `backdrop: false` — no dark overlay at all
  - `no-modal-mode` CSS class — sets `pointer-events: none` on the modal overlay and `pointer-events: auto` on the dialog, so clicks pass through to the PHP source pane behind it
  - `body.modal-open` removed synchronously — re-enables background scroll/interaction
  - Esc still dismisses via Bootstrap `keyboard: true`
- Changed the works section edit button in `_person_sections.html.haml` to call `openWorkEditPanel` instead of `openModal`
- Updated `verification_works_modal_spec.rb` (renamed describe block to "Verification Works Edit Panel UX") and added three new assertions: no `.modal-backdrop`, no `body.modal-open`, and `#generalDlg.no-modal-mode`

All existing drag/resize/positioning tests continue to pass (10/10 examples).

## Test plan

- [ ] Open a LexPerson verification workbench with at least one work
- [ ] Click the ✏️ edit button on a work — panel opens on the left as before
- [ ] While the panel is open, scroll and click in the PHP source iframe on the right — should work normally
- [ ] Press Esc — panel dismisses
- [ ] Clicking × button — panel dismisses  
- [ ] Save a change — panel closes and page reloads, scrolling to section-works
- [ ] Verify all other edit modals (title, bio, citations, etc.) still use backdrop

🤖 Generated with [Claude Code](https://claude.com/claude-code)