### PR TITLE
Scroll /works browse to top after AJAX filter/search

### DIFF
--- a/app/views/manifestation/browse.js.erb
+++ b/app/views/manifestation/browse.js.erb
@@ -2,3 +2,7 @@ $('#thelist').html("<%= j(render partial: 'browse_list') %>");
 $('#sort_filter_panel').html("<%= j(render partial: 'browse_filters') %>");
 $('#authorsDlg').html("<%= j(render partial: 'authors_select', locals: {authors: @authors, list: @authors_list}) %>");
 stopModal('spinnerdiv');
+// After filters/search/pagination replace the list, the (possibly few) results may
+// render above the current scroll position, leaving the viewport apparently empty.
+// Scroll back to the top so the freshly rendered results are visible.
+window.scrollTo(0, 0);

--- a/spec/controllers/manifestations_controller_spec.rb
+++ b/spec/controllers/manifestations_controller_spec.rb
@@ -30,6 +30,16 @@ describe ManifestationController do
       it { is_expected.to be_successful }
     end
 
+    # Regression: when filters/search are applied via AJAX and the (few) results
+    # render above the current scroll position, the page looked empty. The AJAX
+    # JS response must instruct the browser to scroll back to the top.
+    context 'when responding to an AJAX (JS) request' do
+      it 'instructs the page to scroll back to the top' do
+        get :browse, params: browse_params, format: :js, xhr: true
+        expect(response.body).to include('window.scrollTo(0, 0)')
+      end
+    end
+
     describe 'passing params to SearchManifestation service' do
       let(:browse_params) do
         {


### PR DESCRIPTION
## Problem

On the `/works` browse page, applying text filters or searching by title replaces the results list via AJAX (`remote: true` → `browse.js.erb`). If the page is already scrolled down and the filtered results contain only a few items, those results render **above** the current scroll position, so the viewport looks empty.

## Fix

After `browse.js.erb` replaces `#thelist` / `#sort_filter_panel`, call `window.scrollTo(0, 0)` so the freshly rendered results are visible. This covers every path that goes through this AJAX response: filter checkboxes, title/author search, tag selection, date range, and pagination (next/prev/letter jump).

## Testing

- Added a controller spec asserting the AJAX (`format: :js`, XHR) browse response includes the scroll-to-top instruction. Verified it **fails without** the fix and **passes with** it.
- `spec/controllers/manifestations_controller_spec.rb` — all 105 examples pass.

### Note on why this is a controller spec rather than a system spec

A `js: true` system spec that checks `window.pageYOffset` cannot distinguish this fix in headless Chrome: when the result set shrinks, headless Chrome's scroll anchoring already resets scroll to 0 on its own, so the assertion passes with or without the fix (a false positive). The bug reproduces in real browsers that preserve/clamp scroll instead. The controller spec deterministically verifies the emitted behavior and genuinely fails if the scroll instruction is removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)