### PR TITLE
Fix mobile author page: content col wraps over sticky navbar

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1237,6 +1237,7 @@ p.by-genre-name-v02.headline-2-v02 {
     top: 120px;
     max-height: calc(100vh - 120px);
     overflow-y: auto;
+    overflow-x: hidden;
   }
 
   .peach2-lexicon .side-menu-area {

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1240,6 +1240,16 @@ p.by-genre-name-v02.headline-2-v02 {
     overflow-x: hidden;
   }
 
+  // Same fix as desktop (min-width: 992px block below): prevent the content col
+  // from wrapping past the spacer and overlapping the sticky nav column.
+  .author-page-content .col-12.col-lg-8 > .row {
+    flex-wrap: nowrap;
+  }
+
+  .author-page-content .col-12.col-lg-8 > .row > .col:not(.author-side-menu-area) {
+    min-width: 0;
+  }
+
   .peach2-lexicon .side-menu-area {
     position: sticky;
     top: 60px;

--- a/spec/system/author_navbar_mobile_overflow_spec.rb
+++ b/spec/system/author_navbar_mobile_overflow_spec.rb
@@ -12,16 +12,13 @@ RSpec.describe 'Author page mobile sticky navbar overflow', :js, type: :system d
       create(:manifestation, title: 'Test Work', status: :published, author: author)
     end
     create(:involved_authority, authority: author, item: collection, role: 'editor')
+    page.driver.browser.manage.window.resize_to(375, 667)
   end
 
   after { Chewy.massacre }
 
   describe 'at mobile viewport width (375px)' do
-    before do
-      page.driver.browser.manage.window.resize_to(375, 667)
-    end
-
-    it 'clips the sticky nav column horizontally so it does not overflow into TOC cards' do
+    it 'sets overflow-x: hidden on the nav col to clip any child overflow' do
       visit authority_path(author)
       expect(page).to have_css('.author-side-nav-col', wait: 5)
 
@@ -30,6 +27,17 @@ RSpec.describe 'Author page mobile sticky navbar overflow', :js, type: :system d
       )
 
       expect(overflow_x).to eq('hidden')
+    end
+
+    it 'prevents the content col from wrapping past the spacer via flex-wrap: nowrap' do
+      visit authority_path(author)
+      expect(page).to have_css('.author-page-content .col-12 > .row', wait: 5)
+
+      flex_wrap = page.evaluate_script(
+        "window.getComputedStyle(document.querySelector('.author-page-content .col-12 > .row')).flexWrap"
+      )
+
+      expect(flex_wrap).to eq('nowrap')
     end
   end
 end

--- a/spec/system/author_navbar_mobile_overflow_spec.rb
+++ b/spec/system/author_navbar_mobile_overflow_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Author page mobile sticky navbar overflow', :js, type: :system do
+  let!(:author) { create(:authority, name: 'Test Author') }
+  let!(:collection) { create(:collection, title: 'Test Collection') }
+
+  before do
+    skip 'WebDriver not available or misconfigured' unless webdriver_available?
+    Chewy.strategy(:atomic) do
+      create(:manifestation, title: 'Test Work', status: :published, author: author)
+    end
+    create(:involved_authority, authority: author, item: collection, role: 'editor')
+  end
+
+  after { Chewy.massacre }
+
+  describe 'at mobile viewport width (375px)' do
+    before do
+      page.driver.browser.manage.window.resize_to(375, 667)
+    end
+
+    it 'clips the sticky nav column horizontally so it does not overflow into TOC cards' do
+      visit authority_path(author)
+      expect(page).to have_css('.author-side-nav-col', wait: 5)
+
+      overflow_x = page.evaluate_script(
+        "window.getComputedStyle(document.querySelector('.author-side-nav-col')).overflowX"
+      )
+
+      expect(overflow_x).to eq('hidden')
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- The inner row (spacer + content col) on the author TOC page lacked `flex-wrap: nowrap` on mobile viewports.
- When the content col's min-content-size (e.g. the sort dropdown with long Hebrew text) exceeded the available space alongside the 50px spacer, it wrapped to a new row at full viewport width — placing it directly under the 34px sticky nav column in the fixed header.
- This caused the vertical role-label strip (יצירות מקור, תרגום, תוכן נוסף) to visually overlap and hide the right edge of the TOC content.

The same `flex-wrap: nowrap` + `min-width: 0` pattern that already exists for desktop (≥992px) is now applied for mobile (≤991px).

The previous attempt (`overflow-x: hidden` on `.author-side-nav-col`) was kept as a secondary safety net but was not the root cause — the wrapping was.

## Test plan

- [ ] View a real author page (e.g. /author/זאב-יעבץ) on a mobile device or emulator at ≤375px width — the sticky nav column on the right should no longer cover the TOC list items
- [ ] Verify `bundle exec rspec spec/system/author_navbar_mobile_overflow_spec.rb` passes (2 examples)
- [ ] Verify no desktop regression on the same author page

🤖 Generated with [Claude Code](https://claude.com/claude-code)