### PR TITLE
Show only volume/periodical/volume_series in /collections browse

### DIFF
--- a/app/controllers/collections_controller.rb
+++ b/app/controllers/collections_controller.rb
@@ -516,12 +516,13 @@ class CollectionsController < ApplicationController
     @filters = []
 
     # collection types -- the browse view only ever surfaces the "browsable" types (see
-    # Collection::BROWSABLE_COLLECTION_TYPES); series/other/uncollected are never shown here. When the user narrows
-    # via checkboxes we intersect their selection with the allowed set; otherwise we default to the whole set.
-    @collection_types = params['ckb_collection_types'] unless @collection_types.present?
+    # Collection::BROWSABLE_COLLECTION_TYPES); series/other/uncollected are never shown here. Drop any
+    # disallowed values from the user's selection up front so the ES filter, the active-filter chips, and the
+    # checkbox state all agree; when nothing browsable remains we default to the whole allowed set.
+    @collection_types = params['ckb_collection_types'] if @collection_types.blank?
+    @collection_types &= Collection::BROWSABLE_COLLECTION_TYPES if @collection_types.present?
     if @collection_types.present?
-      ret['collection_types'] = (@collection_types & Collection::BROWSABLE_COLLECTION_TYPES).presence ||
-                                Collection::BROWSABLE_COLLECTION_TYPES
+      ret['collection_types'] = @collection_types
       @filters += @collection_types.map { |x| [textify_collection_type(x), "collection_type_#{x}", :checkbox] }
     else
       ret['collection_types'] = Collection::BROWSABLE_COLLECTION_TYPES

--- a/app/controllers/collections_controller.rb
+++ b/app/controllers/collections_controller.rb
@@ -515,11 +515,16 @@ class CollectionsController < ApplicationController
     ret = {}
     @filters = []
 
-    # collection types
+    # collection types -- the browse view only ever surfaces the "browsable" types (see
+    # Collection::BROWSABLE_COLLECTION_TYPES); series/other/uncollected are never shown here. When the user narrows
+    # via checkboxes we intersect their selection with the allowed set; otherwise we default to the whole set.
     @collection_types = params['ckb_collection_types'] unless @collection_types.present?
     if @collection_types.present?
-      ret['collection_types'] = @collection_types
+      ret['collection_types'] = (@collection_types & Collection::BROWSABLE_COLLECTION_TYPES).presence ||
+                                Collection::BROWSABLE_COLLECTION_TYPES
       @filters += @collection_types.map { |x| [textify_collection_type(x), "collection_type_#{x}", :checkbox] }
+    else
+      ret['collection_types'] = Collection::BROWSABLE_COLLECTION_TYPES
     end
 
     # tags by tag_id

--- a/app/helpers/collections_helper.rb
+++ b/app/helpers/collections_helper.rb
@@ -87,6 +87,8 @@ module CollectionsHelper
       content_tag(:span, '📚', class: 'collection-type-icon', title: textify_collection_type(:volume))
     when 'periodical'
       content_tag(:span, '📰', class: 'collection-type-icon', title: textify_collection_type(:periodical))
+    when 'volume_series'
+      content_tag(:span, '📖', class: 'collection-type-icon', title: textify_collection_type(:volume_series))
     when 'series'
       content_tag(:span, '📑', class: 'collection-type-icon', title: textify_collection_type(:series))
     when 'other'

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -67,6 +67,12 @@ class Collection < ApplicationRecord
   }
   enum :toc_strategy, { default: 0, custom_markdown: 1 } # placeholder for future custom ToC-generation strategies
 
+  # Collection types surfaced in the public /collections browse listing. `series` and `other` are deliberately
+  # excluded (they are not meaningful as standalone browsable collections), as are `uncollected` collections.
+  # `periodical_issue` is listed for completeness, but note it is also excluded from CollectionsIndex, so it never
+  # actually appears in the browse list (issues are shown nested under their parent periodical).
+  BROWSABLE_COLLECTION_TYPES = %w(volume periodical periodical_issue volume_series).freeze
+
   # scope :published, -> { where(status: Collection.statuses[:published]) }
   scope :by_type, ->(thetype) { where(collection_type: thetype) }
   scope :by_tag, ->(tag_id) { joins(:taggings).where(taggings: { tag_id: tag_id }) }

--- a/app/views/collections/_browse_filters.html.haml
+++ b/app/views/collections/_browse_filters.html.haml
@@ -14,9 +14,10 @@
                        class: %w(field-v02 field-without-label),
                        placeholder: t(:collection_title_search)
 
-    - collection_types_to_show = %w(volume periodical)
-    - labels = collection_types_to_show.index_with { |type| textify_collection_type(type) }
-    - icons = { 'volume' => '📚', 'periodical' => '📰' }
+    :ruby
+      collection_types_to_show = %w(volume periodical volume_series)
+      labels = collection_types_to_show.index_with { |type| textify_collection_type(type) }
+      icons = { 'volume' => '📚', 'periodical' => '📰', 'volume_series' => '📖' }
     = render partial: 'shared/filters/checkbox_group',
              locals: { group_name: :collection_type,
                        title: Collection.human_attribute_name(:collection_type),

--- a/app/views/collections/_browse_filters.html.haml
+++ b/app/views/collections/_browse_filters.html.haml
@@ -14,9 +14,9 @@
                        class: %w(field-v02 field-without-label),
                        placeholder: t(:collection_title_search)
 
-    - collection_types_to_show = %w(volume periodical series other)
+    - collection_types_to_show = %w(volume periodical)
     - labels = collection_types_to_show.index_with { |type| textify_collection_type(type) }
-    - icons = { 'volume' => '📚', 'periodical' => '📰', 'series' => '📑', 'other' => '📁' }
+    - icons = { 'volume' => '📚', 'periodical' => '📰' }
     = render partial: 'shared/filters/checkbox_group',
              locals: { group_name: :collection_type,
                        title: Collection.human_attribute_name(:collection_type),

--- a/spec/controllers/collections_controller_spec.rb
+++ b/spec/controllers/collections_controller_spec.rb
@@ -711,7 +711,11 @@ describe CollectionsController do
     let(:volume_1) { create(:collection, title: 'Alpha Volume', collection_type: :volume, sort_title: 'alpha volume') }
     let(:volume_2) { create(:collection, title: 'Beta Volume', collection_type: :volume, sort_title: 'beta volume') }
     let(:periodical) { create(:collection, title: 'Gamma Periodical', collection_type: :periodical, sort_title: 'gamma periodical') }
-    let(:series) { create(:collection, title: 'Delta Series', collection_type: :series, sort_title: 'delta series') }
+    let(:volume_series) do
+      create(:collection, title: 'Delta Volume Series', collection_type: :volume_series, sort_title: 'delta series')
+    end
+    # A non-browsable type: it is indexed but must never appear in the /collections browse listing.
+    let(:series) { create(:collection, title: 'Omega Series', collection_type: :series, sort_title: 'omega series') }
 
     before do
       Chewy.massacre
@@ -719,6 +723,7 @@ describe CollectionsController do
         volume_1
         volume_2
         periodical
+        volume_series
         series
       end
     end
@@ -732,7 +737,9 @@ describe CollectionsController do
         get :browse
         expect(response).to be_successful
         expect(response).to render_template(:browse)
+        # Four browsable collections are indexed; the `series` collection is excluded from the browse listing.
         expect(assigns(:collections).count).to eq(4)
+        expect(assigns(:collections).map(&:id)).not_to include(series.id)
         expect(assigns(:collections_list_title)).to be_present
       end
     end
@@ -767,9 +774,9 @@ describe CollectionsController do
       end
 
       it 'filters by multiple collection types' do
-        get :browse, params: { ckb_collection_types: ['volume', 'series'] }
+        get :browse, params: { ckb_collection_types: %w(volume volume_series) }
         expect(response).to be_successful
-        expect(assigns(:collections).map(&:id)).to contain_exactly(volume_1.id, volume_2.id, series.id)
+        expect(assigns(:collections).map(&:id)).to contain_exactly(volume_1.id, volume_2.id, volume_series.id)
       end
     end
 
@@ -777,20 +784,20 @@ describe CollectionsController do
       it 'sorts alphabetically by default' do
         get :browse
         expect(assigns(:sort_by)).to eq('alphabetical')
-        expect(assigns(:collections).map(&:id)).to eq([volume_1.id, volume_2.id, series.id, periodical.id])
+        expect(assigns(:collections).map(&:id)).to eq([volume_1.id, volume_2.id, volume_series.id, periodical.id])
       end
 
       it 'sorts by popularity when requested' do
         Chewy.strategy(:atomic) do
           volume_1.update!(impressions_count: 100)
-          series.update!(impressions_count: 50)
+          volume_series.update!(impressions_count: 50)
           periodical.update!(impressions_count: 75)
           volume_2.update!(impressions_count: 25)
         end
 
         get :browse, params: { sort_by: 'popularity_desc' }
         expect(assigns(:sort_by)).to eq('popularity')
-        expect(assigns(:collections).map(&:id)).to eq([volume_1.id, periodical.id, series.id, volume_2.id])
+        expect(assigns(:collections).map(&:id)).to eq([volume_1.id, periodical.id, volume_series.id, volume_2.id])
       end
 
       it 'sorts by publication date when requested' do
@@ -798,12 +805,12 @@ describe CollectionsController do
           volume_1.update!(normalized_pub_year: 2000)
           volume_2.update!(normalized_pub_year: 1990)
           periodical.update!(normalized_pub_year: 1980)
-          series.update!(normalized_pub_year: 2010)
+          volume_series.update!(normalized_pub_year: 2010)
         end
 
         get :browse, params: { sort_by: 'publication_date_asc' }
         expect(assigns(:sort_by)).to eq('publication_date')
-        expect(assigns(:collections).map(&:id)).to eq([periodical.id, volume_2.id, volume_1.id, series.id])
+        expect(assigns(:collections).map(&:id)).to eq([periodical.id, volume_2.id, volume_1.id, volume_series.id])
       end
     end
 

--- a/spec/controllers/collections_controller_spec.rb
+++ b/spec/controllers/collections_controller_spec.rb
@@ -778,6 +778,16 @@ describe CollectionsController do
         expect(response).to be_successful
         expect(assigns(:collections).map(&:id)).to contain_exactly(volume_1.id, volume_2.id, volume_series.id)
       end
+
+      it 'drops disallowed types from the active-filter chips and applied filter' do
+        get :browse, params: { ckb_collection_types: %w(volume series) }
+        expect(response).to be_successful
+        chip_ids = assigns(:filters).map { |_label, id, _which| id }
+        expect(chip_ids).to include('collection_type_volume')
+        expect(chip_ids).not_to include('collection_type_series')
+        # only the browsable 'volume' results come back; the disallowed 'series' is ignored
+        expect(assigns(:collections).map(&:id)).to contain_exactly(volume_1.id, volume_2.id)
+      end
     end
 
     context 'with sorting' do

--- a/spec/requests/collections_browse_spec.rb
+++ b/spec/requests/collections_browse_spec.rb
@@ -8,10 +8,17 @@ RSpec.describe 'Collections Browse', type: :request do
   end
 
   let!(:volume) { create(:collection, title: 'Test Volume', collection_type: :volume, sort_title: 'test volume') }
+  let!(:periodical) do
+    create(:collection, title: 'Test Periodical', collection_type: :periodical, sort_title: 'test periodical')
+  end
+  let!(:volume_series) do
+    create(:collection, title: 'Test Volume Series', collection_type: :volume_series, sort_title: 'test volume series')
+  end
   let!(:series) { create(:collection, title: 'Test Series', collection_type: :series, sort_title: 'test series') }
+  let!(:other) { create(:collection, title: 'Test Other', collection_type: :other, sort_title: 'test other') }
 
   before do
-    CollectionsIndex.import([volume, series])
+    CollectionsIndex.import([volume, periodical, volume_series, series, other])
   end
 
   describe 'GET /collections' do
@@ -35,10 +42,17 @@ RSpec.describe 'Collections Browse', type: :request do
         expect(response.body).to include('submit_filters') # JavaScript from browse.html.haml
       end
 
-      it 'displays collection results' do
+      it 'displays browsable collection types (volume, periodical, volume_series)' do
         get collections_browse_path
         expect(response.body).to include('Test Volume')
-        expect(response.body).to include('Test Series')
+        expect(response.body).to include('Test Periodical')
+        expect(response.body).to include('Test Volume Series')
+      end
+
+      it 'hides non-browsable collection types (series, other)' do
+        get collections_browse_path
+        expect(response.body).not_to include('Test Series')
+        expect(response.body).not_to include('Test Other')
       end
 
       it 'includes filter form elements' do
@@ -83,6 +97,12 @@ RSpec.describe 'Collections Browse', type: :request do
         get collections_browse_path, params: { ckb_collection_types: ['volume'] }
         expect(response).to have_http_status(:success)
         expect(response.body).to include('Test Volume')
+      end
+
+      it 'never surfaces a non-browsable type even when explicitly requested via a stale checkbox param' do
+        get collections_browse_path, params: { ckb_collection_types: ['series'] }
+        expect(response).to have_http_status(:success)
+        expect(response.body).not_to include('Test Series')
       end
 
       it 'searches by title' do

--- a/spec/requests/collections_browse_spec.rb
+++ b/spec/requests/collections_browse_spec.rb
@@ -69,6 +69,16 @@ RSpec.describe 'Collections Browse', type: :request do
         get collections_browse_path
         expect(response.body).to include('sort_by_dd') # sort dropdown
       end
+
+      it 'offers volume, periodical and volume_series as filterable collection types' do
+        get collections_browse_path
+        expect(response.body).to include('id="collection_type_volume"')
+        expect(response.body).to include('id="collection_type_periodical"')
+        expect(response.body).to include('id="collection_type_volume_series"')
+        # non-browsable types are not offered as filters
+        expect(response.body).not_to include('id="collection_type_series"')
+        expect(response.body).not_to include('id="collection_type_other"')
+      end
     end
 
     context 'JS/AJAX request' do


### PR DESCRIPTION
## Summary

The `/collections` browse listing showed every indexed collection type, including `series` and `other`, which aren't meaningful as standalone browsable collections. This restricts the listing to the browsable types — **volume, periodical, volume_series** (and `periodical_issue`, which is already excluded at the index level and so never appears). `series` and `other` are now hidden.

## Changes

- **`Collection::BROWSABLE_COLLECTION_TYPES`** — single source of truth for the allowed types.
- **`collections#browse`** — always constrain the ES query to the whitelist. When the user narrows via checkboxes, intersect their selection with it (falling back to the whole set if a stale/disallowed value is passed, so `series`/`other` can never leak into the results).
- **Browse filters** — drop `series` and `other` from the collection-type checkboxes.

## Test plan

- `bundle exec rspec spec/requests/collections_browse_spec.rb spec/controllers/collections_controller_spec.rb` — all green.
- Regression tests: browsable types shown, `series`/`other` hidden, and a stale-checkbox-param guard.

## Note

`periodical_issue` is in the allowed set for completeness but is excluded from `CollectionsIndex` (issues appear nested under their parent periodical), so it does not appear as a top-level entry — unchanged by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)