### PR TITLE
Give static assets and Active Storage requests a separate, higher rate limit

### DIFF
--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -13,8 +13,21 @@ class Rack::Attack
   Rack::Attack.blocklist "Block IPs from Environment Variable" do |req|
     BAD_IPS.include?(req.ip)
   end
-  # Throttle requests to 100 requests per 3 minutes per IP
+
+  ASSET_PATH_PREFIXES = ['/assets', '/rails/active_storage'].freeze
+
+  def self.asset_request?(req)
+    ASSET_PATH_PREFIXES.any? { |prefix| req.path.start_with?(prefix) }
+  end
+
+  # A single page can load dozens of images (Active Storage) or static assets,
+  # so give these paths a much higher allowance than regular page/API requests.
+  throttle('req/ip/assets', limit: 1500, period: 5.minutes) do |req|
+    req.ip if asset_request?(req)
+  end
+
+  # Throttle other requests to 100 requests per 3 minutes per IP
   throttle('req/ip', limit: 100, period: 3.minutes) do |req|
-    req.ip unless req.path.start_with?('/assets')
+    req.ip unless asset_request?(req)
   end
 end

--- a/spec/requests/rack_attack_spec.rb
+++ b/spec/requests/rack_attack_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Rack::Attack throttling', type: :request do
+  include ActiveSupport::Testing::TimeHelpers
+
+  around do |example|
+    original_store = Rack::Attack.cache.store
+    Rack::Attack.cache.store = ActiveSupport::Cache::MemoryStore.new
+    Rack::Attack.reset!
+    # Rack::Attack buckets counts by wall-clock time / period, so freeze time to
+    # avoid flakiness from the bucket rolling over mid-test.
+    freeze_time do
+      example.run
+    end
+    Rack::Attack.cache.store = original_store
+  end
+
+  let(:ip) { '203.0.113.7' }
+
+  before do
+    self.remote_addr = ip
+  end
+
+  it 'throttles regular (non-asset) paths after 100 requests per IP within the window' do
+    101.times { get '/this-path-does-not-exist' }
+
+    expect(response.status).to eq(429)
+  end
+
+  it 'gives /assets and /rails/active_storage paths a much higher throttle bucket' do
+    101.times { get '/assets/does-not-exist.js' }
+    expect(response.status).not_to eq(429)
+
+    101.times { get '/rails/active_storage/blobs/redirect/x/y.jpg' }
+    expect(response.status).not_to eq(429)
+  end
+end


### PR DESCRIPTION
## Summary
- Anonymous visitors browsing image-heavy pages (e.g. `Collection#show` with dozens of manifestation images, like `/collections/9217`) were getting broken images after the first couple — Rack::Attack's general `req/ip` throttle (100 req / 3 min) counted every `/rails/active_storage/...` image request, and only `/assets` was excluded from it.
- Logged-in users never hit this because they're unconditionally safelisted (`allow-logged-in-users`), so the bug was invisible in that flow — only anonymous requests got 429'd once the per-IP cap was exceeded.
- Adds a separate `req/ip/assets` throttle (1500 req / 5 min) covering `/assets` and `/rails/active_storage`, so a single page loading dozens of images doesn't exhaust the general-purpose throttle, while keeping the original 100/3min limit for all other traffic.

## Test plan
- Added `spec/requests/rack_attack_spec.rb`:
  - confirms non-asset paths still throttle after 100 requests/3min per IP
  - confirms `/assets` and `/rails/active_storage` paths tolerate >100 requests without hitting 429 (using the new higher-limit bucket)
  - freezes time during the test to avoid flakiness from the throttle's wall-clock bucket rolling over mid-run
- Ran the new spec 3x in isolation: stable, no flakes
- Ran full suite (`bundle exec rspec`): 3081 examples, 0 failures, 17 pending (all pre-existing/unrelated)