### PR TITLE
Show a single parent collection in Manifestation#read

### DIFF
--- a/app/controllers/manifestation_controller.rb
+++ b/app/controllers/manifestation_controller.rb
@@ -1329,9 +1329,77 @@ class ManifestationController < ApplicationController
       @containments.reject! { |ci| ci.collection.uncollected? }
     end
     @single_text_volume = @containments.size == 1 && @containments.first.collection.collection_type == 'volume' && !@containments.first.collection.has_multiple_manifestations?
+    select_parent_containment
   end
 
   private
+
+  # When a manifestation belongs to more than one collection, navigating within one collection can
+  # inadvertently land the user on a work that is also in a second collection, whose next/prev
+  # controls would then lead them astray. To prevent this we surface only a single parent collection
+  # -- both in the "inside X" volume list (@volumes) and in the in-collection navigation
+  # (@containments) -- choosing it from (in order of preference):
+  #   1. an explicit parent_collection_id param (carried by sibling next/prev links), or
+  #   2. the Collection#show page the user arrived from (via the referer header), or
+  #   3. the parent with the earliest publication year (fallback for direct/external arrivals).
+  # The remaining parent collections are exposed via @other_parent_collections for a sidebar pane.
+  def select_parent_containment
+    @other_parent_collections = []
+    return if @containments.size <= 1
+
+    @multiple_parents = true
+    chosen = containment_for_hint(parent_collection_hint) ||
+             @containments.min_by { |ci| parent_pub_year(ci) }
+    chosen_volume = parent_volume_for(chosen)
+    @other_parent_collections = (@containments - [chosen])
+                                .map { |ci| parent_volume_for(ci) || ci.collection }
+                                .uniq
+                                .reject { |c| c == chosen_volume }
+                                .sort_by { |c| [c.normalized_pub_year || Float::INFINITY, c.id] }
+    @containments = [chosen]
+    @volumes = [chosen_volume].compact
+  end
+
+  # Returns the containment matching the given collection id, either directly or via its
+  # volume/issue-level ancestor (a Collection#show referer points at the volume, not the sub-series).
+  def containment_for_hint(collection_id)
+    return nil if collection_id.nil?
+
+    @containments.find { |ci| ci.collection_id == collection_id || parent_volume_for(ci)&.id == collection_id }
+  end
+
+  # The volume/issue-level collection a containment ultimately belongs to (itself if it is one, its
+  # volume/issue ancestor otherwise, or nil for collections with no such ancestor). Mirrors the
+  # per-collection logic in Manifestation#volumes so @volumes stays consistent with the chosen parent.
+  def parent_volume_for(containment)
+    collection = containment.collection
+    return collection if collection.volume? || collection.periodical_issue?
+
+    collection.parent_volume_or_isssue
+  end
+
+  # Publication year used to pick the default parent: the volume/issue's year (falling back to the
+  # containing collection's own), with unknowns sorting last.
+  def parent_pub_year(containment)
+    (parent_volume_for(containment) || containment.collection).normalized_pub_year || Float::INFINITY
+  end
+
+  # Extracts a hint about the "current" parent collection from the request: an explicit
+  # parent_collection_id param takes precedence, otherwise a referer pointing at a Collection#show
+  # page (/collections/:id) is used. Returns an Integer id or nil.
+  def parent_collection_hint
+    id = params[:parent_collection_id].presence
+    return id.to_i if id
+
+    ref = request.referer
+    return nil if ref.blank?
+
+    path = URI(ref).path
+    match = path.match(%r{\A/collections/(\d+)})
+    match && match[1].to_i
+  rescue URI::InvalidURIError
+    nil
+  end
 
   def set_manifestation
     @m = Manifestation.find(params[:id])

--- a/app/controllers/manifestation_controller.rb
+++ b/app/controllers/manifestation_controller.rb
@@ -1328,8 +1328,13 @@ class ManifestationController < ApplicationController
       RefreshUncollectedWorksCollectionJob.perform_async(uncollected_collection_ids)
       @containments.reject! { |ci| ci.collection.uncollected? }
     end
-    @single_text_volume = @containments.size == 1 && @containments.first.collection.collection_type == 'volume' && !@containments.first.collection.has_multiple_manifestations?
     select_parent_containment
+    # Computed after select_parent_containment so it reflects the finally-chosen containment. A work
+    # with several parents is never treated as a single-text volume: we still want to show the chosen
+    # parent's "inside X" line and navigation alongside the other-parents sidebar.
+    @single_text_volume = !@multiple_parents && @containments.size == 1 &&
+                          @containments.first.collection.collection_type == 'volume' &&
+                          !@containments.first.collection.has_multiple_manifestations?
   end
 
   private

--- a/app/helpers/manifestation_helper.rb
+++ b/app/helpers/manifestation_helper.rb
@@ -64,7 +64,7 @@ module ManifestationHelper
   # Builds the path for a sibling next/prev navigation link in Manifestation#read, optionally
   # carrying forward the current parent collection (so the target page shows the same parent when the
   # work belongs to several collections) and the count of skipped placeholder items.
-  def read_sibling_path(item, skipped: 0, parent_collection_id: nil)
+  def read_sibling_path(item, parent_collection_id = nil, skipped: 0)
     query = {}
     query[:skipped] = skipped if skipped.to_i.positive?
     query[:parent_collection_id] = parent_collection_id if parent_collection_id.present?

--- a/app/helpers/manifestation_helper.rb
+++ b/app/helpers/manifestation_helper.rb
@@ -60,4 +60,15 @@ module ManifestationHelper
   def browse_null_decorator(item)
     ''
   end
+
+  # Builds the path for a sibling next/prev navigation link in Manifestation#read, optionally
+  # carrying forward the current parent collection (so the target page shows the same parent when the
+  # work belongs to several collections) and the count of skipped placeholder items.
+  def read_sibling_path(item, skipped: 0, parent_collection_id: nil)
+    query = {}
+    query[:skipped] = skipped if skipped.to_i.positive?
+    query[:parent_collection_id] = parent_collection_id if parent_collection_id.present?
+    base = default_link_by_class(item.class, item.id)
+    query.empty? ? base : "#{base}?#{query.to_query}"
+  end
 end

--- a/app/views/manifestation/read.html.haml
+++ b/app/views/manifestation/read.html.haml
@@ -38,17 +38,21 @@
                 show_nav = prev.present? || nextsib.present? || show_collection_link ||
                            siblings.more_before? || siblings.more_after? ||
                            cross_prev.present? || cross_next.present?
+                parent_hint = @multiple_parents ? ci.collection_id : nil
+                prev_path = prev && read_sibling_path(prev[:item], parent_hint, skipped: prev[:skipped])
+                next_path = nextsib && read_sibling_path(nextsib[:item], parent_hint, skipped: nextsib[:skipped])
+                cross_prev_path = cross_prev && read_sibling_path(cross_prev, parent_hint)
+                cross_next_path = cross_next && read_sibling_path(cross_next, parent_hint)
               - next unless show_nav
-              - parent_hint = @multiple_parents ? ci.collection_id : nil
               .author-works-nav
                 .topNavEntry
                   .link-nav
                     - if prev.present?
-                      = link_to read_sibling_path(prev[:item], skipped: prev[:skipped], parent_collection_id: parent_hint) do
+                      = link_to prev_path do
                         %span.right-arrow= '2'
                         = t(:to_previous_item)
                     - elsif cross_prev.present?
-                      = link_to read_sibling_path(cross_prev, parent_collection_id: parent_hint) do
+                      = link_to cross_prev_path do
                         %span.right-arrow= '2'
                         = t(:to_previous_item)
                     - elsif siblings.more_before?
@@ -63,11 +67,11 @@
                 .topNavEntry
                   .link-nav
                     - if nextsib.present?
-                      = link_to read_sibling_path(nextsib[:item], skipped: nextsib[:skipped], parent_collection_id: parent_hint) do
+                      = link_to next_path do
                         = t(:to_next_item)
                         %span.left-arrow= '1'
                     - elsif cross_next.present?
-                      = link_to read_sibling_path(cross_next, parent_collection_id: parent_hint) do
+                      = link_to cross_next_path do
                         = t(:to_next_item)
                         %span.left-arrow= '1'
                     - elsif siblings.more_after?
@@ -91,8 +95,9 @@
       .col
         = render partial: 'shared/about_pby'
         = render partial: 'shared/donation_box_negative'
-        -# Other collections in the corpus that also contain this work (shown when it has several
-        -# parent collections, so only one is used for the in-collection navigation above)
+        -#
+          Other collections in the corpus that also contain this work (shown when it has several
+          parent collections, so only one is used for the in-collection navigation above)
         - if @other_parent_collections.present?
           .by-card-v02.left-side-card-v02
             .by-card-header-left-v02

--- a/app/views/manifestation/read.html.haml
+++ b/app/views/manifestation/read.html.haml
@@ -100,7 +100,7 @@
             .by-card-content-v02
               %ul
                 - @other_parent_collections.each do |coll|
-                  %li= link_to coll.title, collection_path(coll)
+                  %li= link_to coll.title, collection_up_link_path(coll)
         -# Works about this work
         - if @works_about.count > 0
           = render partial: 'public_aboutnesses', locals: {edit: false, add: false}

--- a/app/views/manifestation/read.html.haml
+++ b/app/views/manifestation/read.html.haml
@@ -39,16 +39,16 @@
                            siblings.more_before? || siblings.more_after? ||
                            cross_prev.present? || cross_next.present?
               - next unless show_nav
+              - parent_hint = @multiple_parents ? ci.collection_id : nil
               .author-works-nav
                 .topNavEntry
                   .link-nav
                     - if prev.present?
-                      - extra = prev[:skipped] > 0 ? "?skipped=#{prev[:skipped]}" : ''
-                      = link_to "#{default_link_by_class(prev[:item].class, prev[:item].id)}#{extra}" do
+                      = link_to read_sibling_path(prev[:item], skipped: prev[:skipped], parent_collection_id: parent_hint) do
                         %span.right-arrow= '2'
                         = t(:to_previous_item)
                     - elsif cross_prev.present?
-                      = link_to default_link_by_class(cross_prev.class, cross_prev.id) do
+                      = link_to read_sibling_path(cross_prev, parent_collection_id: parent_hint) do
                         %span.right-arrow= '2'
                         = t(:to_previous_item)
                     - elsif siblings.more_before?
@@ -63,12 +63,11 @@
                 .topNavEntry
                   .link-nav
                     - if nextsib.present?
-                      - extra = nextsib[:skipped] > 0 ? "?skipped=#{nextsib[:skipped]}" : ''
-                      = link_to "#{default_link_by_class(nextsib[:item].class, nextsib[:item].id)}#{extra}" do
+                      = link_to read_sibling_path(nextsib[:item], skipped: nextsib[:skipped], parent_collection_id: parent_hint) do
                         = t(:to_next_item)
                         %span.left-arrow= '1'
                     - elsif cross_next.present?
-                      = link_to default_link_by_class(cross_next.class, cross_next.id) do
+                      = link_to read_sibling_path(cross_next, parent_collection_id: parent_hint) do
                         = t(:to_next_item)
                         %span.left-arrow= '1'
                     - elsif siblings.more_after?
@@ -92,6 +91,16 @@
       .col
         = render partial: 'shared/about_pby'
         = render partial: 'shared/donation_box_negative'
+        -# Other collections in the corpus that also contain this work (shown when it has several
+        -# parent collections, so only one is used for the in-collection navigation above)
+        - if @other_parent_collections.present?
+          .by-card-v02.left-side-card-v02
+            .by-card-header-left-v02
+              %span.headline-1-v02= t(:other_containing_collections)
+            .by-card-content-v02
+              %ul
+                - @other_parent_collections.each do |coll|
+                  %li= link_to coll.title, collection_path(coll)
         -# Works about this work
         - if @works_about.count > 0
           = render partial: 'public_aboutnesses', locals: {edit: false, add: false}

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1062,6 +1062,7 @@ en:
     tagging suggestion: "%{explanation}"'
   additional_translations: Additional Translations of the Work
   additional_versions: Additional Versions of this Work
+  other_containing_collections: Other collections in the corpus containing this work
   link_to_another_text: Link to Another Text/Translation
   enter_manifestation_id: Manifestation ID to Link
   show_details: Show Details

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -638,6 +638,7 @@ he:
   chapters_list: 'רשימת פרקים:'
   additional_translations: תרגומים נוספים ליצירה
   additional_versions: נוסחים אחרים ליצירה זו
+  other_containing_collections: חיבורים נוספים במאגר המכילים יצירה זו
   link_to_another_text: קישור לנוסח/תרגום אחר
   enter_manifestation_id: מספר מימוש לקישור
   show_details: הצג פרטים

--- a/spec/controllers/manifestations_controller_spec.rb
+++ b/spec/controllers/manifestations_controller_spec.rb
@@ -481,6 +481,61 @@ describe ManifestationController do
           expect(response.body).to include("href=\"#{expected_href}\"")
         end
       end
+
+      context 'when manifestation belongs to more than one collection' do
+        let!(:earlier_collection) do
+          create(:collection, collection_type: :volume, pub_year: '1920', manifestations: [manifestation])
+        end
+        let!(:later_collection) do
+          create(:collection, collection_type: :volume, pub_year: '1950', manifestations: [manifestation])
+        end
+
+        it 'defaults to the earliest-published parent and lists the rest in the sidebar' do
+          expect(call).to be_successful
+          expect(assigns(:containments).size).to eq(1)
+          expect(assigns(:containments).first.collection).to eq(earlier_collection)
+          expect(assigns(:volumes)).to eq([earlier_collection])
+          expect(assigns(:other_parent_collections)).to eq([later_collection])
+          expect(response.body).to include(I18n.t(:other_containing_collections))
+          expect(response.body).to include(collection_path(later_collection))
+        end
+
+        it 'honours an explicit parent_collection_id param' do
+          get :read, params: { id: manifestation.id, parent_collection_id: later_collection.id }
+          expect(assigns(:containments).size).to eq(1)
+          expect(assigns(:containments).first.collection).to eq(later_collection)
+          expect(assigns(:other_parent_collections)).to eq([earlier_collection])
+        end
+
+        it 'uses the referring Collection#show page when no param is given' do
+          request.env['HTTP_REFERER'] = collection_url(later_collection)
+          get :read, params: { id: manifestation.id }
+          expect(assigns(:containments).first.collection).to eq(later_collection)
+        end
+
+        it 'falls back to the earliest parent when the referer is unrelated' do
+          request.env['HTTP_REFERER'] = 'https://example.com/some/other/page'
+          get :read, params: { id: manifestation.id }
+          expect(assigns(:containments).first.collection).to eq(earlier_collection)
+        end
+      end
+
+      context 'when manifestation has multiple parents and siblings in the chosen one' do
+        let(:next_manifestation) { create(:manifestation) }
+        let!(:nav_collection) do
+          create(:collection, collection_type: :volume, pub_year: '1920',
+                              manifestations: [manifestation, next_manifestation])
+        end
+        let!(:other_collection) do
+          create(:collection, collection_type: :volume, pub_year: '1950', manifestations: [manifestation])
+        end
+
+        it 'carries the chosen parent forward on sibling navigation links' do
+          expect(call).to be_successful
+          expect(assigns(:containments).first.collection).to eq(nav_collection)
+          expect(response.body).to include("parent_collection_id=#{nav_collection.id}")
+        end
+      end
     end
 
     describe '#readmode' do


### PR DESCRIPTION
## Summary

In `Manifestation#read`, when a work belongs to **more than one collection**, the page previously showed **every** parent collection — both in the "inside X" volume list (metadata) and as separate next/prev navigation controls. This could disorient a reader: navigating "next" within collection c1 could land on a work also in c2, and the reader might then click c2's "next" and be led into a different volume/issue.

This PR makes the read page surface **only one** parent collection, and lists the rest in a new sidebar pane.

## Behavior

- **0 or 1 parent collection:** unchanged.
- **More than one parent collection**, the single displayed parent (used for both the "inside X" list and the nav controls) is chosen by:
  1. an explicit `parent_collection_id` param — now carried forward on sibling next/prev links (and matched against a containment's collection **or** its volume/issue ancestor);
  2. otherwise a `Collection#show` referer (`/collections/:id`), matched the same way;
  3. otherwise the parent with the **earliest publication year** (for direct/external arrivals), unknown years sorting last.
- The remaining parents are shown in a new sidebar pane (after `donation_box_negative`, before `works_about`) titled **חיבורים נוספים במאגר המכילים יצירה זו**, each a link to that collection's `Collection#show`.

## Changes

- `manifestation_controller.rb`: `select_parent_containment` + helpers reduce `@containments`/`@volumes` to the chosen parent and expose `@other_parent_collections`.
- `manifestation_helper.rb`: `read_sibling_path` builds sibling nav links carrying the chosen parent (and `skipped`).
- `read.html.haml`: nav links use the new helper; new sidebar pane.
- `he.yml` / `en.yml`: `other_containing_collections`.

## Testing

- New controller specs cover: earliest-pub-year default, explicit param, referer-derived parent, fallback on unrelated referer, and forward-carried param on sibling links (`spec/controllers/manifestations_controller_spec.rb`).
- `bundle exec rspec spec/controllers/manifestations_controller_spec.rb` → 104 examples, 0 failures.
- Full suite passed (exit 0) on the pre-`@volumes` revision; only the localized read-path specs were re-run after the `@volumes` follow-up.
- Verified live on the dev server (`/read/11246`, three volume parents): metadata + nav now show only the earliest (1939) volume; the other two appear in the sidebar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
