### PR TITLE
Add per-volume collapse toggle to Authority TOC

### DIFF
--- a/.claude/rules/testing-requirements.md
+++ b/.claude/rules/testing-requirements.md
@@ -111,4 +111,36 @@ Capybara automatically waits (default 2 seconds, configurable) for:
 - `find`, `have_content`, `have_css`, `have_xpath`, `have_text`
 - All matchers and finders
 
+### Subtle trap: RSpec predicate matchers and attribute reads do NOT wait
+
+`sleep` is not the only source of flakiness. **RSpec predicate matchers and
+snapshot attribute reads on a Capybara node read the DOM exactly once — they do
+NOT poll.** After an animation (jQuery `slideUp`/`slideToggle`, fades, CSS
+transitions) or any async DOM update, they will observe the *pre-transition*
+state and fail intermittently.
+
+**DO NOT** (these snapshot state once, no retry):
+```ruby
+toggle.click
+expect(child_list).not_to be_visible            # ❌ be_visible = one-shot predicate
+expect(toggle[:class]).to include('collapsed')  # ❌ [:class] read once
+expect(card['aria-expanded']).to eq('false')    # ❌ attribute read once
+```
+
+**DO** — assert through a waiting Capybara matcher first, so the animation
+settles before you read any snapshot values:
+```ruby
+toggle.click
+# have_css with a visibility filter polls until the element is actually hidden:
+expect(cwrapper).to have_css('ul.toclist', visible: :hidden)   # ✅ waits
+# Only NOW read snapshot attributes — the DOM has settled:
+expect(toggle[:class]).to include('collapsed')
+expect(card['aria-expanded']).to eq('false')
+```
+
+Use `visible: :visible` / `visible: :hidden` on `have_css`/`have_selector` to
+wait for visibility changes. Reach for `matches_css?`/`match_selector` when you
+must wait on a specific element's class. **Never** gate correctness on a bare
+`be_visible`, `[:attr]`, or `['aria-*']` read immediately after an interaction.
+
 **Remember**: A feature without tests is an incomplete feature.

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -15,6 +15,22 @@
  *= require_self
  *= require slick
 */
+// Per-volume collapse toggle in the Authority TOC: uses the ben-yehuda chevron
+// glyph ")" (same as the navbar .dropdown-arrow). Expanded points up, collapsed points down.
+.volume-collapse-toggle {
+  font-family: ben-yehuda;
+  font-size: 0.7em;
+  cursor: pointer;
+  display: inline-block;
+  margin-inline-start: 8px;
+  transform: rotate(180deg); // expanded state: chevron points up
+  transition: transform 0.2s ease;
+
+  &.collapsed {
+    transform: rotate(0deg); // collapsed state: chevron points down
+  }
+}
+
 // Staging environment indicator: diagonal stripe overlay
 body.staging::before {
   content: '';

--- a/app/views/authors/_generated_toc.html.haml
+++ b/app/views/authors/_generated_toc.html.haml
@@ -82,6 +82,10 @@
               $(this).children('.by-icon-v02').remove();
               $(this).prepend(manifs.find('.by-icon-v02').clone());
               manifs.hide();
+              // this volume is now shown as a single link, so there is nothing left
+              // to collapse: drop the per-volume toggle and its ARIA expanded state
+              $(this).find('.volume-collapse-toggle').remove();
+              $(this).closest('.by-card-v02[role="treeitem"]').removeAttr('aria-expanded');
             }
           }
         }

--- a/app/views/authors/_toc_node.html.haml
+++ b/app/views/authors/_toc_node.html.haml
@@ -75,8 +75,9 @@
                   = link_to t(:edit), collection_manage_path(collection.id), style: 'font-size: 70%;'
                 - if collection.volume? && renders_toclist
                   - toggle_label = t(:toggle_collapse_volume)
+                  -# aria-expanded on the toggle itself: focus lands here, not on the treeitem li
                   %span.volume-collapse-toggle{ role: 'button', tabindex: 0, title: toggle_label,
-                                                aria: { label: toggle_label } } )
+                                                aria: { label: toggle_label, expanded: 'true' } } )
               - ias = collection.involved_authorities
               - authorities = {}
               - ias.each do |ia|

--- a/app/views/authors/_toc_node.html.haml
+++ b/app/views/authors/_toc_node.html.haml
@@ -41,7 +41,7 @@
     - children = toc_node.children_by_role(role, authority_id, involved_on_collection_level)
     - children.reject! { |child| child.is_a?(TocTree::ManifestationNode) && child.manifestation.deprecated? }
     - if !uncollected || children.present?
-      %li.by-card-v02{"aria-expanede" => "false", :role => "treeitem"}
+      %li.by-card-v02{"aria-expanded" => "true", :role => "treeitem"}
         .by-card-content-v02{:style => "padding-top: 12px;"}
           .cwrapper{ id: "cwrapper_#{collection.id}", 'data-nonce' => nonce, 'data-collection-id' => collection.id, class: uncollected ? 'uncollected' : '' }
             %div{style:'font-size:120%;'}
@@ -70,6 +70,8 @@
                     = " (#{type_prefix})"
                   != '&nbsp;&nbsp;&nbsp;'
                   = link_to t(:edit), collection_manage_path(collection.id), style: 'font-size: 70%;'
+                - if collection.volume? && children.present?
+                  %span.volume-collapse-toggle{ role: 'button', tabindex: 0, title: t(:toggle_collapse_volume), 'aria-label' => t(:toggle_collapse_volume) } )
               - ias = collection.involved_authorities
               - authorities = {}
               - ias.each do |ia|

--- a/app/views/authors/_toc_node.html.haml
+++ b/app/views/authors/_toc_node.html.haml
@@ -40,8 +40,11 @@
     - uncollected = collection.collection_type == 'uncollected'
     - children = toc_node.children_by_role(role, authority_id, involved_on_collection_level)
     - children.reject! { |child| child.is_a?(TocTree::ManifestationNode) && child.manifestation.deprecated? }
+    -# a collapsible ul.toclist is rendered only in the non-editable branch below, when there are children
+    - renders_toclist = children.present? && !(editable && (collection.uncollected? || involved_on_collection_level))
     - if !uncollected || children.present?
-      %li.by-card-v02{"aria-expanded" => "true", :role => "treeitem"}
+      -# aria-expanded only on items that actually have an expandable list, per ARIA tree semantics
+      %li.by-card-v02{ 'aria-expanded' => (renders_toclist ? 'true' : nil), :role => 'treeitem' }
         .by-card-content-v02{:style => "padding-top: 12px;"}
           .cwrapper{ id: "cwrapper_#{collection.id}", 'data-nonce' => nonce, 'data-collection-id' => collection.id, class: uncollected ? 'uncollected' : '' }
             %div{style:'font-size:120%;'}
@@ -70,8 +73,10 @@
                     = " (#{type_prefix})"
                   != '&nbsp;&nbsp;&nbsp;'
                   = link_to t(:edit), collection_manage_path(collection.id), style: 'font-size: 70%;'
-                - if collection.volume? && children.present?
-                  %span.volume-collapse-toggle{ role: 'button', tabindex: 0, title: t(:toggle_collapse_volume), 'aria-label' => t(:toggle_collapse_volume) } )
+                - if collection.volume? && renders_toclist
+                  - toggle_label = t(:toggle_collapse_volume)
+                  %span.volume-collapse-toggle{ role: 'button', tabindex: 0, title: toggle_label,
+                                                aria: { label: toggle_label } } )
               - ias = collection.involved_authorities
               - authorities = {}
               - ias.each do |ia|

--- a/app/views/authors/toc.html.haml
+++ b/app/views/authors/toc.html.haml
@@ -375,7 +375,8 @@
         $('#browse_mainlist .by-card-v02[role="treeitem"] .toclist').slideUp();
         // only expandable cards (those with a .toclist) carry aria-expanded
         $('#browse_mainlist .by-card-v02[role="treeitem"]:has(.toclist)').attr('aria-expanded', 'false');
-        $('#browse_mainlist .volume-collapse-toggle').addClass('collapsed');
+        // keep the focusable toggles' own aria-expanded in sync with their state
+        $('#browse_mainlist .volume-collapse-toggle').addClass('collapsed').attr('aria-expanded', 'false');
       });
 
       // Expand all sections
@@ -384,7 +385,8 @@
         $('#browse_mainlist .by-card-v02[role="treeitem"] .toclist').slideDown();
         // only expandable cards (those with a .toclist) carry aria-expanded
         $('#browse_mainlist .by-card-v02[role="treeitem"]:has(.toclist)').attr('aria-expanded', 'true');
-        $('#browse_mainlist .volume-collapse-toggle').removeClass('collapsed');
+        // keep the focusable toggles' own aria-expanded in sync with their state
+        $('#browse_mainlist .volume-collapse-toggle').removeClass('collapsed').attr('aria-expanded', 'true');
       });
 
       // Toggle a single volume's children list (delegated: nodes are server-rendered)
@@ -396,12 +398,13 @@
         var expanded = $card.attr('aria-expanded') !== 'false';
         if (expanded) {
           $list.slideUp();
+          // keep both the treeitem card and the focusable toggle's aria-expanded in sync
           $card.attr('aria-expanded', 'false');
-          $toggle.addClass('collapsed');
+          $toggle.addClass('collapsed').attr('aria-expanded', 'false');
         } else {
           $list.slideDown();
           $card.attr('aria-expanded', 'true');
-          $toggle.removeClass('collapsed');
+          $toggle.removeClass('collapsed').attr('aria-expanded', 'true');
         }
       }
       $('#browse_mainlist').on('click', '.volume-collapse-toggle', function(e) {

--- a/app/views/authors/toc.html.haml
+++ b/app/views/authors/toc.html.haml
@@ -373,7 +373,8 @@
       $('#max_collapse').click(function(e) {
         e.preventDefault();
         $('#browse_mainlist .by-card-v02[role="treeitem"] .toclist').slideUp();
-        $('#browse_mainlist .by-card-v02[role="treeitem"]').attr('aria-expanded', 'false');
+        // only expandable cards (those with a .toclist) carry aria-expanded
+        $('#browse_mainlist .by-card-v02[role="treeitem"]:has(.toclist)').attr('aria-expanded', 'false');
         $('#browse_mainlist .volume-collapse-toggle').addClass('collapsed');
       });
 
@@ -381,7 +382,8 @@
       $('#expand-all').click(function(e) {
         e.preventDefault();
         $('#browse_mainlist .by-card-v02[role="treeitem"] .toclist').slideDown();
-        $('#browse_mainlist .by-card-v02[role="treeitem"]').attr('aria-expanded', 'true');
+        // only expandable cards (those with a .toclist) carry aria-expanded
+        $('#browse_mainlist .by-card-v02[role="treeitem"]:has(.toclist)').attr('aria-expanded', 'true');
         $('#browse_mainlist .volume-collapse-toggle').removeClass('collapsed');
       });
 

--- a/app/views/authors/toc.html.haml
+++ b/app/views/authors/toc.html.haml
@@ -374,6 +374,7 @@
         e.preventDefault();
         $('#browse_mainlist .by-card-v02[role="treeitem"] .toclist').slideUp();
         $('#browse_mainlist .by-card-v02[role="treeitem"]').attr('aria-expanded', 'false');
+        $('#browse_mainlist .volume-collapse-toggle').addClass('collapsed');
       });
 
       // Expand all sections
@@ -381,5 +382,34 @@
         e.preventDefault();
         $('#browse_mainlist .by-card-v02[role="treeitem"] .toclist').slideDown();
         $('#browse_mainlist .by-card-v02[role="treeitem"]').attr('aria-expanded', 'true');
+        $('#browse_mainlist .volume-collapse-toggle').removeClass('collapsed');
+      });
+
+      // Toggle a single volume's children list (delegated: nodes are server-rendered)
+      function toggleVolume($toggle) {
+        var $card = $toggle.closest('.by-card-v02[role="treeitem"]');
+        // Only this volume's own children list (direct child of its cwrapper),
+        // not the toclists of any nested collections deeper in the tree.
+        var $list = $toggle.closest('.cwrapper').children('ul.toclist');
+        var expanded = $card.attr('aria-expanded') !== 'false';
+        if (expanded) {
+          $list.slideUp();
+          $card.attr('aria-expanded', 'false');
+          $toggle.addClass('collapsed');
+        } else {
+          $list.slideDown();
+          $card.attr('aria-expanded', 'true');
+          $toggle.removeClass('collapsed');
+        }
+      }
+      $('#browse_mainlist').on('click', '.volume-collapse-toggle', function(e) {
+        e.preventDefault();
+        toggleVolume($(this));
+      });
+      $('#browse_mainlist').on('keydown', '.volume-collapse-toggle', function(e) {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          toggleVolume($(this));
+        }
       });
   });

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3197,6 +3197,7 @@ en:
   total_collections_including_author: Total collections involving author
   collapse_all_sections: Collapse all sections
   expand_all_sections: Expand all sections
+  toggle_collapse_volume: Collapse or expand this volume
   legacy_urls:
     index:
       title: Legacy URL Mappings

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -2454,6 +2454,7 @@ he:
   total_collections_including_author: כותרים במאגר
   collapse_all_sections: צמצם הכל
   expand_all_sections: הרחב הכל
+  toggle_collapse_volume: צמצם או הרחב כרך זה
   by_involved_authorities: לפי אישים מעורבים
   works_and_volumes: כותרים ויצירות
   list_all_collections: רשימת כל הכותרים

--- a/spec/system/author_toc_volume_collapse_toggle_spec.rb
+++ b/spec/system/author_toc_volume_collapse_toggle_spec.rb
@@ -46,18 +46,21 @@ describe 'Author TOC per-volume collapse toggle', :js do
     expect(card['aria-expanded']).to eq('true')
     expect(cwrapper).to have_css('ul.toclist', visible: :visible)
     expect(toggle[:class]).not_to include('collapsed')
+    expect(toggle['aria-expanded']).to eq('true')
 
     # Collapse this volume (Capybara waits for the slide animation to finish)
     toggle.click
     expect(cwrapper).to have_css('ul.toclist', visible: :hidden)
     expect(toggle[:class]).to include('collapsed')
     expect(card['aria-expanded']).to eq('false')
+    expect(toggle['aria-expanded']).to eq('false')
 
     # Expand it again
     toggle.click
     expect(cwrapper).to have_css('ul.toclist', visible: :visible)
     expect(toggle[:class]).not_to include('collapsed')
     expect(card['aria-expanded']).to eq('true')
+    expect(toggle['aria-expanded']).to eq('true')
   end
 
   it 'drops the toggle for a single-work volume pruned into a single link' do
@@ -99,12 +102,14 @@ describe 'Author TOC per-volume collapse toggle', :js do
 
     find('#max_collapse').click
     expect(page).to have_css('#browse_mainlist .volume-collapse-toggle.collapsed')
-    # every toggle must be collapsed, not just some
+    # every toggle must be collapsed, not just some (class and its own aria-expanded)
     expect(page).to have_no_css('#browse_mainlist .volume-collapse-toggle:not(.collapsed)')
+    expect(page).to have_no_css('#browse_mainlist .volume-collapse-toggle[aria-expanded="true"]')
 
     find('#expand-all').click
     expect(page).to have_css('#browse_mainlist .volume-collapse-toggle:not(.collapsed)')
-    # every toggle must be expanded, not just some
+    # every toggle must be expanded, not just some (class and its own aria-expanded)
     expect(page).to have_no_css('#browse_mainlist .volume-collapse-toggle.collapsed')
+    expect(page).to have_no_css('#browse_mainlist .volume-collapse-toggle[aria-expanded="false"]')
   end
 end

--- a/spec/system/author_toc_volume_collapse_toggle_spec.rb
+++ b/spec/system/author_toc_volume_collapse_toggle_spec.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# Covers the per-volume collapse toggle added to the Authority TOC: each
+# volume-type collection with children gets a chevron toggle at the end of its
+# title line that collapses/expands only that volume's children list.
+describe 'Author TOC per-volume collapse toggle', :js do
+  before do
+    skip 'WebDriver not available or misconfigured' unless webdriver_available?
+  end
+
+  let!(:author) { create(:authority, name: 'Test Author') }
+
+  let!(:volume) do
+    create(:collection, title: 'Test Volume', collection_type: :volume)
+  end
+
+  let!(:work_in_volume) do
+    Chewy.strategy(:atomic) do
+      create(:manifestation, title: 'Work in Volume', status: :published, author: author)
+    end
+  end
+
+  let!(:collection_item) do
+    create(:collection_item, collection: volume, item: work_in_volume)
+  end
+
+  let!(:involved_authority) do
+    create(:involved_authority, authority: author, item: volume, role: 'editor')
+  end
+
+  after { Chewy.massacre }
+
+  it 'shows a collapse toggle on the volume and toggles only that volume' do
+    visit authority_path(author)
+
+    expect(page).to have_css('#browse_mainlist')
+    toggle = find('#browse_mainlist .volume-collapse-toggle', match: :first)
+
+    card = toggle.find(:xpath, "./ancestor::li[contains(@class, 'by-card-v02')][1]")
+    # This volume's own children list lives directly under its cwrapper.
+    cwrapper = toggle.find(:xpath, "./ancestor::div[contains(@class, 'cwrapper')][1]")
+
+    # Initially expanded: children visible, toggle not collapsed
+    expect(card['aria-expanded']).to eq('true')
+    expect(cwrapper).to have_css('ul.toclist', visible: :visible)
+    expect(toggle[:class]).not_to include('collapsed')
+
+    # Collapse this volume (Capybara waits for the slide animation to finish)
+    toggle.click
+    expect(cwrapper).to have_css('ul.toclist', visible: :hidden)
+    expect(toggle[:class]).to include('collapsed')
+    expect(card['aria-expanded']).to eq('false')
+
+    # Expand it again
+    toggle.click
+    expect(cwrapper).to have_css('ul.toclist', visible: :visible)
+    expect(toggle[:class]).not_to include('collapsed')
+    expect(card['aria-expanded']).to eq('true')
+  end
+
+  it 'keeps individual toggles in sync with the collapse-all / expand-all buttons' do
+    visit authority_path(author)
+
+    expect(page).to have_css('#browse_mainlist .volume-collapse-toggle')
+
+    find('#max_collapse').click
+    expect(page).to have_css('#browse_mainlist .volume-collapse-toggle.collapsed')
+
+    find('#expand-all').click
+    expect(page).to have_css('#browse_mainlist .volume-collapse-toggle:not(.collapsed)')
+  end
+end

--- a/spec/system/author_toc_volume_collapse_toggle_spec.rb
+++ b/spec/system/author_toc_volume_collapse_toggle_spec.rb
@@ -67,8 +67,12 @@ describe 'Author TOC per-volume collapse toggle', :js do
 
     find('#max_collapse').click
     expect(page).to have_css('#browse_mainlist .volume-collapse-toggle.collapsed')
+    # every toggle must be collapsed, not just some
+    expect(page).to have_no_css('#browse_mainlist .volume-collapse-toggle:not(.collapsed)')
 
     find('#expand-all').click
     expect(page).to have_css('#browse_mainlist .volume-collapse-toggle:not(.collapsed)')
+    # every toggle must be expanded, not just some
+    expect(page).to have_no_css('#browse_mainlist .volume-collapse-toggle.collapsed')
   end
 end

--- a/spec/system/author_toc_volume_collapse_toggle_spec.rb
+++ b/spec/system/author_toc_volume_collapse_toggle_spec.rb
@@ -60,6 +60,38 @@ describe 'Author TOC per-volume collapse toggle', :js do
     expect(card['aria-expanded']).to eq('true')
   end
 
+  it 'drops the toggle for a single-work volume pruned into a single link' do
+    # prune_collections() collapses a volume into a single link when it holds exactly one
+    # manifestation whose title matches the collection title. Such a volume has nothing left
+    # to collapse, so it must NOT carry a per-volume toggle.
+    solo_title = 'Solo Volume'
+    solo_volume = create(:collection, title: solo_title, collection_type: :volume)
+    solo_work = Chewy.strategy(:atomic) do
+      create(:manifestation, title: solo_title, status: :published, author: author)
+    end
+    create(:collection_item, collection: solo_volume, item: solo_work)
+    create(:involved_authority, authority: author, item: solo_volume, role: 'editor')
+
+    visit authority_path(author)
+    expect(page).to have_css('#browse_mainlist')
+
+    # NOTE: a volume can render in both the collection-level and work-level sections, so its
+    # cwrapper id is not unique; assert via CSS existence (matches every copy) rather than find.
+
+    # The mismatched-title volume from the shared fixtures keeps its toggle...
+    expect(page).to have_css("#cwrapper_#{volume.id} .volume-collapse-toggle")
+
+    # ...but every copy of the pruned single-work volume must have had its toggle removed
+    # (have_no_css waits for prune_collections to run on page load)...
+    expect(page).to have_no_css("#cwrapper_#{solo_volume.id} .volume-collapse-toggle")
+
+    # ...and none of its cards may still advertise an expandable state.
+    all("#cwrapper_#{solo_volume.id}").each do |cw|
+      card = cw.find(:xpath, "./ancestor::li[contains(@class, 'by-card-v02')][1]")
+      expect(card['aria-expanded']).to be_nil
+    end
+  end
+
   it 'keeps individual toggles in sync with the collapse-all / expand-all buttons' do
     visit authority_path(author)
 


### PR DESCRIPTION
## Summary

In the Authority TOC, each **volume**-type collection (with children) now has an individual collapse/expand toggle at the end of its title line, so a user can toggle a single volume without affecting the others. Previously only the global "collapse all / expand all" buttons existed.

- The toggle uses the same ben-yehuda chevron glyph (`)`) as the navbar dropdown arrow (`.dropdown-arrow`), rotated 180° between the expanded (up) and collapsed (down) states.
- Clicking a toggle slides only that volume's own children list (the `ul.toclist` directly under its `.cwrapper`) — nested collections are untouched.
- The existing **collapse all / expand all** buttons now also sync the per-volume chevrons' state.
- Keyboard accessible (`role=button`, `tabindex=0`, Enter/Space).

Also fixes a pre-existing typo on the collection card (`aria-expanede` → `aria-expanded`) and sets the correct initial value (`true`, since children render expanded by default).

## Files
- `app/views/authors/_toc_node.html.haml` — render the toggle for volume collections with children; fix aria attribute
- `app/views/authors/toc.html.haml` — delegated click/keydown handlers; sync chevrons with collapse-all/expand-all
- `app/assets/stylesheets/application.scss` — `.volume-collapse-toggle` styling + rotation
- `config/locales/{en,he}.yml` — `toggle_collapse_volume` label (title/aria-label)
- `.claude/rules/testing-requirements.md` — document the "predicate matchers / attribute reads don't wait" Capybara pitfall

## Test plan
- New system spec `spec/system/author_toc_volume_collapse_toggle_spec.rb` (`js: true`):
  - toggle collapses/expands only its own volume; verifies visibility, `.collapsed` class, and `aria-expanded`
  - collapse-all / expand-all keep the individual chevrons in sync
- Re-ran related author navbar/TOC system specs — no regressions (an intermittent failure was an Elasticsearch disk-watermark read-only block in the local env, unrelated to this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)