### PR TITLE
Authority TOC: cascade volume expand into toggle-less sub-collections (s6c)

### DIFF
--- a/app/views/authors/toc.html.haml
+++ b/app/views/authors/toc.html.haml
@@ -397,12 +397,16 @@
       // toggle are left untouched so they keep their own collapsed/expanded state.
       function cascadeExpand($card) {
         var $wrapper = $card.children('.by-card-content-v02').children('.cwrapper');
-        $wrapper.children('ul.toclist').slideDown();
+        var $list = $wrapper.children('ul.toclist');
+        // Only cards that actually have a children list are expandable and, per
+        // this view's convention, carry aria-expanded — leave others untouched.
+        if ($list.length === 0) { return; }
+        $list.slideDown();
         $card.attr('aria-expanded', 'true');
         // Direct sub-collection cards inside this card's own list. The card
         // li is a direct child of ul.toclist (the browser auto-closes the
         // empty wrapper li that HTML forbids nesting an li inside).
-        $wrapper.children('ul.toclist').children('.by-card-v02[role="treeitem"]').each(function() {
+        $list.children('.by-card-v02[role="treeitem"]').each(function() {
             var $sub = $(this);
             var $subwrapper = $sub.children('.by-card-content-v02').children('.cwrapper');
             var hasOwnToggle = $subwrapper.children('div').children('.volume-collapse-toggle').length > 0;

--- a/app/views/authors/toc.html.haml
+++ b/app/views/authors/toc.html.haml
@@ -389,6 +389,29 @@
         $('#browse_mainlist .volume-collapse-toggle').removeClass('collapsed').attr('aria-expanded', 'true');
       });
 
+      // Expand a treeitem card's own children list, then cascade into any
+      // nested sub-collections that have NO toggle of their own (series /
+      // sub-volumes). Those have no independent control, so their collapsed
+      // state (e.g. after collapse-all) would otherwise be unreachable — they
+      // must follow their parent volume. Nested volumes that DO have their own
+      // toggle are left untouched so they keep their own collapsed/expanded state.
+      function cascadeExpand($card) {
+        var $wrapper = $card.children('.by-card-content-v02').children('.cwrapper');
+        $wrapper.children('ul.toclist').slideDown();
+        $card.attr('aria-expanded', 'true');
+        // Direct sub-collection cards inside this card's own list. The card
+        // li is a direct child of ul.toclist (the browser auto-closes the
+        // empty wrapper li that HTML forbids nesting an li inside).
+        $wrapper.children('ul.toclist').children('.by-card-v02[role="treeitem"]').each(function() {
+            var $sub = $(this);
+            var $subwrapper = $sub.children('.by-card-content-v02').children('.cwrapper');
+            var hasOwnToggle = $subwrapper.children('div').children('.volume-collapse-toggle').length > 0;
+            if (!hasOwnToggle) {
+              cascadeExpand($sub);
+            }
+          });
+      }
+
       // Toggle a single volume's children list (delegated: nodes are server-rendered)
       function toggleVolume($toggle) {
         var $card = $toggle.closest('.by-card-v02[role="treeitem"]');
@@ -402,8 +425,9 @@
           $card.attr('aria-expanded', 'false');
           $toggle.addClass('collapsed').attr('aria-expanded', 'false');
         } else {
-          $list.slideDown();
-          $card.attr('aria-expanded', 'true');
+          // Expand this volume all the way down through any toggle-less
+          // sub-collections, which cannot be re-opened on their own.
+          cascadeExpand($card);
           $toggle.removeClass('collapsed').attr('aria-expanded', 'true');
         }
       }

--- a/spec/system/author_toc_volume_collapse_toggle_spec.rb
+++ b/spec/system/author_toc_volume_collapse_toggle_spec.rb
@@ -95,6 +95,44 @@ describe 'Author TOC per-volume collapse toggle', :js do
     end
   end
 
+  it 'expands nested toggle-less sub-collections when re-expanding a volume after collapse-all' do
+    # A series sub-collection has NO toggle of its own, so after collapse-all it
+    # can only be re-opened by cascading through its parent volume's toggle.
+    # Give the nested work a different author so it renders only inside the
+    # series (avoids a duplicate copy in this author's work-level section).
+    other_author = create(:authority, name: 'Other Author')
+    inner_work = Chewy.strategy(:atomic) do
+      create(:manifestation, title: 'Nested Series Work', status: :published, author: other_author)
+    end
+    series = create(:collection, title: 'Inner Series', collection_type: :series)
+    create(:collection_item, collection: series, item: inner_work)
+
+    outer_volume = create(:collection, title: 'Outer Volume', collection_type: :volume)
+    create(:collection_item, collection: outer_volume, item: series)
+    create(:involved_authority, authority: author, item: outer_volume, role: 'editor')
+
+    visit authority_path(author)
+    expect(page).to have_css('#browse_mainlist')
+
+    # The nested series has no toggle of its own; the outer volume does.
+    expect(page).to have_no_css("#cwrapper_#{series.id} .volume-collapse-toggle")
+    expect(page).to have_css("#cwrapper_#{outer_volume.id} .volume-collapse-toggle")
+
+    # Initially the deeply nested work is visible.
+    expect(page).to have_link('Nested Series Work', visible: :visible)
+
+    # Collapse everything, then re-expand ONLY the outer volume via its toggle.
+    find('#max_collapse').click
+    expect(page).to have_link('Nested Series Work', visible: :hidden)
+
+    outer_toggle = find("#cwrapper_#{outer_volume.id} .volume-collapse-toggle", match: :first)
+    outer_toggle.click
+
+    # The fix cascades expansion into the toggle-less series, so its work must
+    # become visible again — not just the series header.
+    expect(page).to have_link('Nested Series Work', visible: :visible)
+  end
+
   it 'keeps individual toggles in sync with the collapse-all / expand-all buttons' do
     visit authority_path(author)
 


### PR DESCRIPTION
## Problem

On the Authority TOC view, the recently-added per-volume collapse toggle clashed with the pre-existing **collapse-all** button:

1. **Collapse-all** (`#max_collapse`) slides up *every* `.toclist` at every nesting level.
2. Re-expanding a volume via its own collapse toggle (`toggleVolume`) only slid down that volume's **direct** children list.
3. Nested sub-collections (series / sub-volumes) render **without a toggle of their own**, so their now-hidden `.toclist`s had no way to be re-opened — you'd see the sub-collection headers appear but not their contents.

Repro: on `/author/391`, click collapse-all, then expand one collection with the collection-level expander — sub-collections show but stay collapsed.

## Fix

`toggleVolume` now cascades expansion downward through descendant sub-collections that **lack their own toggle** (series/sub-volumes), which have no independent control and must follow their parent volume. Nested volumes that *do* have their own toggle are left untouched, preserving their independent collapsed/expanded state (as the existing `toggleVolume` comment intended).

The new `cascadeExpand()` helper walks a card's own `ul.toclist`, revealing it and recursing only into toggle-less child collection cards.

Note: child collection cards are direct children of `ul.toclist` in the live DOM — the browser auto-closes the empty wrapper `<li>` (HTML forbids nesting an `<li>` inside another), so the recursion selects `ul.toclist > .by-card-v02[role="treeitem"]` directly.

## Testing

Added a system spec (`spec/system/author_toc_volume_collapse_toggle_spec.rb`) that builds a `volume` containing a toggle-less `series` sub-collection with a work, collapses everything via collapse-all, re-expands only the outer volume, and asserts the deeply-nested work becomes visible again. Verified it **fails without the fix** and passes with it. All 4 examples in the file pass.

Closes beads_by-s6c.

🤖 Generated with [Claude Code](https://claude.com/claude-code)