### PR TITLE
MOBI download fix

### DIFF
--- a/app/services/make_fresh_downloadable.rb
+++ b/app/services/make_fresh_downloadable.rb
@@ -1,6 +1,7 @@
 # Creates or overwrites downloadable from given Html file using provided file format
 class MakeFreshDownloadable < ApplicationService
   # @return created Downloadable object
+  # rubocop:disable Metrics/MethodLength
   def call(format, filename, html, download_entity, author_string, kwic_text: nil)
     # Convert images to absolute URLs for formats that need them (PDF, DOCX, etc.)
     # EPUBs handle images internally by embedding them
@@ -75,8 +76,11 @@ class MakeFreshDownloadable < ApplicationService
         begin
           # TODO: figure out how not to go through epub
           epubname = make_epub_from_single_html(html, download_entity, author_string)
-          mobiname = epubname[epubname.rindex('/') + 1..-6] + '.mobi'
-          unless system('kindlegen', epubname, '-c1', '-o', mobiname)
+          mobiname = epubname[(epubname.rindex('/') + 1)..-6] + '.mobi'
+
+          # kindlegen returns status 1 if there were warnings and 2 if there were critical errors
+          _stdout, _stderr, status = Open3.capture3('kindlegen', epubname, '-c1', '-o', mobiname)
+          if status.exitstatus > 1
             raise "Kindlegen conversion failed for EPUB #{epubname}"
           end
           mobiname = epubname[0..-6] + '.mobi'
@@ -164,4 +168,5 @@ class MakeFreshDownloadable < ApplicationService
       "<img#{before_src}src=#{quote}#{new_src}#{quote}#{after_src}"
     end
   end
+  # rubocop:enable Metrics/MethodLength
 end


### PR DESCRIPTION
Mobi file generation failed if kindlegen finished with a warning (e.g. missing cover).

The problem was introduced in this commit: https://github.com/projectbenyehuda/bybe/commit/440c418318198e8a6714ecae99401ac79d1871c3

```:ruby
      unless system('kindlegen', epubname, '-c1', '-o', mobiname)
        raise "Kindlegen conversion failed for EPUB #{epubname}"
      end
```

It checks if `kindlegen` utility was completed successfully, and if not raises an error.
The problem is that `system` call returns true only when return code is 0. It turned out though, that if mobi file was generated successfully but with warning it returns 1. And it returns 2 for critical errors.

There are many warnings, e.g. broken links, etc:
```
Warning(prcgen):W14001: Hyperlink not resolved:  /tmp/mobi-UZPpWi/OEBPS/8_text.xhtml#fnref:1
```

 But this warning should affect all files in system:
```
Warning(prcgen):W14016: Cover not specified
```
So I believe in our case any attempt to download mobi file ended with an error (with exception to mobi files generated before that change and stored in Downloadable table)

Fixed, by checking exit status and threating 0 and 1 statuses as success.