### PR TITLE
Collection#show: prev/next volume nav within volume_series (beads_by-cr1)

### DIFF
--- a/app/controllers/collections_controller.rb
+++ b/app/controllers/collections_controller.rb
@@ -45,6 +45,8 @@ class CollectionsController < ApplicationController
     @pagetype = :collection
     @taggings = @collection.taggings
     @lex_citations = @collection.lex_citations
+    # Prev/next volume navigation when this volume sits inside a volume_series
+    @volume_series_nav = FindSeriesVolumeSiblings.call(@collection) if @collection.volume?
 
     @included_recs = @collection.included_recommendations.count
     @total_recs = @collection.recommendations.count + @included_recs

--- a/app/services/find_series_volume_siblings.rb
+++ b/app/services/find_series_volume_siblings.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+# Finds the previous/next sibling volume of a given volume within its containing
+# volume_series collection, so Collection#show can offer prev/next volume navigation
+# (mirroring the cross-collection navigation offered in Manifestation#read).
+#
+# Usage: FindSeriesVolumeSiblings.call(volume_collection)
+# Exposes #series (the containing volume_series Collection, or nil), #prev_volume, #next_volume.
+class FindSeriesVolumeSiblings < ApplicationService
+  def call(collection)
+    @series = collection.parent_collections.find(&:volume_series?)
+    if @series
+      @volumes = sibling_volumes(@series)
+      @index = @volumes.find_index { |c| c.id == collection.id }
+    end
+    self
+  end
+
+  attr_reader :series
+
+  def prev_volume
+    return nil unless @index&.positive?
+
+    @volumes[@index - 1]
+  end
+
+  def next_volume
+    return nil unless @index && @index < @volumes.length - 1
+
+    @volumes[@index + 1]
+  end
+
+  private
+
+  # Direct volume children of the series, in seqno order
+  def sibling_volumes(series)
+    CollectionItem.where(collection: series, item_type: 'Collection').order(:seqno).preload(:item).filter_map do |ci|
+      c = ci.item
+      c if c.present? && c.volume?
+    end
+  end
+end

--- a/app/services/find_series_volume_siblings.rb
+++ b/app/services/find_series_volume_siblings.rb
@@ -8,7 +8,8 @@
 # Exposes #series (the containing volume_series Collection, or nil), #prev_volume, #next_volume.
 class FindSeriesVolumeSiblings < ApplicationService
   def call(collection)
-    @series = collection.parent_collections.find(&:volume_series?)
+    parents = collection.parent_collection_items.includes(:collection).map(&:collection)
+    @series = parents.find(&:volume_series?)
     if @series
       @volumes = sibling_volumes(@series)
       @index = @volumes.find_index { |c| c.id == collection.id }

--- a/app/views/collections/show.html.haml
+++ b/app/views/collections/show.html.haml
@@ -130,6 +130,31 @@
                 -#  %span{style: "font-weight:bold"} המלצות:
                 -#  %a{href: "#"} 3 המלצות קוראים
 
+          -# Prev/next volume navigation within a containing volume_series (mirrors Manifestation#read nav)
+          - if @volume_series_nav&.series.present?
+            - prev_vol = @volume_series_nav.prev_volume
+            - next_vol = @volume_series_nav.next_volume
+            - if prev_vol.present? || next_vol.present?
+              .author-works-nav
+                .topNavEntry
+                  .link-nav
+                    - if prev_vol.present?
+                      = link_to collection_path(prev_vol) do
+                        %span.right-arrow= '2'
+                        = t(:to_previous_volume)
+                .topNavEntry
+                  .link-nav{style: 'margin-left:20px; margin-right:20px;'}
+                    = link_to collection_path(@volume_series_nav.series) do
+                      %span.right-arrow= '🢁'
+                      = textify_collection_up_link(@volume_series_nav.series)
+                      %span.left-arrow= '🢁'
+                .topNavEntry
+                  .link-nav
+                    - if next_vol.present?
+                      = link_to collection_path(next_vol) do
+                        = t(:to_next_volume)
+                        %span.left-arrow= '1'
+
           - if @collection.cover_image.attached?
             .by-card-v02.collection-cover-image-card
               .by-card-content-v02

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3014,9 +3014,11 @@ en:
   to_full_tagging_policy: To Full Tagging Policy
   to_manage_people: To Manage People
   to_next_item: To Next Item
+  to_next_volume: To Next Volume
   to_other_translations_of_author: To Other Translations Of Author
   to_periodical: To Periodical
   to_previous_item: To Previous Item
+  to_previous_volume: To Previous Volume
   next_items_not_yet_uploaded: The next items have not been uploaded yet
   previous_items_not_yet_uploaded: The previous items have not been uploaded yet
   to_tagging_instructions: To Tagging Instructions

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -1470,7 +1470,9 @@ he:
   suggested_tag: התגית המוצעת
   quick_actions: פעולות מהירות
   to_next_item: לפריט הבא
+  to_next_volume: לכרך הבא
   to_previous_item: לפריט הקודם
+  to_previous_volume: לכרך הקודם
   next_items_not_yet_uploaded: הפריטים הבאים טרם הועלו
   previous_items_not_yet_uploaded: הפריטים הקודמים טרם הועלו
   time_waiting: זמן המתנה

--- a/spec/services/find_series_volume_siblings_spec.rb
+++ b/spec/services/find_series_volume_siblings_spec.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe FindSeriesVolumeSiblings do
+  subject(:result) { described_class.call(volume) }
+
+  let(:series) { create(:collection, collection_type: :volume_series) }
+  let(:vol1) { create(:collection, collection_type: :volume) }
+  let(:vol2) { create(:collection, collection_type: :volume) }
+  let(:vol3) { create(:collection, collection_type: :volume) }
+
+  # volume_series layout:
+  #   seqno 1 → vol1
+  #   seqno 2 → vol2
+  #   seqno 3 → vol3
+  before do
+    series.collection_items.create!(item: vol1, seqno: 1)
+    series.collection_items.create!(item: vol2, seqno: 2)
+    series.collection_items.create!(item: vol3, seqno: 3)
+  end
+
+  context 'when the volume is the first in the series' do
+    let(:volume) { vol1 }
+
+    it 'exposes the containing series' do
+      expect(result.series).to eq(series)
+    end
+
+    it 'returns nil for prev_volume' do
+      expect(result.prev_volume).to be_nil
+    end
+
+    it 'returns the next volume' do
+      expect(result.next_volume).to eq(vol2)
+    end
+  end
+
+  context 'when the volume is in the middle of the series' do
+    let(:volume) { vol2 }
+
+    it 'returns the previous volume' do
+      expect(result.prev_volume).to eq(vol1)
+    end
+
+    it 'returns the next volume' do
+      expect(result.next_volume).to eq(vol3)
+    end
+  end
+
+  context 'when the volume is the last in the series' do
+    let(:volume) { vol3 }
+
+    it 'returns the previous volume' do
+      expect(result.prev_volume).to eq(vol2)
+    end
+
+    it 'returns nil for next_volume' do
+      expect(result.next_volume).to be_nil
+    end
+  end
+
+  context 'when the volume has no volume_series parent' do
+    let(:volume) { create(:collection, collection_type: :volume) }
+
+    it 'returns nil for series, prev_volume and next_volume' do
+      expect(result.series).to be_nil
+      expect(result.prev_volume).to be_nil
+      expect(result.next_volume).to be_nil
+    end
+  end
+
+  context 'when the series also contains non-volume items' do
+    subject(:result) { described_class.call(vol_a) }
+
+    let(:other_series) { create(:collection, collection_type: :volume_series) }
+    let(:vol_a) { create(:collection, collection_type: :volume) }
+    let(:vol_b) { create(:collection, collection_type: :volume) }
+    let(:sub_series) { create(:collection, collection_type: :series) }
+    let(:loose_manifestation) { create(:manifestation) }
+
+    # Interleave a non-volume collection and a direct manifestation between the volumes
+    before do
+      other_series.collection_items.create!(item: vol_a, seqno: 1)
+      other_series.collection_items.create!(item: sub_series, seqno: 2)
+      other_series.collection_items.create!(item: loose_manifestation, seqno: 3)
+      other_series.collection_items.create!(item: vol_b, seqno: 4)
+    end
+
+    it 'navigates only among volume-type siblings, skipping the others' do
+      expect(result.next_volume).to eq(vol_b)
+    end
+  end
+end

--- a/spec/system/collection_volume_series_nav_spec.rb
+++ b/spec/system/collection_volume_series_nav_spec.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# Prev/next volume navigation shown on Collection#show when a 'volume' sits inside
+# a 'volume_series'. The links are plain server-rendered anchors (no JS), so a
+# rack_test system spec exercises them reliably.
+describe 'Collection#show volume-series navigation' do
+  # Each volume needs >= 2 manifestations, otherwise Collection#show redirects a
+  # single-manifestation collection straight to that manifestation.
+  def build_volume(title)
+    Chewy.strategy(:atomic) do
+      create(:collection, title: title, collection_type: :volume,
+                          manifestations: create_list(:manifestation, 2, status: :published))
+    end
+  end
+
+  let!(:vol1) { build_volume('Volume One') }
+  let!(:vol2) { build_volume('Volume Two') }
+  let!(:vol3) { build_volume('Volume Three') }
+
+  let!(:series) do
+    Chewy.strategy(:atomic) do
+      create(:collection, title: 'The Series', collection_type: :volume_series,
+                          included_collections: [vol1, vol2, vol3])
+    end
+  end
+
+  after { Chewy.massacre }
+
+  it 'shows prev, up (series) and next links for a middle volume' do
+    visit collection_path(vol2)
+
+    nav = find('.author-works-nav', wait: 10)
+    within(nav) do
+      expect(page).to have_link(href: collection_path(vol1))
+      expect(page).to have_link(href: collection_path(vol3))
+      expect(page).to have_link(href: collection_path(series))
+      expect(page).to have_text(I18n.t(:to_previous_volume))
+      expect(page).to have_text(I18n.t(:to_next_volume))
+    end
+  end
+
+  it 'omits the prev link for the first volume' do
+    visit collection_path(vol1)
+
+    nav = find('.author-works-nav', wait: 10)
+    within(nav) do
+      expect(page).to have_link(href: collection_path(vol2))
+      expect(page).to have_link(href: collection_path(series))
+      expect(page).not_to have_text(I18n.t(:to_previous_volume))
+    end
+  end
+
+  it 'omits the next link for the last volume' do
+    visit collection_path(vol3)
+
+    nav = find('.author-works-nav', wait: 10)
+    within(nav) do
+      expect(page).to have_link(href: collection_path(vol2))
+      expect(page).not_to have_text(I18n.t(:to_next_volume))
+    end
+  end
+
+  it 'shows no series navigation for a standalone volume' do
+    standalone = build_volume('Standalone Volume')
+
+    visit collection_path(standalone)
+
+    expect(page).to have_css('.work-info-card', wait: 10)
+    expect(page).not_to have_css('.author-works-nav')
+  end
+end


### PR DESCRIPTION
## Summary

When a `volume` collection sits inside a `volume_series` parent, `Collection#show` now shows **prev/next volume navigation**, reusing the exact same nav UI as `Manifestation#read` (`.author-works-nav` with prev / up-to-series / next links). This mirrors how a Manifestation bubbles up to its containing volume/issue for cross-item navigation — here a volume bubbles up to its containing `volume_series` and navigates among sibling volumes.

## Changes

- **`app/services/find_series_volume_siblings.rb`** (new): given a volume, finds the containing `volume_series` parent and returns `#series`, `#prev_volume`, `#next_volume` — navigating only among the `volume`-type children in `seqno` order.
- **`app/controllers/collections_controller.rb`**: `show` sets `@volume_series_nav` for volume collections.
- **`app/views/collections/show.html.haml`**: renders the `.author-works-nav` block (reusing existing classes/glyph arrows) after the work-info card; only when a series parent and at least one neighbor exist.
- **`config/locales/{en,he}.yml`**: new keys `to_previous_volume` / `to_next_volume`.

## Design notes

- Bubbles up **one level** via `parent_collections` (a volume sits directly under its `volume_series`), unlike the deeper BFS needed for manifestations nested in series/volumes.
- Navigation is restricted to **`volume`-type** children of the series, matching "prev/next volume."
- Includes the middle **"up to volume series"** link for full parity with the read-page UI (reuses the existing `up_link.volume_series` i18n key).

## Test plan

- `spec/services/find_series_volume_siblings_spec.rb` — first/middle/last position, no-series-parent, non-volume-items-skipped (9 examples).
- `spec/system/collection_volume_series_nav_spec.rb` — rack_test system spec asserting prev/up/next links and their absence at the ends / for standalone volumes (4 examples). No `js: true` (plain server-rendered anchors).
- Full suite run: the only failures were 9 transient `ActiveRecord::Deadlocked` MySQL errors in an unrelated API spec's DB-cleanup hook (`spec/api/v1/texts_api_spec.rb`), which pass cleanly in isolation (31/0). Not related to these changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)