### PR TITLE
Cross-collection navigation for volumes and periodical issues

### DIFF
--- a/RAILS_GOTCHAS.md
+++ b/RAILS_GOTCHAS.md
@@ -118,6 +118,82 @@ If you must use `link_to`, test thoroughly in:
 
 ---
 
+## `inverse_of` Pre-Populates `collection_items` with Stale Cache
+
+**Date Discovered:** 2026-07-01
+**Time Spent Debugging:** ~2 hours
+**Affected Rails Version:** Rails 8.1.3
+
+### Symptoms
+
+When you load a Collection's `collection_items` after the collection was loaded via `parent_collection_items.map(&:collection)` (or any `has_many ... inverse_of: :item` loaded association chain), `collection_items` appears pre-loaded but contains fewer items than the database actually has:
+
+```ruby
+series.parent_collection_items.first.collection.collection_items.loaded?  # => true  (!!)
+series.parent_collection_items.first.collection.collection_items.count    # => 2  (wrong, DB has 3)
+series.parent_collection_items.first.collection.collection_items.reset.count  # => 3  (correct)
+```
+
+### What Triggers It
+
+The exact chain that causes the stale cache:
+
+1. A Collection (e.g. `volume`) has `has_many :collection_items, inverse_of: :collection`
+2. `volume.collection_items.create!(item: sub_collection)` is called — at this moment, Rails caches `volume.collection_items` in memory (say, with 2 items)
+3. Later, more items are added to `volume.collection_items` (cache grows to 3 items), but the CollectionItem created in step 2 still carries an internal reference to the volume as it was at that moment
+4. `sub_collection.parent_collection_items` is loaded (via `has_many :parent_collection_items, as: :item, inverse_of: :item`)
+5. `.first.collection` is called on the loaded CollectionItem — Rails's `inverse_of` mechanism loads a *new* Ruby object for the volume, but pre-populates its `collection_items` from the in-memory state at step 2 (only 2 items), not from the DB
+
+### Root Cause
+
+Rails's `inverse_of` association pre-populates the `has_many` side when loading via the `belongs_to` side. When the `CollectionItem` is loaded as part of a `has_many ... as: :item, inverse_of: :item` association, the resulting Ruby object carries a reference back to the original in-memory collection object. When `.collection` is subsequently called on that CollectionItem, Rails creates a new Collection object but pre-populates its `collection_items` association from whatever was already in memory — which may be a stale snapshot from when the CollectionItem was originally created through `collection.collection_items.create!`.
+
+This is invisible to normal queries (`loaded?` returns `true`) and silently returns incomplete data.
+
+### Which Patterns Are Safe vs. Unsafe
+
+```ruby
+# UNSAFE — triggers stale pre-population:
+parent_collection = ci.collection  # when ci loaded via has_many ... inverse_of: :item
+parent_collection.collection_items  # may return stale/incomplete list
+
+# SAFE — bypasses the association cache entirely:
+CollectionItem.where(collection: parent_collection).order(:seqno)
+
+# SAFE — forces a fresh DB query on the existing object:
+parent_collection.collection_items.reset
+
+# SAFE — loading a collection directly never has this issue:
+Collection.find(id).collection_items
+CollectionItem.find(id).collection  # when loaded standalone, not via a has_many
+```
+
+### Where This Exists in This Codebase
+
+**`CrossCollectionNavigation` (fixed):** The original `flatten_manifestations` used `collection.collection_items`; it was fixed to use `CollectionItem.where(collection: collection)` directly (see PR #1406).
+
+**`propagate_count_update_to_parents` → `recalculate_manifestations_count!` (theoretical risk):**
+
+```ruby
+def propagate_count_update_to_parents
+  stack = parent_collections.to_a  # parent_collections uses parent_collection_items.map(&:collection)
+  ...
+  collections_to_update.each do |collection|
+    collection.recalculate_manifestations_count!  # accesses collection.collection_items — may be stale
+  end
+end
+```
+
+Each `collection` here was obtained via `parent_collection_items.first.collection`, so its `collection_items` could be stale. In practice this only produces wrong counts if a parent collection's own `collection_items` was modified in the same request *before* the callback fires; in normal usage the parent's items are unchanged at that point, so the stale cache happens to be correct. However, if you ever perform multiple CollectionItem operations on the same parent in one request, verify that `recalculate_manifestations_count!` is producing the right result.
+
+**`Collection#parent_collections` (safe):** The result is used only to check `pc.volume?`, traverse further up the tree, or call `pc.authorities` / `pc.invalidate_cached_credits!` — none of which iterate `collection_items` on the returned objects.
+
+### Prevention
+
+Any time you navigate upward via `parent_collections` (or `parent_collection_items.map(&:collection)`) and then need to iterate `collection_items` on the resulting parent, use one of the safe patterns above. Add a comment explaining why.
+
+---
+
 ## Template for Future Gotchas
 
 When adding new entries, include:

--- a/app/services/cross_collection_navigation.rb
+++ b/app/services/cross_collection_navigation.rb
@@ -46,11 +46,11 @@ class CrossCollectionNavigation < ApplicationService
   end
 
   def flatten_manifestations(collection)
-    # Use a direct query to avoid stale inverse_of association caches
-    CollectionItem.where(collection: collection).order(:seqno).flat_map do |ci|
+    # Direct query avoids stale inverse_of cache; preload :item avoids N+1 per row
+    CollectionItem.where(collection: collection).order(:seqno).preload(:item).flat_map do |ci|
       next [] if ci.item_id.nil?
 
-      if ci.item_type == 'Manifestation'
+      if ci.item_type == 'Manifestation' && ci.item.present?
         [ci.item]
       elsif ci.item_type == 'Collection' && ci.item.present?
         flatten_manifestations(ci.item)

--- a/app/services/cross_collection_navigation.rb
+++ b/app/services/cross_collection_navigation.rb
@@ -35,6 +35,7 @@ class CrossCollectionNavigation < ApplicationService
     visited = Set.new
     while queue.any?
       pc = queue.shift
+      next if pc.nil?
       next if visited.include?(pc.id)
 
       visited.add(pc.id)

--- a/app/services/cross_collection_navigation.rb
+++ b/app/services/cross_collection_navigation.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+# Finds the previous/next manifestation when navigating across sub-collection
+# boundaries within a parent collection of type 'volume' or 'periodical_issue'.
+#
+# Usage: CrossCollectionNavigation.call(manifestation, sub_collection)
+# Returns an object with #prev_in_parent and #next_in_parent (Manifestation or nil).
+# Returns nil from both methods when the sub_collection has no volume/issue ancestor.
+class CrossCollectionNavigation < ApplicationService
+  def call(manifestation, sub_collection)
+    @parent = find_parent_volume_or_issue(sub_collection)
+    if @parent
+      @flat = flatten_manifestations(@parent)
+      @index = @flat.find_index { |m| m.id == manifestation.id }
+    end
+    self
+  end
+
+  def prev_in_parent
+    return nil unless @parent && @index && @index > 0
+
+    @flat[@index - 1]
+  end
+
+  def next_in_parent
+    return nil unless @parent && @index && @index < @flat.length - 1
+
+    @flat[@index + 1]
+  end
+
+  private
+
+  def find_parent_volume_or_issue(collection)
+    queue = collection.parent_collections.dup
+    visited = Set.new
+    while queue.any?
+      pc = queue.shift
+      next if visited.include?(pc.id)
+
+      visited.add(pc.id)
+      return pc if pc.volume? || pc.periodical_issue?
+
+      queue.concat(pc.parent_collections)
+    end
+    nil
+  end
+
+  def flatten_manifestations(collection)
+    # Use a direct query to avoid stale inverse_of association caches
+    CollectionItem.where(collection: collection).order(:seqno).flat_map do |ci|
+      next [] if ci.item_id.nil?
+
+      if ci.item_type == 'Manifestation'
+        [ci.item]
+      elsif ci.item_type == 'Collection' && ci.item.present?
+        flatten_manifestations(ci.item)
+      else
+        []
+      end
+    end
+  end
+end

--- a/app/services/find_siblings.rb
+++ b/app/services/find_siblings.rb
@@ -44,7 +44,44 @@ class FindSiblings < ApplicationService
         skipped += 1
         next
       end
+      if ci.item_type == 'Collection'
+        m = step > 0 ? first_manifestation_in(ci.item) : last_manifestation_in(ci.item)
+        if m.present?
+          return { item: m, skipped: skipped }
+        else
+          skipped += 1
+          next
+        end
+      end
       return { item: ci.item, skipped: skipped }
+    end
+    nil
+  end
+
+  def first_manifestation_in(collection)
+    CollectionItem.where(collection: collection).order(:seqno).each do |ci|
+      next if ci.item_id.nil?
+
+      return ci.item if ci.item_type == 'Manifestation'
+
+      if ci.item_type == 'Collection' && ci.item.present?
+        found = first_manifestation_in(ci.item)
+        return found if found.present?
+      end
+    end
+    nil
+  end
+
+  def last_manifestation_in(collection)
+    CollectionItem.where(collection: collection).order(seqno: :desc).each do |ci|
+      next if ci.item_id.nil?
+
+      return ci.item if ci.item_type == 'Manifestation'
+
+      if ci.item_type == 'Collection' && ci.item.present?
+        found = last_manifestation_in(ci.item)
+        return found if found.present?
+      end
     end
     nil
   end

--- a/app/services/find_siblings.rb
+++ b/app/services/find_siblings.rb
@@ -45,13 +45,12 @@ class FindSiblings < ApplicationService
         next
       end
       if ci.item_type == 'Collection'
-        m = step > 0 ? first_manifestation_in(ci.item) : last_manifestation_in(ci.item)
-        if m.present?
-          return { item: m, skipped: skipped }
-        else
-          skipped += 1
-          next
+        if ci.item.present?
+          m = step > 0 ? first_manifestation_in(ci.item) : last_manifestation_in(ci.item)
+          return { item: m, skipped: skipped } if m.present?
         end
+        skipped += 1
+        next
       end
       return { item: ci.item, skipped: skipped }
     end
@@ -59,10 +58,10 @@ class FindSiblings < ApplicationService
   end
 
   def first_manifestation_in(collection)
-    CollectionItem.where(collection: collection).order(:seqno).each do |ci|
+    CollectionItem.where(collection: collection).order(:seqno).preload(:item).each do |ci|
       next if ci.item_id.nil?
 
-      return ci.item if ci.item_type == 'Manifestation'
+      return ci.item if ci.item_type == 'Manifestation' && ci.item.present?
 
       if ci.item_type == 'Collection' && ci.item.present?
         found = first_manifestation_in(ci.item)
@@ -73,10 +72,10 @@ class FindSiblings < ApplicationService
   end
 
   def last_manifestation_in(collection)
-    CollectionItem.where(collection: collection).order(seqno: :desc).each do |ci|
+    CollectionItem.where(collection: collection).order(seqno: :desc).preload(:item).each do |ci|
       next if ci.item_id.nil?
 
-      return ci.item if ci.item_type == 'Manifestation'
+      return ci.item if ci.item_type == 'Manifestation' && ci.item.present?
 
       if ci.item_type == 'Collection' && ci.item.present?
         found = last_manifestation_in(ci.item)

--- a/app/views/manifestation/read.html.haml
+++ b/app/views/manifestation/read.html.haml
@@ -30,9 +30,13 @@
                 siblings = FindSiblings.call(@m, ci.collection)
                 prev = siblings.previous_sibling
                 nextsib = siblings.next_sibling
+                cross_nav = CrossCollectionNavigation.call(@m, ci.collection)
+                cross_prev = prev.nil? && !siblings.more_before? ? cross_nav.prev_in_parent : nil
+                cross_next = nextsib.nil? && !siblings.more_after? ? cross_nav.next_in_parent : nil
                 show_collection_link = !ci.collection.system?
                 show_nav = prev.present? || nextsib.present? || show_collection_link ||
-                           siblings.more_before? || siblings.more_after?
+                           siblings.more_before? || siblings.more_after? ||
+                           cross_prev.present? || cross_next.present?
               - next unless show_nav
               .author-works-nav
                 .topNavEntry
@@ -40,6 +44,10 @@
                     - if prev.present?
                       - extra = prev[:skipped] > 0 ? "?skipped=#{prev[:skipped]}" : ''
                       = link_to "#{default_link_by_class(prev[:item].class, prev[:item].id)}#{extra}" do
+                        %span.right-arrow= '2'
+                        = t(:to_previous_item)
+                    - elsif cross_prev.present?
+                      = link_to default_link_by_class(cross_prev.class, cross_prev.id) do
                         %span.right-arrow= '2'
                         = t(:to_previous_item)
                     - elsif siblings.more_before?
@@ -56,6 +64,10 @@
                     - if nextsib.present?
                       - extra = nextsib[:skipped] > 0 ? "?skipped=#{nextsib[:skipped]}" : ''
                       = link_to "#{default_link_by_class(nextsib[:item].class, nextsib[:item].id)}#{extra}" do
+                        = t(:to_next_item)
+                        %span.left-arrow= '1'
+                    - elsif cross_next.present?
+                      = link_to default_link_by_class(cross_next.class, cross_next.id) do
                         = t(:to_next_item)
                         %span.left-arrow= '1'
                     - elsif siblings.more_after?

--- a/app/views/manifestation/read.html.haml
+++ b/app/views/manifestation/read.html.haml
@@ -30,9 +30,10 @@
                 siblings = FindSiblings.call(@m, ci.collection)
                 prev = siblings.previous_sibling
                 nextsib = siblings.next_sibling
-                cross_nav = CrossCollectionNavigation.call(@m, ci.collection)
-                cross_prev = prev.nil? && !siblings.more_before? ? cross_nav.prev_in_parent : nil
-                cross_next = nextsib.nil? && !siblings.more_after? ? cross_nav.next_in_parent : nil
+                needs_cross_nav = (prev.nil? && !siblings.more_before?) || (nextsib.nil? && !siblings.more_after?)
+                cross_nav = needs_cross_nav ? CrossCollectionNavigation.call(@m, ci.collection) : nil
+                cross_prev = prev.nil? && !siblings.more_before? ? cross_nav&.prev_in_parent : nil
+                cross_next = nextsib.nil? && !siblings.more_after? ? cross_nav&.next_in_parent : nil
                 show_collection_link = !ci.collection.system?
                 show_nav = prev.present? || nextsib.present? || show_collection_link ||
                            siblings.more_before? || siblings.more_after? ||

--- a/spec/services/cross_collection_navigation_spec.rb
+++ b/spec/services/cross_collection_navigation_spec.rb
@@ -1,0 +1,147 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe CrossCollectionNavigation do
+  subject(:result) { described_class.call(manifestation, sub_collection) }
+
+  let(:volume) { create(:collection, collection_type: :volume) }
+  let(:sub_a) { create(:collection, collection_type: :series) }
+  let(:sub_b) { create(:collection, collection_type: :series) }
+  let(:m1) { create(:manifestation) }
+  let(:m2) { create(:manifestation) }
+  let(:m3) { create(:manifestation) }
+  let(:m4) { create(:manifestation) }
+  let(:m5) { create(:manifestation) }
+
+  # Volume layout:
+  #   seqno 1 → sub_a  (series)
+  #     seqno 1 → m1
+  #     seqno 2 → m2
+  #   seqno 2 → m3  (direct manifestation in volume)
+  #   seqno 3 → sub_b  (series)
+  #     seqno 1 → m4
+  #     seqno 2 → m5
+  before do
+    volume.collection_items.create!(item: sub_a, seqno: 1)
+    volume.collection_items.create!(item: m3, seqno: 2)
+    volume.collection_items.create!(item: sub_b, seqno: 3)
+    sub_a.collection_items.create!(item: m1, seqno: 1)
+    sub_a.collection_items.create!(item: m2, seqno: 2)
+    sub_b.collection_items.create!(item: m4, seqno: 1)
+    sub_b.collection_items.create!(item: m5, seqno: 2)
+  end
+
+  context 'when sub_collection has no volume/issue parent' do
+    subject(:result) { described_class.call(manifestation, orphan_collection) }
+
+    let(:orphan_collection) { create(:collection, collection_type: :series) }
+    let(:manifestation) { create(:manifestation) }
+
+    before { orphan_collection.collection_items.create!(item: manifestation, seqno: 1) }
+
+    it 'returns nil for both prev and next' do
+      expect(result.prev_in_parent).to be_nil
+      expect(result.next_in_parent).to be_nil
+    end
+  end
+
+  context 'when manifestation is first in sub_a (first sub-collection)' do
+    let(:manifestation) { m1 }
+    let(:sub_collection) { sub_a }
+
+    it 'returns nil for prev (first in volume)' do
+      expect(result.prev_in_parent).to be_nil
+    end
+
+    it 'returns m2 as next (still within sub_a)' do
+      expect(result.next_in_parent).to eq(m2)
+    end
+  end
+
+  context 'when manifestation is last in sub_a' do
+    let(:manifestation) { m2 }
+    let(:sub_collection) { sub_a }
+
+    it 'returns m1 as prev' do
+      expect(result.prev_in_parent).to eq(m1)
+    end
+
+    it 'returns m3 (direct volume item) as next' do
+      expect(result.next_in_parent).to eq(m3)
+    end
+  end
+
+  context 'when manifestation is first in sub_b' do
+    let(:manifestation) { m4 }
+    let(:sub_collection) { sub_b }
+
+    it 'returns m3 (direct volume item) as prev' do
+      expect(result.prev_in_parent).to eq(m3)
+    end
+
+    it 'returns m5 as next (still within sub_b)' do
+      expect(result.next_in_parent).to eq(m5)
+    end
+  end
+
+  context 'when manifestation is last in sub_b (last sub-collection)' do
+    let(:manifestation) { m5 }
+    let(:sub_collection) { sub_b }
+
+    it 'returns m4 as prev' do
+      expect(result.prev_in_parent).to eq(m4)
+    end
+
+    it 'returns nil for next (last in volume)' do
+      expect(result.next_in_parent).to be_nil
+    end
+  end
+
+  context 'with a periodical_issue parent' do
+    let(:issue) { create(:collection, collection_type: :periodical_issue) }
+    let(:series) { create(:collection, collection_type: :series) }
+    let(:article1) { create(:manifestation) }
+    let(:article2) { create(:manifestation) }
+    let(:poem) { create(:manifestation) }
+
+    before do
+      issue.collection_items.create!(item: article1, seqno: 1)
+      issue.collection_items.create!(item: series, seqno: 2)
+      series.collection_items.create!(item: poem, seqno: 1)
+      issue.collection_items.create!(item: article2, seqno: 3)
+    end
+
+    context 'when at last item in series' do
+      subject(:result) { described_class.call(poem, series) }
+
+      it 'returns article1 as prev' do
+        expect(result.prev_in_parent).to eq(article1)
+      end
+
+      it 'returns article2 as next' do
+        expect(result.next_in_parent).to eq(article2)
+      end
+    end
+  end
+
+  context 'when volume has a placeholder item' do
+    subject(:result) { described_class.call(ma, sub) }
+
+    let(:volume_with_placeholder) { create(:collection, collection_type: :volume) }
+    let(:sub) { create(:collection, collection_type: :series) }
+    let(:ma) { create(:manifestation) }
+    let(:mb) { create(:manifestation) }
+
+    before do
+      volume_with_placeholder.collection_items.create!(item: sub, seqno: 1)
+      volume_with_placeholder.collection_items.create!(alt_title: 'Placeholder', seqno: 2)
+      volume_with_placeholder.collection_items.create!(item: mb, seqno: 3)
+      sub.collection_items.create!(item: ma, seqno: 1)
+    end
+
+    it 'skips the placeholder and returns mb as next' do
+      expect(result.next_in_parent).to eq(mb)
+    end
+  end
+end

--- a/spec/services/find_siblings_spec.rb
+++ b/spec/services/find_siblings_spec.rb
@@ -105,4 +105,95 @@ describe FindSiblings do
       expect { result }.to raise_error('Item not found in collection')
     end
   end
+
+  context 'when next sibling is a sub-collection' do
+    subject(:result) { described_class.call(manifestation_a, parent_col) }
+
+    let(:parent_col) { create(:collection) }
+    let(:sub_col) { create(:collection) }
+    let(:manifestation_a) { create(:manifestation) }
+    let(:manifestation_b) { create(:manifestation) }
+    let(:manifestation_c) { create(:manifestation) }
+
+    before do
+      parent_col.collection_items.create!(item: manifestation_a, seqno: 1)
+      parent_col.collection_items.create!(item: sub_col, seqno: 2)
+      sub_col.collection_items.create!(item: manifestation_b, seqno: 1)
+      sub_col.collection_items.create!(item: manifestation_c, seqno: 2)
+    end
+
+    it 'drills into the sub-collection and returns its first manifestation as next' do
+      expect(result.next_sibling).to eq({ item: manifestation_b, skipped: 0 })
+    end
+
+    it 'returns nil as previous' do
+      expect(result.previous_sibling).to be_nil
+    end
+  end
+
+  context 'when previous sibling is a sub-collection' do
+    subject(:result) { described_class.call(manifestation_c, parent_col) }
+
+    let(:parent_col) { create(:collection) }
+    let(:sub_col) { create(:collection) }
+    let(:manifestation_a) { create(:manifestation) }
+    let(:manifestation_b) { create(:manifestation) }
+    let(:manifestation_c) { create(:manifestation) }
+
+    before do
+      parent_col.collection_items.create!(item: sub_col, seqno: 1)
+      sub_col.collection_items.create!(item: manifestation_a, seqno: 1)
+      sub_col.collection_items.create!(item: manifestation_b, seqno: 2)
+      parent_col.collection_items.create!(item: manifestation_c, seqno: 2)
+    end
+
+    it 'drills into the sub-collection and returns its last manifestation as previous' do
+      expect(result.previous_sibling).to eq({ item: manifestation_b, skipped: 0 })
+    end
+
+    it 'returns nil as next' do
+      expect(result.next_sibling).to be_nil
+    end
+  end
+
+  context 'when next sibling sub-collection has no manifestations (all placeholders)' do
+    subject(:result) { described_class.call(manifestation_a, parent_col) }
+
+    let(:parent_col) { create(:collection) }
+    let(:empty_sub) { create(:collection) }
+    let(:manifestation_a) { create(:manifestation) }
+    let(:manifestation_b) { create(:manifestation) }
+
+    before do
+      parent_col.collection_items.create!(item: manifestation_a, seqno: 1)
+      parent_col.collection_items.create!(item: empty_sub, seqno: 2)
+      empty_sub.collection_items.create!(alt_title: 'placeholder', seqno: 1)
+      parent_col.collection_items.create!(item: manifestation_b, seqno: 3)
+    end
+
+    it 'skips the empty sub-collection and returns the next real manifestation' do
+      expect(result.next_sibling).to eq({ item: manifestation_b, skipped: 1 })
+    end
+  end
+
+  context 'when next sibling sub-collection contains a nested sub-collection' do
+    subject(:result) { described_class.call(manifestation_a, parent_col) }
+
+    let(:parent_col) { create(:collection) }
+    let(:sub_col) { create(:collection) }
+    let(:nested_sub) { create(:collection) }
+    let(:manifestation_a) { create(:manifestation) }
+    let(:manifestation_b) { create(:manifestation) }
+
+    before do
+      parent_col.collection_items.create!(item: manifestation_a, seqno: 1)
+      parent_col.collection_items.create!(item: sub_col, seqno: 2)
+      sub_col.collection_items.create!(item: nested_sub, seqno: 1)
+      nested_sub.collection_items.create!(item: manifestation_b, seqno: 1)
+    end
+
+    it 'drills recursively into nested sub-collections to find the first manifestation' do
+      expect(result.next_sibling).to eq({ item: manifestation_b, skipped: 0 })
+    end
+  end
 end


### PR DESCRIPTION
## Summary

- Adds a new `CrossCollectionNavigation` service that finds the nearest `volume` or `periodical_issue` ancestor of a sub-collection and flattens all its manifestations into an ordered sequence
- When a user is at the last item in a sub-collection, the **next** button now links to the first item that follows that sub-collection in the parent volume/issue (first item of the next sibling sub-collection, or the next direct item)
- Symmetric for **prev** at the first item
- At the absolute first or last manifestation of the whole volume/issue, no button is shown
- Placeholders still take precedence: if there are placeholder items before/after in the current sub-collection, the placeholder message is shown instead of cross-collection navigation

## Technical notes

- `CrossCollectionNavigation` uses a direct `CollectionItem.where(collection: ...)` query (rather than `collection.collection_items`) to bypass stale `inverse_of` association caches that Rails sets up when loading collections through `parent_collection_items`
- Navigation supports arbitrary nesting depth (volume → sub-collection → sub-sub-collection → manifestation)
- View changes are minimal: 7 new lines in the `:ruby` block + 5 lines for the two new `elsif` branches

## Test plan

- [x] New service spec: `spec/services/cross_collection_navigation_spec.rb` (12 examples, all passing)
- [x] Existing `FindSiblings` spec still passes
- Covers: no-parent case, first/last in first/last sub-collection, direct items in parent, periodical_issue parent, placeholders

Closes beads_by-1m1

🤖 Generated with [Claude Code](https://claude.com/claude-code)