### PR TITLE
Scroll filtered lists back to top after shrinking (author TOC, /authors, /collections)

### DIFF
--- a/app/views/authors/_generated_toc.html.haml
+++ b/app/views/authors/_generated_toc.html.haml
@@ -332,6 +332,20 @@
         updateCounts(state, all);
       }
 
+      // After a filter interaction shrinks the flat list, the (few) remaining
+      // results can sit above the current scroll position, leaving the viewport
+      // apparently empty. Bring the top of the list back into view (mirrors the
+      // /works browse scroll-to-top). Only scrolls up, never down.
+      function scrollListIntoView() {
+        var list = document.getElementById('browse_mainlist');
+        if (!list) { return; }
+        var top = list.getBoundingClientRect().top + window.pageYOffset;
+        if (window.pageYOffset > top) { window.scrollTo(0, top); }
+      }
+
+      // apply() triggered by a user filter interaction: re-filter, then reveal results.
+      function applyFromUser() { apply(); scrollListIntoView(); }
+
       // ---- date histogram + range slider ----
       function positionSlider() {
         if (minYear == null || maxYear == null || maxYear === minYear) {
@@ -428,6 +442,7 @@
           if (isNaN(f)) { f = minYear; }
           if (isNaN(t)) { t = maxYear; }
           setRange(f, t);
+          scrollListIntoView();
         });
 
         $('.toc-date-type').on('click', function() {
@@ -435,22 +450,22 @@
           $(this).addClass('active');
           dateField = $(this).attr('data-datefield');
           refreshDateWidget();
-          apply();
+          applyFromUser();
         });
       }
 
       function bindInputs() {
         $('#toc-filter-name').on('input', function() {
           if (debounceTimer) { window.clearTimeout(debounceTimer); }
-          debounceTimer = window.setTimeout(apply, NAME_DEBOUNCE);
+          debounceTimer = window.setTimeout(applyFromUser, NAME_DEBOUNCE);
         });
         $('#toc-filter-name-clear').on('click', function(e) {
           e.preventDefault();
           $('#toc-filter-name').val('');
-          apply();
+          applyFromUser();
         });
-        $('#toc_filters_pane').on('change', 'input[type=checkbox]', apply);
-        $('#toc-filter-reset').on('click', function(e) { e.preventDefault(); reset(); });
+        $('#toc_filters_pane').on('change', 'input[type=checkbox]', applyFromUser);
+        $('#toc-filter-reset').on('click', function(e) { e.preventDefault(); reset(); scrollListIntoView(); });
       }
 
       function clearInputs() {

--- a/app/views/authors/browse.js.erb
+++ b/app/views/authors/browse.js.erb
@@ -1,3 +1,7 @@
 $('#thelist').html("<%= j(render partial: 'browse_list') %>");
 $('#sort_filter_panel').html("<%= j(render partial: 'browse_filters') %>");
 stopModal('spinnerdiv');
+// After filters/search/pagination replace the list, the (possibly few) results may
+// render above the current scroll position, leaving the viewport apparently empty.
+// Scroll back to the top so the freshly rendered results are visible.
+window.scrollTo(0, 0);

--- a/app/views/collections/browse.js.erb
+++ b/app/views/collections/browse.js.erb
@@ -2,3 +2,7 @@ $('#thelist').html("<%= j(render partial: 'browse_list') %>");
 $('#sort_filter_panel').html("<%= j(render partial: 'browse_filters') %>");
 $('#authoritiesDlg').html("<%= j(render partial: 'authorities_select', locals: {authorities: @authorities, list: @authorities_list}) %>");
 stopModal('spinnerdiv');
+// After filters/search/pagination replace the list, the (possibly few) results may
+// render above the current scroll position, leaving the viewport apparently empty.
+// Scroll back to the top so the freshly rendered results are visible.
+window.scrollTo(0, 0);

--- a/spec/controllers/authors_controller_spec.rb
+++ b/spec/controllers/authors_controller_spec.rb
@@ -18,6 +18,16 @@ describe AuthorsController do
 
     it { is_expected.to be_successful }
 
+    # Regression: when filters/search shrink the list, the (few) results can render
+    # above the current scroll position, leaving the viewport empty. The AJAX JS
+    # response must instruct the browser to scroll back to the top.
+    context 'when responding to an AJAX (JS) request' do
+      it 'instructs the page to scroll back to the top' do
+        get :browse, params: { sort_by: sort_by }.compact, format: :js, xhr: true
+        expect(response.body).to include('window.scrollTo(0, 0)')
+      end
+    end
+
     context 'when displaying work counts' do
       render_views
 

--- a/spec/controllers/collections_controller_spec.rb
+++ b/spec/controllers/collections_controller_spec.rb
@@ -743,6 +743,14 @@ describe CollectionsController do
         expect(response).to be_successful
         expect(response.content_type).to include('text/javascript')
       end
+
+      # Regression: when filters/search shrink the list, the (few) results can render
+      # above the current scroll position, leaving the viewport empty. The AJAX JS
+      # response must instruct the browser to scroll back to the top.
+      it 'instructs the page to scroll back to the top' do
+        get :browse, format: :js, xhr: true
+        expect(response.body).to include('window.scrollTo(0, 0)')
+      end
     end
 
     context 'with filters' do

--- a/spec/system/author_toc_filters_spec.rb
+++ b/spec/system/author_toc_filters_spec.rb
@@ -138,6 +138,32 @@ describe 'Author TOC flat-list filters', :js do
     end
   end
 
+  it 'scrolls the shrunk list back into view after filtering while scrolled down' do
+    # enough works to make the flat list taller than the viewport
+    Chewy.strategy(:atomic) do
+      create_list(:manifestation, 15, status: :published, author: author,
+                                      genre: 'poetry', orig_lang: 'he', language: 'he')
+    end
+
+    visit authority_path(author)
+    choose_sort('title')
+    expect(page).to have_css('#sorted_card .manifestation-node', minimum: 15)
+
+    # scroll to the bottom so the results sit above the viewport
+    page.execute_script('window.scrollTo(0, document.body.scrollHeight)')
+    expect(page.evaluate_script('window.pageYOffset')).to be > 0
+
+    # filter down to the single translated work; the list shrinks dramatically
+    check 'toc-filter-translated'
+    within('#sorted_card') { expect(page).to have_content('Beta Story') }
+
+    # the top of the list is now at or above the viewport top (no empty space)
+    list_top = page.evaluate_script(
+      "Math.round(document.getElementById('browse_mainlist').getBoundingClientRect().top + window.pageYOffset)"
+    )
+    expect(page.evaluate_script('Math.round(window.pageYOffset)')).to be <= list_top
+  end
+
   it 'clears all filters via the reset link' do
     visit authority_path(author)
     choose_sort('title')


### PR DESCRIPTION
## What

When a filter/search shrinks a list while the page is scrolled down, the few remaining results can render **above** the current scroll position, leaving apparent empty space until the user manually scrolls up. PR #1444 (`116a5267f`) fixed this for `/works`; this applies the same treatment to the other three filterable lists that were missed.

## Changes

- **Author TOC flat-list filter** (`_generated_toc.html.haml`, client-side): new `scrollListIntoView()` brings the top of `#browse_mainlist` back into view after an interactive filter change — checkbox facets, free-text name, name-clear, date-type toggle, date from/to fields, and reset. Only scrolls **up**, never down; deliberately **not** wired into live slider drag (would fight the drag) or programmatic activation/reset.
- **`/authors` and `/collections` browse** (AJAX): `window.scrollTo(0, 0)` in their `browse.js.erb`, identical to the `/works` fix.

## Tests

- `spec/system/author_toc_filters_spec.rb` — with a scrollable list, scroll to bottom, filter to one result, assert the list top is at/above the viewport top.
- `spec/controllers/authors_controller_spec.rb` & `collections_controller_spec.rb` — assert the AJAX JS response includes `window.scrollTo(0, 0)` (mirrors the `/works` regression test).

Full suite green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)