### PR TITLE
Fix flaky quick-verify spec (was misattributed to modal Esc-handling)

### DIFF
--- a/spec/system/lexicon/verification_external_identifiers_spec.rb
+++ b/spec/system/lexicon/verification_external_identifiers_spec.rb
@@ -77,6 +77,11 @@ describe 'Lexicon Verification Workbench – External Identifiers', :js do
         find('button[data-action="click->verification#quickVerify"]').click
       end
 
+      # quickVerify's PATCH is async and the click returns before it completes;
+      # the section reloads with the persisted state once it succeeds, so wait
+      # for that reload instead of racing entry.reload against the AJAX call.
+      expect(page).to have_css('#section-external-identifiers.verified', wait: 5)
+
       entry.reload
       expect(entry.verification_progress.dig('checklist', 'external_identifiers', 'verified')).to be true
     end


### PR DESCRIPTION
## Summary
- Fixes the flakiness tracked in bd `s31`, previously suspected to originate from the modal Esc-handling commit (21a68c1f). That hypothesis didn't hold up: the modal/Escape code only affects `openWorkEditPanel` (used by a different flow), and none of the tests in this spec file exercise it.
- The real cause: `spec/system/lexicon/verification_external_identifiers_spec.rb`'s "can mark external_identifiers as verified via the quick verify button" test clicked the quick-verify button and immediately did `entry.reload` + a DB assertion, with no Capybara wait in between. Capybara's `click` returns as soon as the DOM event fires — it does not wait for the async `PATCH` in `updateChecklistItem()` (`app/assets/javascripts/verification.js:155-165`) to complete. Under full-suite load this AJAX call sometimes lost the race against the Ruby test reaching `entry.reload`, producing a false failure.
- A leftover screenshot from the original flaky run (`tmp/capybara/failures_..._quick_verify_button_223.png`) shows the button still in "not verified" state right after the click — consistent with the AJAX not having completed, not with any modal/Escape issue.

## Fix
Added `expect(page).to have_css('#section-external-identifiers.verified', wait: 5)` after the click and before `entry.reload`, matching the wait pattern already used by the other tests in this same file (e.g. "marks the section as verified when the checkbox is checked").

## Test plan
- [x] `bundle exec rspec spec/system/lexicon/` (144 examples, 0 failures) — the file that previously flaked, run together with its 16 sibling specs under load.
- [x] Full `bundle exec rspec` (3081 examples, 0 failures, 17 pending — all pre-existing/unrelated pending specs).

Closes investigation for bd `s31`.