### PR TITLE
Manifestation breadcrumbs: full collection ancestor chain

### DIFF
--- a/app/controllers/manifestation_controller.rb
+++ b/app/controllers/manifestation_controller.rb
@@ -1335,6 +1335,8 @@ class ManifestationController < ApplicationController
     @single_text_volume = !@multiple_parents && @containments.size == 1 &&
                           @containments.first.collection.collection_type == 'volume' &&
                           !@containments.first.collection.has_multiple_manifestations?
+    # Ancestor collection chain (root-first) for the breadcrumbs of the chosen containment.
+    @breadcrumb_collections = breadcrumb_collection_chain(@containments.first)
   end
 
   private
@@ -1363,6 +1365,29 @@ class ManifestationController < ApplicationController
                                 .sort_by { |c| [c.normalized_pub_year || Float::INFINITY, c.id] }
     @containments = [chosen]
     @volumes = [chosen_volume].compact
+  end
+
+  # Builds the ancestor collection chain (root-first) for a chosen containment, used by the
+  # Manifestation breadcrumbs. Starting from the immediate parent collection, it walks up
+  # parent_collections to the outermost root, so a text in series A in series B in volume C
+  # yields [C, B, A]. The system 'uncollected' collection is not a real container and yields
+  # no breadcrumbs. When a collection has several parents we follow the first (the common case
+  # is a single linear chain); a visited set guards against cycles.
+  def breadcrumb_collection_chain(containment)
+    return [] if containment.nil?
+
+    collection = containment.collection
+    return [] if collection.nil? || collection.uncollected?
+
+    chain = []
+    visited = Set.new
+    current = collection
+    while current && visited.exclude?(current.id)
+      visited.add(current.id)
+      chain << current
+      current = current.parent_collections.first
+    end
+    chain.reverse
   end
 
   # Returns the containment matching the given collection id, either directly or via its

--- a/app/controllers/manifestation_controller.rb
+++ b/app/controllers/manifestation_controller.rb
@@ -1368,11 +1368,11 @@ class ManifestationController < ApplicationController
   end
 
   # Builds the ancestor collection chain (root-first) for a chosen containment, used by the
-  # Manifestation breadcrumbs. Starting from the immediate parent collection, it walks up
-  # parent_collections to the outermost root, so a text in series A in series B in volume C
-  # yields [C, B, A]. The system 'uncollected' collection is not a real container and yields
-  # no breadcrumbs. When a collection has several parents we follow the first (the common case
-  # is a single linear chain); a visited set guards against cycles.
+  # Manifestation breadcrumbs. Starting from the immediate parent collection, it walks up to
+  # the outermost root, so a text in series A in series B in volume C yields [C, B, A]. The
+  # system 'uncollected' collection is not a real container and yields no breadcrumbs. When a
+  # collection has several parents we follow the lowest-id one (a deterministic pick for the
+  # rare multi-parent case); a visited set guards against cycles.
   def breadcrumb_collection_chain(containment)
     return [] if containment.nil?
 
@@ -1385,9 +1385,20 @@ class ManifestationController < ApplicationController
     while current && visited.exclude?(current.id)
       visited.add(current.id)
       chain << current
-      current = current.parent_collections.first
+      current = first_parent_collection(current)
     end
     chain.reverse
+  end
+
+  # Deterministically returns a single parent collection of the given collection (or nil), the
+  # one with the lowest parent collection_id, eager-loading it to avoid an N+1 while walking the
+  # breadcrumb chain. Ordering directly on parent_collection_items (which is otherwise unordered)
+  # keeps the chosen ancestor stable across DB/query plans.
+  def first_parent_collection(collection)
+    collection.parent_collection_items
+              .includes(:collection)
+              .order(:collection_id)
+              .first&.collection
   end
 
   # Returns the containment matching the given collection id, either directly or via its

--- a/app/views/shared/_breadcrumbs.html.haml
+++ b/app/views/shared/_breadcrumbs.html.haml
@@ -13,15 +13,13 @@
         = link_to authority.name, authority_path(id: authority.id)
       - else
         = '?'
-    .breadcrumbs-arrow= 1
-    - genre = textify_genre(w.genre)
-    - unless authority.nil?
+    - Array(@breadcrumb_collections).each do |coll|
+      .breadcrumbs-arrow= 1
       .breadcrumbs-text
-        = link_to e.translation ? "#{t(:translation)} #{genre}" : genre,
-                  controller: :authors, action: :toc, id: authority.id, genre: w.genre
-      -#.breadcrumbs-arrow= 1
-      -#.breadcrumbs-text
-      -#  %b= @entity.title
+        - if coll.series?
+          = coll.title
+        - else
+          = link_to coll.title, collection_path(coll)
   - elsif @pagetype == :author
     .breadcrumbs-text= link_to t(:authors), authors_path
     -#.breadcrumbs-arrow= 1

--- a/spec/system/manifestation_breadcrumbs_spec.rb
+++ b/spec/system/manifestation_breadcrumbs_spec.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# Breadcrumbs on Manifestation#read. Since the move to Collection-based organization, the
+# breadcrumbs show the full containing-collection ancestor chain (root-first) instead of the
+# old trailing genre leaf: home -> authors -> author -> C -> B -> A, where sub-volume 'series'
+# collections are shown but not clickable. Breadcrumbs are plain server-rendered markup, so a
+# rack_test system spec exercises them reliably (no JS needed).
+describe 'Manifestation#read breadcrumbs' do
+  let!(:author) { create(:authority, toc: create(:toc)) }
+
+  # A text inside series A, inside series B, inside volume C.
+  let!(:text) do
+    Chewy.strategy(:atomic) do
+      create(:manifestation, author: author, orig_lang: 'he', status: :published)
+    end
+  end
+
+  let!(:series_a) do
+    Chewy.strategy(:atomic) do
+      create(:collection, title: 'Series A', collection_type: :series, manifestations: [text])
+    end
+  end
+
+  let!(:series_b) do
+    Chewy.strategy(:atomic) do
+      create(:collection, title: 'Series B', collection_type: :series, included_collections: [series_a])
+    end
+  end
+
+  let!(:volume_c) do
+    Chewy.strategy(:atomic) do
+      create(:collection, title: 'Volume C', collection_type: :volume, included_collections: [series_b])
+    end
+  end
+
+  after { Chewy.massacre }
+
+  it 'shows the full collection ancestor chain, root-first, with series not clickable' do
+    visit manifestation_path(text)
+
+    within('#breadcrumbs') do
+      # home -> authors -> author
+      expect(page).to have_link(I18n.t(:authors), href: authors_path)
+      expect(page).to have_link(author.name, href: authority_path(author))
+
+      # ancestor chain: volume C (clickable) -> series B -> series A (both plain text)
+      expect(page).to have_link('Volume C', href: collection_path(volume_c))
+      expect(page).to have_text('Series B')
+      expect(page).to have_text('Series A')
+      expect(page).not_to have_link('Series B')
+      expect(page).not_to have_link('Series A')
+
+      # the old genre-leaf breadcrumb (linking into authors#toc with a genre param) is gone
+      expect(page).not_to have_css("a[href*='genre=']")
+    end
+  end
+
+  it 'orders the crumbs C before B before A (outermost first)' do
+    visit manifestation_path(text)
+
+    crumbs = all('#breadcrumbs .breadcrumbs-text').map(&:text)
+    expect(crumbs.index('Volume C')).to be < crumbs.index('Series B')
+    expect(crumbs.index('Series B')).to be < crumbs.index('Series A')
+  end
+
+  context 'when the text is not in any collection' do
+    let!(:lone_text) do
+      Chewy.strategy(:atomic) do
+        create(:manifestation, author: author, orig_lang: 'he', status: :published)
+      end
+    end
+
+    it 'shows only home -> authors -> author with no collection crumbs or genre leaf' do
+      visit manifestation_path(lone_text)
+
+      within('#breadcrumbs') do
+        expect(page).to have_link(I18n.t(:authors), href: authors_path)
+        expect(page).to have_link(author.name, href: authority_path(author))
+        expect(page).not_to have_css("a[href*='/collections/']")
+        expect(page).not_to have_css("a[href*='genre=']")
+      end
+    end
+  end
+end


### PR DESCRIPTION
## What & why

The site-wide breadcrumbs mechanism predates the move to Collection-based organization of Manifestations. On `Manifestation#read` it ended with a **genre leaf** (linking into `authors#toc?genre=...`), which no longer reflects where a text actually lives.

This replaces that genre leaf with the **full containing-collection ancestor chain**, shown root-first:

```
home → authors → [author] → C → B → A
```

for a text inside series A, inside series B, inside volume C. Sub-volume `series` collections are shown but **not clickable**; every other collection type links to its `Collection#show`.

## How

- `ManifestationController#prep_for_read` now sets `@breadcrumb_collections` via a new private `breadcrumb_collection_chain`, which walks `parent_collections` up from the **already-chosen featured containment** (`select_parent_containment`) to the outermost root. This reuses the existing multi-parent disambiguation (explicit `parent_collection_id` param → `Collection#show` referer → earliest publication year), so the breadcrumb chain matches the "inside X" line and in-collection next/prev nav.
- The system `uncollected` collection yields no breadcrumbs (falls back to `home → authors → author`).
- `shared/_breadcrumbs.html.haml`: removed the genre leaf; renders the chain, `series` as plain text and all other types as links.

## Tests

New `spec/system/manifestation_breadcrumbs_spec.rb` (rack_test — breadcrumbs are server-rendered):
- full C→B→A chain, series not clickable, volume clickable, no genre leaf
- ordering (outermost first)
- text in no collection → author-only breadcrumbs, no genre leaf

Ran green locally alongside `spec/requests/manifestaion_spec.rb`, `spec/controllers/manifestations_controller_spec.rb`, `spec/system/collection_volume_series_nav_spec.rb`, and the lexicon UX spec (no regressions).

## Notes
- Clickable rule: only `series` is non-clickable (per requirements); `volume`, `volume_series`, `periodical`, `periodical_issue`, `other` all link.
- Collection-level multiple parents (a diamond in the collection tree) follow the first parent; the common case is a single linear chain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)