### PR TITLE
Fix focus-triggered popovers not opening on tap on iOS Safari

### DIFF
--- a/app/views/authors/_author_top.html.haml
+++ b/app/views/authors/_author_top.html.haml
@@ -14,7 +14,7 @@
         .author-sort-area
           .author-page-top-sort-desktop.notyet
             = t(:sort_and_filter)
-            = link_to '[?]', '#', 'class' => 'help', 'data-toggle' => 'popover', 'data-trigger' => 'focus', title: t(:about_sort_and_filter), 'data-content' => t(:sort_and_filter_popover)
+            = link_to '[?]', '#', 'class' => 'help', 'tabindex' => 0, 'data-toggle' => 'popover', 'data-trigger' => 'focus', title: t(:about_sort_and_filter), 'data-content' => t(:sort_and_filter_popover)
             .toggle-background-no{title: t(:toggle_filters_tt)}
               .toggle-button-no
           .author-page-top-sort-mobile

--- a/app/views/authors/toc.html.haml
+++ b/app/views/authors/toc.html.haml
@@ -21,7 +21,7 @@
                 - if @author.person.present?
                   .author-page-top-years!= "(#{@author.person.life_years})"
                   .metadata-link
-                    %a.help{href: '#', onclick: 'return false;', data: { toggle: :popover, trigger: :focus, content: t('period_popover') }}
+                    %a.help{href: '#', tabindex: 0, onclick: 'return false;', data: { toggle: :popover, trigger: :focus, content: t('period_popover') }}
                       %span.metadata-link-icon> P
                       = t(@author.person.period)
             .by-card-content-v02{class: @unpublished ? 'unpublished' : ''}

--- a/app/views/shared/_intellectual_property.html.haml
+++ b/app/views/shared/_intellectual_property.html.haml
@@ -1,6 +1,7 @@
 %span.by-icon-v02.copyright-icon= intellectual_property_glyph(intellectual_property)
 = link_to textify_intellectual_property(intellectual_property), '#',
           class: :help,
+          tabindex: 0,
           onclick: 'return false;',
           data: { toggle: :popover, trigger: :focus, content: t(".popover.#{intellectual_property}") },
           title: t(".about.#{intellectual_property}")

--- a/spec/system/ios_focus_popover_tabindex_spec.rb
+++ b/spec/system/ios_focus_popover_tabindex_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# Regression test for a bug where tapping the "intellectual property" label (and other
+# focus-triggered popovers) did nothing on iPhone, while working fine on desktop and Android.
+#
+# Root cause: these links use Bootstrap's `trigger: 'focus'` popover option, but iOS Safari
+# never fires a `focus` event when a plain <a> (without `tabindex`) is tapped, so the popover
+# never opens. Adding `tabindex="0"` makes iOS Safari treat the link as focusable on tap.
+describe 'Focus-triggered popover links are focusable on tap (iOS Safari fix)' do
+  it 'has tabindex on the intellectual property popover link on Manifestation#read' do
+    manifestation = create(:manifestation, status: :published)
+
+    visit manifestation_path(manifestation)
+
+    expect(page).to have_css('a.help[data-trigger="focus"][tabindex="0"]', visible: :all)
+  end
+
+  it 'has tabindex on all focus-triggered popover links on the author TOC page' do
+    author = create(:authority, name: 'Test Author', gender: 'male')
+
+    visit authority_path(author)
+
+    focus_popovers = page.all(:css, 'a.help[data-trigger="focus"]', visible: :all)
+
+    # intellectual property (rendered twice: header card and body), period, sort-and-filter
+    expect(focus_popovers.size).to eq(4)
+    focus_popovers.each do |link|
+      expect(link[:tabindex]).to eq('0')
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Users reported that tapping the intellectual property (זכויות יוצרים) label in Manifestation#read's metadata section did nothing on iPhone, while it worked fine on desktop and Android.
- Root cause: these labels use Bootstrap's `trigger: 'focus'` popover option on plain `<a href="#">` links. iOS Safari does not fire a `focus` event when such a link is tapped unless it has an explicit `tabindex` attribute — desktop browsers and Android Chrome do focus tapped/clicked anchors regardless, which is why the bug only showed up on iPhone.
- Added `tabindex="0"` to the three affected links so iOS Safari treats them as tap-focusable:
  - `app/views/shared/_intellectual_property.html.haml` (intellectual property label — Manifestation#read and other pages)
  - `app/views/authors/toc.html.haml` (author period label)
  - `app/views/authors/_author_top.html.haml` (sort-and-filter help label)

## Test plan
- [x] Added `spec/system/ios_focus_popover_tabindex_spec.rb`, verifying the fix would have caught the bug (confirmed test fails without the `tabindex` attribute, passes with it)
- [x] `bundle exec rubocop` and `bundle exec haml-lint` on all changed files — no new warnings introduced
- [x] `bundle exec rspec spec/system/ios_focus_popover_tabindex_spec.rb` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)