### PR TITLE
Fix ExtractCitations yielding no citations when empty font precedes citation lists

### DIFF
--- a/app/services/lexicon/extract_citations.rb
+++ b/app/services/lexicon/extract_citations.rb
@@ -10,8 +10,13 @@ module Lexicon
       return [] if header.nil?
 
       # The next element should be a 'font' tag containing all citations. Sometimes there could be one or more blank
-      # paragraphs before it, so we need to skip them.
-      citations_node = next_element_skipping_blank(header)
+      # paragraphs before it, so we skip blank non-font elements. Font elements are always potential
+      # citations-section markers even when their content is empty (e.g. <font color="#FF0000"></font>),
+      # so we must not skip them.
+      citations_node = header.next_element
+      while citations_node.present? && citations_node.name != 'font' && citations_node.text.blank?
+        citations_node = citations_node.next_element
+      end
 
       return [] if citations_node&.name != 'font'
 

--- a/spec/fixtures/files/lexicon/empty_font_before_citations.php
+++ b/spec/fixtures/files/lexicon/empty_font_before_citations.php
@@ -1,0 +1,19 @@
+<html>
+<head><meta http-equiv="Content-Type" content="text/html; charset=UTF-8"></head>
+<body dir="rtl">
+<font size="4" color="#0000FF"><a name="Books">ספריה:</a></font></p>
+<ul type="circle">
+  <li>ספר ראשון (תל אביב, 2012)</li>
+</ul>
+<font size="4" color="#0000FF"><a name="Bib.">על המחברת ויצירתה:</a></font></p>
+<font color="#FF0000"></font>
+<ul type="circle">
+  <li><b>כהן, דוד.</b> ביקורת על הספר. <u>הארץ</u>, 1 בינואר 2020, עמ׳ 5.</li>
+  <li><b>לוי, יוסף.</b> מאמר נוסף. <u>מעריב</u>, 10 בפברואר 2021, עמ׳ 8.</li>
+</ul>
+<font color="#FF0000">על ״ספר ראשון״</font>
+<ul type="circle">
+  <li><b>פלוני, ראובן.</b> ביקורת שנייה. <u>ידיעות אחרונות</u>, 5 במארס 2022, עמ׳ 3.</li>
+</ul>
+</body>
+</html>

--- a/spec/services/lexicon/extract_citations_spec.rb
+++ b/spec/services/lexicon/extract_citations_spec.rb
@@ -49,6 +49,29 @@ describe Lexicon::ExtractCitations do
     end
   end
 
+  context 'when an empty <font> precedes the citation lists (new-style PHP export)' do
+    # Regression: updated PHP files place an empty <font color="#FF0000"></font> immediately after
+    # the Bib. anchor header, with no blank <p> buffer before the <ul> lists. The original
+    # next_element_skipping_blank call skipped that empty font (blank text) and landed on the <ul>,
+    # which failed the "must be a font" guard and returned []. Fix: only skip blank non-font elements.
+    let(:filename) { Rails.root.join('spec/fixtures/files/lexicon/empty_font_before_citations.php') }
+
+    it 'extracts all citations across every subject group' do
+      captured_html = nil
+      allow(Lexicon::ParseCitations).to receive(:call) do |html|
+        captured_html = html
+        []
+      end
+
+      result
+
+      expect(captured_html).not_to be_nil
+      expect(Nokogiri::HTML(captured_html).css('li').size).to eq(3)
+      expect(captured_html).to include('כהן, דוד')
+      expect(captured_html).to include('על ״ספר ראשון״')
+    end
+  end
+
   context 'when a stray </span> inside a <li> prematurely closes the parent span' do
     # Regression test for 00034.php: a stray </span> after </b> inside a citation <li>
     # caused Nokogiri to prematurely close the <span dir="rtl"> wrapping the citations section.


### PR DESCRIPTION
## Summary

- **Bug**: The updated `00118.php` places an empty `<font color="#FF0000"></font>` directly after the `Bib.` section anchor, with no blank `<p>` buffer before the `<ul>` citation lists. The existing `next_element_skipping_blank` call skipped that empty font (its `.text` is blank), landed on the `<ul>`, and the `citations_node.name != 'font'` guard returned `[]` — so zero citations were extracted despite the file having many.
- **Root cause**: `next_element_skipping_blank` was designed to skip blank paragraphs between the header and the citations `<font>` container. But an empty `<font color="#FF0000">` is a valid (if content-free) section marker and must not be skipped.
- **Fix**: Replace the `next_element_skipping_blank` call for the initial `citations_node` search with an inline loop that only skips blank **non-font** elements. This preserves the blank-paragraph-skip behavior while stopping at any `<font>` node regardless of content.

## Test plan

- [ ] `bundle exec rspec spec/services/lexicon/extract_citations_spec.rb` — all 5 examples pass, including the new regression test with a `empty_font_before_citations.php` fixture that reproduces the exact structure
- [ ] Existing VCR cassettes (00002, 00024) still match — `next_element_skipping_blank` is unchanged in all code paths that don't start the initial search, so legacy-malformed documents are unaffected
- [ ] Fixture 00006 (well-formed, from PR #1300) still passes — the blank `<p>` before its first citation font is still skipped by the new loop (it's non-font and blank)

Closes beads_by-a8z

🤖 Generated with [Claude Code](https://claude.com/claude-code)