### PR TITLE
Fix alphabetical sorting: normalize sort_title/name whitespace

### DIFF
--- a/app/chewy/collections_index.rb
+++ b/app/chewy/collections_index.rb
@@ -11,7 +11,8 @@ class CollectionsIndex < Chewy::Index
                         .preload(involved_authorities: :authority)
   field :id, type: :integer
   field :title
-  field :sort_title, type: :keyword # for sorting
+  # for sorting; normalize whitespace so incidental leading/trailing spaces don't corrupt alphabetical order
+  field :sort_title, type: :keyword, value: ->(c) { SortedTitle.normalize_whitespace(c.sort_title) }
   field :alternate_titles
   field :subtitle
   field :collection_type, type: :keyword # for filtering
@@ -26,7 +27,8 @@ class CollectionsIndex < Chewy::Index
   # }
   field :tags, type: :integer, value: ->(c) { c.tags.pluck(:id) }
   field :first_letter, type: :keyword, value: lambda { |c|
-    c.sort_title.present? ? c.sort_title[0].downcase : 'א'
+    st = SortedTitle.normalize_whitespace(c.sort_title)
+    st.present? ? st[0].downcase : 'א'
   }
   field :items_count, type: :integer, value: ->(c) { c.collection_items.count }
   field :inception_year, type: :integer

--- a/app/chewy/manifestations_index.rb
+++ b/app/chewy/manifestations_index.rb
@@ -14,7 +14,8 @@ class ManifestationsIndex < Chewy::Index
   field :title
   field :primary, type: 'boolean', value: ->(manifestation) { manifestation.expression.work.primary }
   field :alternate_titles
-  field :sort_title, type: 'keyword' # for sorting
+  # for sorting; normalize whitespace so incidental leading/trailing spaces don't corrupt alphabetical order
+  field :sort_title, type: 'keyword', value: ->(m) { SortedTitle.normalize_whitespace(m.sort_title) }
   field :first_letter, value: ->(manifestation) { manifestation.first_hebrew_letter }
   field :fulltext, value: ->(manifestation) { manifestation.to_plaintext }
   field :genre, value: ->(manifestation) { manifestation.expression.work.genre }, type: 'keyword'

--- a/app/models/authority.rb
+++ b/app/models/authority.rb
@@ -83,6 +83,9 @@ class Authority < ApplicationRecord
   validates_attachment_content_type :profile_image, content_type: %r{\Aimage/.*\z}
 
   before_validation do
+    # Strip incidental leading/trailing whitespace so it doesn't corrupt alphabetical sorting/display
+    self.name = SortedTitle.normalize_whitespace(name) if name.present?
+
     if wikidata_uri.blank?
       self.wikidata_uri = nil
     else

--- a/app/models/concerns/sorted_title.rb
+++ b/app/models/concerns/sorted_title.rb
@@ -38,7 +38,7 @@ module SortedTitle
 
   def strip_whitespaces_from_title!
     # strip is insufficient as it doesn't remove nbsps, which are sometimes coming from bibliographic data
-    self.title = title.strip.gsub(/\p{Space}*$/, '') if title.present?
+    self.title = SortedTitle.normalize_whitespace(title) if title.present?
   end
 
   def strip_whitespaces_from_sort_title!

--- a/app/models/concerns/sorted_title.rb
+++ b/app/models/concerns/sorted_title.rb
@@ -8,6 +8,14 @@
 module SortedTitle
   extend ActiveSupport::Concern
 
+  # Removes leading and trailing Unicode whitespace, including nbsp and other spaces that
+  # sometimes arrive with bibliographic data. Internal whitespace is preserved.
+  def self.normalize_whitespace(str)
+    return str if str.nil?
+
+    str.gsub(/\A\p{Space}+/, '').gsub(/\p{Space}+\z/, '')
+  end
+
   included do
     before_validation do
       strip_whitespaces_from_title!
@@ -19,12 +27,22 @@ module SortedTitle
       if sort_title.blank? || (title_changed? && !sort_title_changed?)
         update_sort_title!
       end
+
+      # Always normalize incidental leading/trailing whitespace, including on manually-set
+      # sort_titles that skip regeneration above. Leading whitespace is especially harmful:
+      # a leading space sorts before every letter and digit, pushing records to the top of
+      # alphabetical browse listings (see /collections).
+      strip_whitespaces_from_sort_title!
     end
   end
 
   def strip_whitespaces_from_title!
     # strip is insufficient as it doesn't remove nbsps, which are sometimes coming from bibliographic data
     self.title = title.strip.gsub(/\p{Space}*$/, '') if title.present?
+  end
+
+  def strip_whitespaces_from_sort_title!
+    self.sort_title = SortedTitle.normalize_whitespace(sort_title) if sort_title.present?
   end
 
   def update_sort_title!

--- a/db/migrate/20260710155303_normalize_sort_title_and_authority_name_whitespace.rb
+++ b/db/migrate/20260710155303_normalize_sort_title_and_authority_name_whitespace.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+# Strips leading/trailing whitespace from existing Collection/Manifestation sort_title values and
+# Authority name values. Leading whitespace in particular corrupts alphabetical sorting (a leading
+# space sorts before every letter and digit), pushing records to the top of browse listings such as
+# /collections and /authors.
+#
+# Going forward, the SortedTitle concern normalizes sort_title on every save; this migration cleans up
+# the rows that were imported/edited before that normalization existed. update_column/update_all are
+# used to skip validations and callbacks (matching NormalizeAuthoritySortNameHyphens). Affected ES
+# indexes must be reindexed separately for the change to take effect in browse listings.
+class NormalizeSortTitleAndAuthorityNameWhitespace < ActiveRecord::Migration[8.0]
+  # Maps each model to the string column whose leading/trailing whitespace is stripped.
+  NORMALIZED_COLUMNS = { Collection => :sort_title, Manifestation => :sort_title, Authority => :name }.freeze
+
+  def up
+    NORMALIZED_COLUMNS.each do |klass, column|
+      klass.where.not(column => nil).pluck(:id, column).each do |id, value|
+        normalized = SortedTitle.normalize_whitespace(value)
+        klass.where(id: id).update_all(column => normalized) if normalized != value
+      end
+    end
+  end
+
+  def down
+    # No-op: whitespace stripping is not reversible and carried no semantic meaning.
+    Rails.logger.warn 'Cannot reverse NormalizeSortTitleAndAuthorityNameWhitespace migration'
+  end
+end

--- a/db/migrate/20260710155303_normalize_sort_title_and_authority_name_whitespace.rb
+++ b/db/migrate/20260710155303_normalize_sort_title_and_authority_name_whitespace.rb
@@ -15,9 +15,11 @@ class NormalizeSortTitleAndAuthorityNameWhitespace < ActiveRecord::Migration[8.0
 
   def up
     NORMALIZED_COLUMNS.each do |klass, column|
-      klass.where.not(column => nil).pluck(:id, column).each do |id, value|
-        normalized = SortedTitle.normalize_whitespace(value)
-        klass.where(id: id).update_all(column => normalized) if normalized != value
+      klass.where.not(column => nil).in_batches(of: 1_000) do |relation|
+        relation.pluck(:id, column).each do |id, value|
+          normalized = SortedTitle.normalize_whitespace(value)
+          klass.where(id: id).update_all(column => normalized) if normalized != value
+        end
       end
     end
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_26_134055) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_10_155303) do
   create_table "aboutnesses", id: :integer, charset: "utf8mb4", collation: "utf8mb4_bin", force: :cascade do |t|
     t.integer "aboutable_id"
     t.string "aboutable_type"
@@ -1198,8 +1198,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_26_134055) do
     t.index ["item_type", "item_id"], name: "index_year_totals_on_item_type_and_item_id"
   end
 
-  add_foreign_key "aboutnesses", "users"
-  add_foreign_key "aboutnesses", "works"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "anthologies", "users"
   add_foreign_key "anthology_texts", "anthologies"

--- a/spec/models/authority_spec.rb
+++ b/spec/models/authority_spec.rb
@@ -18,6 +18,11 @@ describe Authority do
       expect(a).to be_valid
     end
 
+    it 'strips leading/trailing whitespace from name on save' do
+      a = create(:authority, name: '  ביאליק  ', person: create(:person))
+      expect(a.reload.name).to eq('ביאליק')
+    end
+
     describe 'uncollected works collection type validation' do
       let(:authority) { build(:authority, uncollected_works_collection: uncollected_works_collection) }
 

--- a/spec/models/collection_spec.rb
+++ b/spec/models/collection_spec.rb
@@ -9,6 +9,11 @@ describe Collection do
     expect { build(:collection, collection_type: 'made_up') }.to raise_error(ArgumentError)
   end
 
+  it 'strips leading/trailing whitespace from a manually-set sort_title on save' do
+    collection = create(:collection, title: 'כותרת', sort_title: '  זבל  ')
+    expect(collection.reload.sort_title).to eq('זבל')
+  end
+
   it 'validates suppress_download_and_print field' do
     collection = build(:collection, suppress_download_and_print: true)
     expect(collection).to be_valid

--- a/spec/models/concerns/sorted_title_spec.rb
+++ b/spec/models/concerns/sorted_title_spec.rb
@@ -76,6 +76,47 @@ describe SortedTitle do
     end
   end
 
+  describe '.normalize_whitespace' do
+    it 'strips leading and trailing ASCII whitespace' do
+      expect(described_class.normalize_whitespace('  שלום  ')).to eq('שלום')
+    end
+
+    it 'strips leading and trailing non-breaking spaces' do
+      expect(described_class.normalize_whitespace("\u00A0\u05E9\u05DC\u05D5\u05DD\u00A0")).to eq('שלום')
+    end
+
+    it 'preserves internal whitespace' do
+      expect(described_class.normalize_whitespace(' שלום עולם ')).to eq('שלום עולם')
+    end
+
+    it 'returns nil unchanged' do
+      expect(described_class.normalize_whitespace(nil)).to be_nil
+    end
+  end
+
+  describe '.strip_whitespaces_from_sort_title!' do
+    let(:title) { 'unused' }
+
+    before do
+      model.sort_title = sort_title_value
+      model.strip_whitespaces_from_sort_title!
+    end
+
+    context 'when sort_title has leading and trailing whitespace' do
+      let(:sort_title_value) { '  זבל  ' }
+
+      it { expect(model.sort_title).to eq('זבל') }
+    end
+
+    context 'when sort_title is blank' do
+      let(:sort_title_value) { '   ' }
+
+      it 'leaves it untouched (blank is handled by regeneration path)' do
+        expect(model.sort_title).to eq('   ')
+      end
+    end
+  end
+
   describe 'before validation hook' do
     let(:title) { ' 1. Some Title  ' }
 
@@ -113,12 +154,12 @@ describe SortedTitle do
         model.sort_title = ' New Sort Title '
       end
 
-      it 'does not generates new sort_title value' do
+      it 'keeps the manually provided sort_title but strips its surrounding whitespace' do
         model.valid?
         expect(model).to have_received(:strip_whitespaces_from_title!).once
         expect(model).not_to have_received(:update_sort_title!)
         expect(model.title).to eq('New Value')
-        expect(model.sort_title).to eq(' New Sort Title ')
+        expect(model.sort_title).to eq('New Sort Title')
       end
     end
 

--- a/spec/models/manifestation_spec.rb
+++ b/spec/models/manifestation_spec.rb
@@ -4,6 +4,11 @@ require 'rails_helper'
 require 'hebrew'
 
 describe Manifestation do
+  it 'strips leading/trailing whitespace from a manually-set sort_title on save' do
+    manifestation = create(:manifestation, title: 'כותרת', sort_title: '  זבל  ')
+    expect(manifestation.reload.sort_title).to eq('זבל')
+  end
+
   describe '.safe_filename' do
     let(:manifestation) { create(:manifestation) }
     let(:subject) { manifestation.safe_filename }

--- a/spec/services/search_collections_spec.rb
+++ b/spec/services/search_collections_spec.rb
@@ -246,6 +246,26 @@ describe SearchCollections do
           expect(result_ids).to eq [coll_c.id, coll_b.id, coll_a.id]
         end
       end
+
+      context 'when a legacy record has leading whitespace in sort_title' do
+        let(:sort_dir) { 'asc' }
+        let(:coll_alef) { create(:collection, title: 'אלף', sort_title: 'אלף') }
+        let(:coll_tav) { create(:collection, title: 'תיו', sort_title: 'תיו') }
+
+        before do
+          # Simulate legacy data written straight to the DB (bypassing SortedTitle normalization):
+          # a leading space would otherwise sort this record before every letter, corrupting the order.
+          coll_tav.update_column(:sort_title, ' תיו')
+          Chewy.strategy(:atomic) do
+            CollectionsIndex.import([coll_alef, coll_tav])
+          end
+        end
+
+        it 'sorts by the whitespace-trimmed sort_title, not the leading space' do
+          result_ids = described_class.call(sorting, sort_dir, {}).map(&:id)
+          expect(result_ids.index(coll_alef.id)).to be < result_ids.index(coll_tav.id)
+        end
+      end
     end
 
     describe 'popularity' do


### PR DESCRIPTION
## Problem

The `/collections` browse list (and, to a lesser extent, the works list) looked unsorted despite being set to sort alphabetically. Collection/Manifestation browse listings sort on the Elasticsearch `sort_title` keyword field, which orders by binary/code-point (the DB collation is `utf8mb4_bin`). Many `sort_title` values had **leading whitespace**, which sorts before every letter and digit — clustering those records at the top.

**Root cause:** the shared `SortedTitle` concern only (re)generated `sort_title` when it was blank or the title changed, so manually-set/imported `sort_title` values were stored verbatim, whitespace and all.

## Changes

- **`SortedTitle` concern:** add `normalize_whitespace` helper and always strip leading/trailing whitespace (incl. nbsp) from `sort_title` on `before_validation`. Covers **Collection, Manifestation, and LexEntry** (all include the concern).
- **`Authority`:** strip leading/trailing whitespace from `name` on `before_validation`.
- **`CollectionsIndex` / `ManifestationsIndex`:** index the whitespace-normalized `sort_title` (and Collections' `first_letter`), as defense against values written via `update_column`/`update_all` that bypass model callbacks.
- **Data migration:** one-time cleanup stripping existing `Collection`/`Manifestation` `sort_title` and `Authority` `name` whitespace (`update_all`, matching the existing `NormalizeAuthoritySortNameHyphens` migration).

## Test plan

- `bundle exec rspec spec/models/concerns/sorted_title_spec.rb spec/models/collection_spec.rb spec/models/manifestation_spec.rb spec/models/authority_spec.rb spec/services/search_collections_spec.rb` — all green.
- Added: concern unit tests, Collection/Manifestation/Authority save specs, and a `SearchCollections` index-defense ordering test (legacy leading-space `sort_title` via `update_column`).
- Verified on dev: migration cleaned all affected rows (0 remaining); reindexed `CollectionsIndex` and confirmed `/collections` now sorts correctly (digits → Latin → Hebrew alphabetical).

## ⚠️ Deploy note

After deploy, **reindex** `CollectionsIndex`, `ManifestationsIndex`, and `AuthoritiesIndex` (+ autocomplete) for the cleaned values to surface in browse listings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)