### PR TITLE
Strip periodical name prefix from Collection#show navbar items

### DIFF
--- a/app/views/shared/_collection_top.html.haml
+++ b/app/views/shared/_collection_top.html.haml
@@ -35,8 +35,10 @@
               - elsif eds.present?
                 #{t(:edited_by)}:
                 %span= eds
+          - short_title = @collection.title.split(/: | – /, 2).first if @collection.periodical?
+          - strip_coll_prefix = ->(t) { short_title ? t.sub(/\A#{Regexp.escape(short_title)}(?:: | – )/, '') : t }
           .field-v02.work-chapters-dropdown-field-desktop{style: 'background-color: unset;'}
-            = select_tag 'collitem', options_for_select(@htmls.reject{|x| x[0].blank?}.map{ |title, authors, html, is_curated, genre, i, ci, nesting_level, parent_authorities| [("– " * nesting_level) + title, i] }, 0), class: 'dropdown-v02', id: 'collitem_dropdown', style: 'width: 100%;'
+            = select_tag 'collitem', options_for_select(@htmls.reject{|x| x[0].blank?}.map{ |title, authors, html, is_curated, genre, i, ci, nesting_level, parent_authorities| [("– " * nesting_level) + strip_coll_prefix.call(title), i] }, 0), class: 'dropdown-v02', id: 'collitem_dropdown', style: 'width: 100%;'
 
           .work-page-top-icons-desktop
             %button.btn-small-outline-v02.btn-text-v02.reading-mode-btn-v02{href: "#"}
@@ -67,8 +69,9 @@
             - li_attrs = { id: "collitem_#{i}_button", 'data-target' => "collitem_text_#{i}" }
             - li_attrs[:style] = "padding-right: #{nesting_level * 10}px;" if nesting_level > 0
             %li.nav-item.side-menu-item{ li_attrs }
-              %a{'class' => 'nav-link nav-chapter-name nav-link-chapter pointer linkcolor '+(first ? ' active' : ''), "aria-controls" => "#", "aria-selected" => "false", 'data-toggle' => 'tooltip', 'title' => title, 'data-placement' => 'top', 'data-delay' => { "show": 500, "hide": 100 }, href: "#"}
-                .nav-chapter-name= title
+              - nav_title = strip_coll_prefix.call(title)
+              %a{'class' => 'nav-link nav-chapter-name nav-link-chapter pointer linkcolor '+(first ? ' active' : ''), "aria-controls" => "#", "aria-selected" => "false", 'data-toggle' => 'tooltip', 'title' => nav_title, 'data-placement' => 'top', 'data-delay' => { "show": 500, "hide": 100 }, href: "#"}
+                .nav-chapter-name= nav_title
                 - first = false
 
     .col{style: "z-order:-1;height:0;"}

--- a/app/views/shared/_collection_top.html.haml
+++ b/app/views/shared/_collection_top.html.haml
@@ -36,7 +36,7 @@
                 #{t(:edited_by)}:
                 %span= eds
           - short_title = @collection.title.split(/: | – /, 2).first if @collection.periodical?
-          - strip_coll_prefix = ->(t) { short_title ? t.sub(/\A#{Regexp.escape(short_title)}(?:: | – )/, '') : t }
+          - strip_coll_prefix = ->(issue_title) { short_title ? issue_title.sub(/\A#{Regexp.escape(short_title)}(?:: | – )/, '') : issue_title }
           .field-v02.work-chapters-dropdown-field-desktop{style: 'background-color: unset;'}
             = select_tag 'collitem', options_for_select(@htmls.reject{|x| x[0].blank?}.map{ |title, authors, html, is_curated, genre, i, ci, nesting_level, parent_authorities| [("– " * nesting_level) + strip_coll_prefix.call(title), i] }, 0), class: 'dropdown-v02', id: 'collitem_dropdown', style: 'width: 100%;'
 

--- a/spec/system/periodical_navbar_prefix_spec.rb
+++ b/spec/system/periodical_navbar_prefix_spec.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe 'Periodical navbar prefix stripping' do
+  let!(:author) { create(:authority) }
+
+  describe 'periodical collection' do
+    let!(:periodical) do
+      create(:collection,
+             title: 'My Periodical: A Magazine',
+             collection_type: :periodical,
+             authors: [author])
+    end
+
+    let!(:issue1) do
+      create(:collection, title: 'My Periodical – Issue 1', collection_type: :periodical_issue)
+    end
+
+    let!(:issue2) do
+      create(:collection, title: 'My Periodical – Issue 2', collection_type: :periodical_issue)
+    end
+
+    before do
+      create(:collection_item, collection: periodical, item: issue1, seqno: 1)
+      create(:collection_item, collection: periodical, item: issue2, seqno: 2)
+    end
+
+    it 'strips the periodical name prefix from sidebar nav items' do
+      visit collection_path(periodical)
+
+      within('#chapter-nav') do
+        expect(page).to have_content('Issue 1')
+        expect(page).to have_content('Issue 2')
+        expect(page).not_to have_content('My Periodical – Issue 1')
+        expect(page).not_to have_content('My Periodical – Issue 2')
+      end
+    end
+
+    it 'strips the periodical name prefix from the chapters dropdown' do
+      visit collection_path(periodical)
+
+      options = all('#collitem_dropdown option').map(&:text)
+      expect(options).to include('Issue 1', 'Issue 2')
+      expect(options.join(' ')).not_to include('My Periodical')
+    end
+  end
+
+  describe 'non-periodical collection' do
+    let!(:volume) do
+      create(:collection,
+             title: 'A Volume',
+             collection_type: :volume,
+             authors: [author])
+    end
+
+    # Two manifestations prevent the single-item redirect in CollectionsController#show
+    let!(:manifestation1) { create(:manifestation, title: 'Chapter One') }
+    let!(:manifestation2) { create(:manifestation, title: 'Chapter Two') }
+
+    before do
+      create(:collection_item, collection: volume, item: manifestation1, seqno: 1)
+      create(:collection_item, collection: volume, item: manifestation2, seqno: 2)
+    end
+
+    it 'leaves nav item titles unchanged' do
+      visit collection_path(volume)
+
+      within('#chapter-nav') do
+        expect(page).to have_content('Chapter One')
+        expect(page).to have_content('Chapter Two')
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- In `Collection#show`, when viewing a periodical, each navbar/TOC item showed the full issue title including the periodical's name (e.g. "פנטסיה 2000 – גיליון 1"), making the sidebar cluttered and hard to scan
- Now only the issue identifier is shown (e.g. "גיליון 1") — the periodical short name and its separator (`: ` or ` – `) are stripped
- Applied to both the sidebar nav items and the chapters dropdown

## Technical note

The "short title" is derived from `@collection.title.split(/: | – /, 2).first`, which correctly handles periodicals with subtitles (e.g. "פנטסיה 2000: המגזין למדע בדיוני" → short title "פנטסיה 2000"), since issue titles only prefix with the short form.

## Test plan

- [ ] Visit a periodical collection (e.g. `/collections/12867` — פנטסיה 2000) and confirm navbar items show "גיליון 1", "גיליון 2", etc. without the periodical name prefix
- [ ] Visit a non-periodical collection and confirm navbar items are unchanged
- [ ] Confirm the chapters dropdown (desktop) also shows the stripped titles