### PR TITLE
Restore drag/transplant editing in manage_toc

### DIFF
--- a/app/views/collections_migration/_gentoc.html.haml
+++ b/app/views/collections_migration/_gentoc.html.haml
@@ -2,8 +2,8 @@
 - InvolvedAuthority::ROLES_PRESENTATION_ORDER.each do |role|
   = render partial: 'authors/toc_by_role',
            locals: { top_nodes: top_nodes,
-                     title: t("toc_by_role.#{role}", gender_letter: @author.gender_letter),
+                     title: t("toc_by_role.headers.#{role}", gender_letter: @author.gender_letter),
                      role: role,
                      authority_id: @author.id,
-                     editable: false,
+                     editable: true,
                      nonce: role }

--- a/spec/system/manage_toc_draggable_spec.rb
+++ b/spec/system/manage_toc_draggable_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# Regression test for the manage_toc TOC losing its drag/transplant editing UI.
+#
+# The manage_toc view (authors#manage_toc -> shared/_manage_toc ->
+# collections_migration/_gentoc) must render collections the author is involved
+# with *at collection level* through the editable partial chain
+# (_toc_node -> shared/_manage_collection -> shared/_editable_collection), which
+# is what wires up the SortableJS drag handles used to reorder/transplant items.
+#
+# A refactor accidentally passed `editable: false` from _gentoc, dropping the
+# editable branch entirely so nothing was draggable. This spec asserts the drag
+# handles are present.
+describe 'manage_toc draggable collections', :js do
+  before do
+    skip 'WebDriver not available or misconfigured' unless webdriver_available?
+    login_as_catalog_editor
+  end
+
+  let!(:author) { create(:authority, name: 'Draggable Author') }
+
+  # A collection the author is involved with at collection level -> renders via
+  # the editable branch of _toc_node.
+  let!(:volume) do
+    create(:collection, title: 'Draggable Volume', collection_type: :volume)
+  end
+
+  let!(:involved_authority) do
+    create(:involved_authority, authority: author, item: volume, role: 'author')
+  end
+
+  let!(:work_in_volume) do
+    Chewy.strategy(:atomic) do
+      create(:manifestation, title: 'Work In Volume', status: :published, author: author)
+    end
+  end
+
+  let!(:collection_item) do
+    create(:collection_item, collection: volume, item: work_in_volume)
+  end
+
+  after { Chewy.massacre }
+
+  it 'renders the SortableJS drag handles for collection-level items' do
+    visit authors_manage_toc_path(author)
+
+    # Sanity: the collections management area rendered.
+    expect(page).to have_css('#coll_toc')
+
+    # The editable collection container and its draggable item with a drag
+    # handle are only emitted by shared/_editable_collection, i.e. only when
+    # `editable` is true. Their presence is the regression guard.
+    expect(page).to have_css('.collection.connectable')
+    expect(page).to have_css('.collection_draggable_item')
+    expect(page).to have_css('.collection_draggable_item .drag-handle')
+  end
+end


### PR DESCRIPTION
## Problem

On the `lexicon` branch, the **manage_toc** view (`authors#manage_toc`) lost its drag-and-drop editing ability compared to `master`: collection items were no longer draggable, so works could not be reordered within or transplanted across collections.

## Root cause

Both regressions were introduced by the role-block refactor (commit `863162d9e`) in `app/views/collections_migration/_gentoc.html.haml`:

1. **`editable: false`** was passed to `authors/_toc_by_role`. That flag flows down to `authors/_toc_node`, which only renders the editable partial chain (`shared/_manage_collection` → `shared/_editable_collection`) — the one that wires up the SortableJS drag handles and the `drag_item` / `transplant_item` AJAX calls — when `editable` is true. With it false, `_toc_node` took its read-only branch and nothing was draggable. The value was `true` before the refactor (commit `0a2abccb7`).

2. **Wrong I18n key**: `t("toc_by_role.#{role}")` (missing `.headers`) produced a `Translation missing` header for every role. The public `authors/_generated_toc` partial correctly uses `t("toc_by_role.headers.#{role}")`.

## Fix

- Restore `editable: true` in `_gentoc.html.haml`. Note: `shared/_manage_collection` is still guarded to only expose editing for collections where the author is a principal contributor (collection-level / uncollected), so this restores — not broadens — master's behavior.
- Use the correct `toc_by_role.headers.#{role}` translation key.

## Testing

- New system spec `spec/system/manage_toc_draggable_spec.rb` visits `manage_toc` for an author with a collection-level volume and asserts the SortableJS drag handles (`.collection.connectable`, `.collection_draggable_item .drag-handle`) render.
- Verified the spec fails with `editable: false` and passes with `editable: true` (genuine regression guard).
- `haml-lint` and `rubocop` clean on the changed files.

Fixes bead beads_by-6yh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)