### PR TITLE
Author TOC: count Taggings as curatorial content in flat-list filter

### DIFF
--- a/app/services/author_toc_filter_data.rb
+++ b/app/services/author_toc_filter_data.rb
@@ -51,19 +51,41 @@ class AuthorTocFilterData < ApplicationService
     direct.merge(collection_tagged_manifestation_ids(ids, authority))
   end
 
-  # Manifestation ids reachable from an approved-tagged collection, cascading
-  # through nested sub-collections (flatten_items), restricted to the author's
-  # own manifestations (ids).
+  # Manifestation ids reachable from an approved-tagged collection, restricted to
+  # the author's own manifestations (ids). A collection counts as "on the author's
+  # page" if the author is directly involved in it OR it is nested (any depth)
+  # under such a collection; a tagging on either cascades to the manifestations it
+  # contains (also any depth).
   def collection_tagged_manifestation_ids(ids, authority)
+    page_collection_ids = page_collection_ids(authority)
+    return Set.new if page_collection_ids.empty?
+
     tagged_collection_ids = Tagging.approved
-                                   .where(taggable_type: 'Collection', taggable_id: authority.collections.select(:id))
+                                   .where(taggable_type: 'Collection', taggable_id: page_collection_ids)
                                    .distinct.pluck(:taggable_id)
     return Set.new if tagged_collection_ids.empty?
 
-    reachable = Collection.where(id: tagged_collection_ids).flat_map do |collection|
-      collection.flatten_items.filter_map { |ci| ci.item_id if ci.item_type == 'Manifestation' }
+    id_set = ids.to_set
+    Collection.where(id: tagged_collection_ids).each_with_object(Set.new) do |collection, acc|
+      collection.flatten_items.each do |ci|
+        acc << ci.item_id if ci.item_type == 'Manifestation' && id_set.include?(ci.item_id)
+      end
     end
-    reachable.to_set & ids.to_set
+  end
+
+  # Ids of every collection appearing on the author's page: those the author is
+  # directly involved in, plus all sub-collections nested under them (any depth).
+  def page_collection_ids(authority)
+    roots = authority.collections.pluck(:id)
+    return roots if roots.empty?
+
+    ids = roots.to_set
+    Collection.where(id: roots).find_each do |collection|
+      collection.flatten_items.each do |ci|
+        ids << ci.item_id if ci.item_type == 'Collection'
+      end
+    end
+    ids.to_a
   end
 
   # genres present, ordered by the canonical genre presentation order

--- a/app/services/author_toc_filter_data.rb
+++ b/app/services/author_toc_filter_data.rb
@@ -7,8 +7,10 @@
 #     manifestations the authority is involved with (in any role).
 #
 # "Curatorial content" means any of: a featuring (FeaturedContent), an approved
-# Recommendation, or an incoming Aboutness (another work that is ABOUT the
-# manifestation).
+# Recommendation, an incoming Aboutness (another work that is ABOUT the
+# manifestation), or an approved Tagging (on the manifestation itself, or on any
+# collection that contains the manifestation on this author's page, including via
+# nested sub-collections).
 #
 # This touches several tables and is only needed by the minority of visitors who
 # change the TOC sort order, so callers are expected to cache the result per
@@ -21,6 +23,7 @@ class AuthorTocFilterData < ApplicationService
       featured_ids: featured_ids(manifestation_ids),
       recommended_ids: recommended_ids(manifestation_ids),
       aboutness_ids: aboutness_ids(manifestation_ids),
+      tagging_ids: tagging_ids(manifestation_ids, authority),
       genres: genres(manifestation_ids),
       orig_langs: orig_langs(manifestation_ids)
     }
@@ -38,6 +41,29 @@ class AuthorTocFilterData < ApplicationService
 
   def aboutness_ids(ids)
     Aboutness.where(aboutable_type: 'Manifestation', aboutable_id: ids).distinct.pluck(:aboutable_id).to_set
+  end
+
+  # Manifestations bearing an approved Tagging, either directly or by belonging to
+  # a collection (on this author's page) that itself bears an approved Tagging.
+  def tagging_ids(ids, authority)
+    direct = Tagging.approved.where(taggable_type: 'Manifestation', taggable_id: ids)
+                    .distinct.pluck(:taggable_id).to_set
+    direct.merge(collection_tagged_manifestation_ids(ids, authority))
+  end
+
+  # Manifestation ids reachable from an approved-tagged collection, cascading
+  # through nested sub-collections (flatten_items), restricted to the author's
+  # own manifestations (ids).
+  def collection_tagged_manifestation_ids(ids, authority)
+    tagged_collection_ids = Tagging.approved
+                                   .where(taggable_type: 'Collection', taggable_id: authority.collections.select(:id))
+                                   .distinct.pluck(:taggable_id)
+    return Set.new if tagged_collection_ids.empty?
+
+    reachable = Collection.where(id: tagged_collection_ids).flat_map do |collection|
+      collection.flatten_items.filter_map { |ci| ci.item_id if ci.item_type == 'Manifestation' }
+    end
+    reachable.to_set & ids.to_set
   end
 
   # genres present, ordered by the canonical genre presentation order

--- a/app/views/authors/_generated_toc.html.haml
+++ b/app/views/authors/_generated_toc.html.haml
@@ -241,6 +241,7 @@
           featured: $m.attr('data-featured') === '1',
           recommended: $m.attr('data-recommended') === '1',
           aboutness: $m.attr('data-aboutness') === '1',
+          tagging: $m.attr('data-tagging') === '1',
           'pubyear': parseInt($m.attr('data-pubyear'), 10),
           'creation-year': parseInt($m.attr('data-creation-year'), 10),
           'upload-year': parseInt($m.attr('data-upload-year'), 10)
@@ -260,7 +261,7 @@
         };
       }
 
-      function hasProps(d) { return d.featured || d.recommended || d.aboutness; }
+      function hasProps(d) { return d.featured || d.recommended || d.aboutness || d.tagging; }
 
       // Does a node match every active filter section, optionally excluding one section.
       function matches(d, s, exclude) {

--- a/app/views/authors/_toc_node.html.haml
+++ b/app/views/authors/_toc_node.html.haml
@@ -10,7 +10,7 @@
     - pub_date = e.normalized_pub_date.presence&.to_date
     - creation_date = w.normalized_creation_date.presence&.to_date
     - upload_date = m.publication_date.presence&.to_date
-    %span.sorting-metadata{ 'data-impressions': m.impressions_count, 'data-title': m.sort_title, 'data-pubdate': pub_date&.jd, 'data-creation-date': creation_date&.jd, 'data-upload-date': upload_date&.jd, 'data-mid': m.id, 'data-genre': genre, 'data-orig-lang': w.orig_lang, 'data-translated': e.translation ? '1' : '0', 'data-pubyear': pub_date&.year, 'data-creation-year': creation_date&.year, 'data-upload-year': upload_date&.year, 'data-featured': fd && fd[:featured_ids].include?(m.id) ? '1' : '0', 'data-recommended': fd && fd[:recommended_ids].include?(m.id) ? '1' : '0', 'data-aboutness': fd && fd[:aboutness_ids].include?(m.id) ? '1' : '0' }
+    %span.sorting-metadata{ 'data-impressions': m.impressions_count, 'data-title': m.sort_title, 'data-pubdate': pub_date&.jd, 'data-creation-date': creation_date&.jd, 'data-upload-date': upload_date&.jd, 'data-mid': m.id, 'data-genre': genre, 'data-orig-lang': w.orig_lang, 'data-translated': e.translation ? '1' : '0', 'data-pubyear': pub_date&.year, 'data-creation-year': creation_date&.year, 'data-upload-year': upload_date&.year, 'data-featured': fd && fd[:featured_ids].include?(m.id) ? '1' : '0', 'data-recommended': fd && fd[:recommended_ids].include?(m.id) ? '1' : '0', 'data-aboutness': fd && fd[:aboutness_ids].include?(m.id) ? '1' : '0', 'data-tagging': fd && fd[:tagging_ids].include?(m.id) ? '1' : '0' }
     %span.by-icon-v02{ title: textify_genre(genre) }>= glyph_for_genre(genre)
     &nbsp;&rlm;
     - if m.published?

--- a/spec/requests/author_toc_filters_spec.rb
+++ b/spec/requests/author_toc_filters_spec.rb
@@ -50,6 +50,24 @@ RSpec.describe 'Author TOC filters (server-rendered)', type: :request do
     expect(node[:'data-recommended']).to eq('1')
   end
 
+  it 'sets data-tagging for a directly-tagged manifestation' do
+    create(:tagging, taggable: story, status: :approved)
+    get authority_path(author)
+
+    node = rendered.first("[data-mid='#{story.id}']", visible: :all)
+    expect(node[:'data-tagging']).to eq('1')
+  end
+
+  it 'sets data-tagging on members of a tagged collection' do
+    create(:tagging, taggable: volume, status: :approved)
+    get authority_path(author)
+
+    poem_node = rendered.first("[data-mid='#{poem.id}']", visible: :all)
+    story_node = rendered.first("[data-mid='#{story.id}']", visible: :all)
+    expect(poem_node[:'data-tagging']).to eq('1')
+    expect(story_node[:'data-tagging']).to eq('1')
+  end
+
   it 'uses the /works-style collapsible block for filter sections' do
     get authority_path(author)
     # same accordion mechanism as /works filtering: .vertical-expand.fcoll toggling a .collapse block

--- a/spec/services/author_toc_filter_data_spec.rb
+++ b/spec/services/author_toc_filter_data_spec.rb
@@ -35,10 +35,48 @@ RSpec.describe AuthorTocFilterData do
     expect(data[:aboutness_ids]).to contain_exactly(poem_he.id)
   end
 
+  it 'collects manifestation ids bearing an approved direct Tagging' do
+    create(:tagging, taggable: poem_he, status: :approved)
+    create(:tagging, taggable: prose_ru, status: :pending) # excluded: not approved
+
+    data = described_class.call(author)
+
+    expect(data[:tagging_ids]).to contain_exactly(poem_he.id)
+  end
+
+  it 'counts an approved Tagging on a collection towards its member manifestations' do
+    collection = create(:collection, authors: [author], manifestations: [prose_ru])
+    create(:tagging, taggable: collection, status: :approved)
+
+    data = described_class.call(author)
+
+    expect(data[:tagging_ids]).to contain_exactly(prose_ru.id)
+  end
+
+  it 'cascades an approved collection Tagging into nested sub-collections' do
+    inner = create(:collection, manifestations: [prose_ru])
+    outer = create(:collection, authors: [author], included_collections: [inner])
+    create(:tagging, taggable: outer, status: :approved)
+
+    data = described_class.call(author)
+
+    expect(data[:tagging_ids]).to contain_exactly(prose_ru.id)
+  end
+
+  it 'ignores a pending Tagging on a collection' do
+    collection = create(:collection, authors: [author], manifestations: [prose_ru])
+    create(:tagging, taggable: collection, status: :pending)
+
+    data = described_class.call(author)
+
+    expect(data[:tagging_ids]).to be_empty
+  end
+
   it 'returns empty sets when the author has no curatorial content' do
     data = described_class.call(author)
     expect(data[:featured_ids]).to be_empty
     expect(data[:recommended_ids]).to be_empty
     expect(data[:aboutness_ids]).to be_empty
+    expect(data[:tagging_ids]).to be_empty
   end
 end

--- a/spec/services/author_toc_filter_data_spec.rb
+++ b/spec/services/author_toc_filter_data_spec.rb
@@ -63,6 +63,18 @@ RSpec.describe AuthorTocFilterData do
     expect(data[:tagging_ids]).to contain_exactly(prose_ru.id)
   end
 
+  it 'counts a Tagging on a nested sub-collection the author is not directly involved in' do
+    # author is involved only in the outer collection; the tagging is on the inner
+    # sub-collection, which appears on the author's page only via nesting.
+    inner = create(:collection, manifestations: [prose_ru])
+    create(:collection, authors: [author], included_collections: [inner])
+    create(:tagging, taggable: inner, status: :approved)
+
+    data = described_class.call(author)
+
+    expect(data[:tagging_ids]).to contain_exactly(prose_ru.id)
+  end
+
   it 'ignores a pending Tagging on a collection' do
     collection = create(:collection, authors: [author], manifestations: [prose_ru])
     create(:tagging, taggable: collection, status: :pending)


### PR DESCRIPTION
## What

The Authority TOC flat-list **"curatorial content"** filter facet currently counts `FeaturedContent`, approved `Recommendation`s, and incoming `Aboutness`es. This extends it to also count **approved `Tagging`s**:

- **directly** on a manifestation, and
- on any **collection** that contains the manifestation on this author's page, **cascading through nested sub-collections** (via `Collection#flatten_items`).

Taggings fold into the existing `curatorial` facet (checkbox + faceted count) — no new UI control, mirroring how Aboutnesses/Recommendations behave.

## Changes

- `app/services/author_toc_filter_data.rb` — returns `tagging_ids` (direct approved manifestation taggings ∪ manifestations reachable from approved-tagged collections, cascading through sub-collections, restricted to the author's own works).
- `app/views/authors/_toc_node.html.haml` — renders `data-tagging` on each manifestation node.
- `app/views/authors/_generated_toc.html.haml` — reads `data-tagging` into `nodeData` and folds it into `hasProps()`.

## Tests

- `spec/services/author_toc_filter_data_spec.rb` — direct approved tagging, collection-tagging propagation, cascade through nested sub-collections, pending-tagging exclusion, empty case.
- `spec/requests/author_toc_filters_spec.rb` — `data-tagging` rendered for a directly-tagged manifestation and for members of a tagged collection.

Full suite green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)