### PR TITLE
Fix literal %{gender_suffix} in author navbar (beads_by-hjt)

### DIFF
--- a/app/views/shared/_newtoc_navbar.html.haml
+++ b/app/views/shared/_newtoc_navbar.html.haml
@@ -112,7 +112,7 @@
     .book-type
       .truncate= t(:latest_updates)
     .book-type
-      .truncate= t(:works_about_this_author)
+      .truncate= t(:works_about_this_author, gender_suffix: @author.person&.gender == 'female' ? '/ת' : '')
     .book-type
       .truncate= t(:external_links)
     .book-type

--- a/app/views/shared/_newtoc_navbar.html.haml
+++ b/app/views/shared/_newtoc_navbar.html.haml
@@ -112,7 +112,7 @@
     .book-type
       .truncate= t(:latest_updates)
     .book-type
-      .truncate= t(:works_about_this_author, gender_suffix: @author.person&.gender == 'female' ? '/ת' : '')
+      .truncate= t(:works_about_this_author, gender_suffix: @author.gender == 'female' ? '/ת' : '')
     .book-type
       .truncate= t(:external_links)
     .book-type

--- a/spec/requests/navbar_works_about_author_i18n_spec.rb
+++ b/spec/requests/navbar_works_about_author_i18n_spec.rb
@@ -10,6 +10,9 @@ RSpec.describe 'Author navbar "works about this author" label', type: :request d
   # the literal placeholder that must never reach the page (not a format token here)
   let(:raw_placeholder) { '%{gender_suffix}' } # rubocop:disable Style/FormatStringToken
 
+  around do |example|
+    I18n.with_locale(:he) { example.run }
+  end
   def visit_author(author)
     work = create(:manifestation, author: author)
     create(:collection_item, collection: volume, item: work)

--- a/spec/requests/navbar_works_about_author_i18n_spec.rb
+++ b/spec/requests/navbar_works_about_author_i18n_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# Regression for beads_by-hjt: the author-page side navbar rendered the literal
+# "%{gender_suffix}" because shared/_newtoc_navbar called
+# t(:works_about_this_author) without the interpolation param the string requires.
+RSpec.describe 'Author navbar "works about this author" label', type: :request do
+  let(:volume) { create(:collection, title: 'A Volume', collection_type: :volume) }
+  # the literal placeholder that must never reach the page (not a format token here)
+  let(:raw_placeholder) { '%{gender_suffix}' } # rubocop:disable Style/FormatStringToken
+
+  def visit_author(author)
+    work = create(:manifestation, author: author)
+    create(:collection_item, collection: volume, item: work)
+    create(:involved_authority, authority: author, item: volume, role: 'editor')
+    get authority_path(author)
+  end
+
+  it 'never renders the raw interpolation placeholder' do
+    visit_author(create(:authority, gender: 'male'))
+    expect(response).to have_http_status(:ok)
+    expect(response.body).not_to include(raw_placeholder)
+  end
+
+  it 'interpolates the gender suffix for a female author' do
+    visit_author(create(:authority, gender: 'female'))
+    expect(response.body).not_to include(raw_placeholder)
+    expect(response.body).to include(I18n.t(:works_about_this_author, gender_suffix: '/ת'))
+  end
+end


### PR DESCRIPTION
## Summary

The author-page side navbar displayed the raw literal `%{gender_suffix}` in the "works about this author" item. `shared/_newtoc_navbar.html.haml:115` called `t(:works_about_this_author)` without the interpolation param the Hebrew string requires:

```
works_about_this_author: "יצירות בַּמאגר על אודות היוצר%{gender_suffix}"
```

Fix: pass `gender_suffix`, mirroring the already-correct call in `authors/_aboutnesses.html.haml:4` (`@author` is in scope in the navbar partial).

## Test

`spec/requests/navbar_works_about_author_i18n_spec.rb` — asserts the page never contains the raw `%{gender_suffix}` placeholder, and that the suffix is interpolated for a female author. Verified it fails without the fix and passes with it.

Fixes **beads_by-hjt** (discovered during ln5 / PR #1422).

🤖 Generated with [Claude Code](https://claude.com/claude-code)