### PR TITLE
Fix two pre-existing system spec failures (rqv, w6f)

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1398,6 +1398,12 @@ p.by-genre-name-v02.headline-2-v02 {
 
 /* Mobile navbar expansion styles (max-width: 991px) */
 @media only screen and (max-width: 991px) {
+  /* On mobile only the thin navbar shows; the full navbar stays hidden until
+     the user expands it (which adds the .mobile-expanded class handled below). */
+  .author-side-nav-col .book-nav-full:not(.mobile-expanded) {
+    display: none;
+  }
+
   .book-nav-full.mobile-expanded {
     display: block;
     position: fixed;

--- a/spec/system/collection_show_orig_lang_spec.rb
+++ b/spec/system/collection_show_orig_lang_spec.rb
@@ -20,9 +20,16 @@ describe 'Collection show page - original language of translated works' do
     end
   end
 
+  # collection_type must be pinned: the factory otherwise samples it randomly
+  # from %w[volume periodical series other], and a 'periodical' collection uses
+  # a different issue/volume layout that does NOT render the .by-card-v02
+  # manifestation cards this spec asserts on. Leaving it unpinned made the spec
+  # flaky in full-suite runs (the sampled value depends on PRNG state polluted
+  # by earlier specs). A 'volume' matches the intent: an anthology of works.
   let!(:collection) do
     Chewy.strategy(:atomic) do
-      create(:collection, title: 'Test Collection', manifestations: [translated_manifestation, original_manifestation])
+      create(:collection, title: 'Test Collection', collection_type: :volume,
+                          manifestations: [translated_manifestation, original_manifestation])
     end
   end
 


### PR DESCRIPTION
Fixes two pre-existing system-spec failures discovered while investigating bead ln5. In both cases the bead's original root-cause hypothesis turned out to be wrong; the real causes are documented below.

## rqv — `author_navbar_mobile_expansion_spec` (all 6 examples failed)

**Bead hypothesis:** mobile viewport `resize_to(375, 667)` isn't honored by headless Firefox.

**Actual cause:** the resize *does* work — Firefox floors the window at 500px wide, but 500 < 991 so the `max-width: 991px` mobile media query is active (verified: `window.matchMedia('(max-width:991px)').matches === true`, `.book-nav-thin` is `display:block`). The genuine bug is that **no CSS rule ever hid the non-expanded `.book-nav-full` on mobile**, so the thin and full navbars rendered on top of each other. This is a real mobile UX bug that has existed since the feature's original PR #900.

**Fix:** add `.author-side-nav-col .book-nav-full:not(.mobile-expanded){ display:none }` inside the existing `max-width:991px` block in `application.scss` (the `.book-nav-full.mobile-expanded` rule already shows it when expanded). `.book-nav-full` only ever renders inside `.author-side-nav-col`, so the rule is scoped precisely. The existing spec serves as the regression test.

## w6f — `collection_show_orig_lang_spec:33` (flaky in full-suite runs)

**Bead hypothesis:** ES/Chewy index state leaking across the suite.

**Actual cause:** not ES at all — `FetchCollection` and `collection#show` are entirely DB-based. The `:collection` factory samples `collection_type` **randomly** from `%w[volume periodical series other]`, and the spec never pinned it. A `periodical` collection renders a different issue/volume layout that does **not** emit the `.by-card-v02.proofable` manifestation cards the spec asserts on. Which type gets sampled depends on global PRNG state, which is polluted by however much randomness earlier specs consumed — hence it passes in isolation but fails in full-suite runs (RSpec order here is *defined*, not random, so it reproduces deterministically).

Diagnostic (isolated): card found for `volume`/`series`/`other`, **not found** for `periodical`.

**Fix:** pin `collection_type: :volume` in the spec (matches intent: an anthology of works).

## Test plan

Both failures reproduce deterministically by running the sorted `spec/system` prefix up to the failing spec (same order as a full `bundle exec rspec`):

- **Before:** `102 examples, 1 failure` (w6f) / navbar spec 6 failures.
- **After:** `102 examples, 0 failures, 4 pending` (the 4 pending are pre-existing, unrelated skips). `author_navbar_mobile_expansion_spec` → `6 examples, 0 failures`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)