### PR TITLE
Fixed #1255 - removed show_all tags

### DIFF
--- a/app/controllers/taggings_controller.rb
+++ b/app/controllers/taggings_controller.rb
@@ -64,7 +64,6 @@ class TaggingsController < ApplicationController
   def browse # public tags listing
     @page_title = "#{t(:tags_list)} – #{t(:project_ben_yehuda)}"
     @sort = params[:sort_by] || 'alphabetical'
-    @show_all = params[:show_all] == 'true'
 
     tags_query = Tag.approved
     tags_query = case @sort
@@ -75,7 +74,7 @@ class TaggingsController < ApplicationController
                  end
 
     @total = tags_query.count
-    @tags = @show_all ? tags_query : tags_query.page(params[:page])
+    @tags = tags_query.page(params[:page])
   end
 
   def list_tags # for backend

--- a/app/views/taggings/browse.html.haml
+++ b/app/views/taggings/browse.html.haml
@@ -8,6 +8,7 @@
           %span.text-muted{style: 'font-size: 80%; margin-right: 10px;'}
             = "(#{@total})"
       .by-card-content-v02
+        - is_editor = current_user&.editor? && current_user.has_bit?('moderate_tags')
         .select-all-with-buttons
           .headline-4-v02= t(:sort_by)
           #sort-by
@@ -15,9 +16,6 @@
               %select#sort_by_select
                 %option{ value: 'alphabetical', selected: @sort == 'alphabetical' }= t(:alphabetical)
                 %option{ value: 'popularity', selected: @sort == 'popularity' }= t(:by_popularity)
-          %label{style: 'margin-left: 20px; display: inline-flex; align-items: center; cursor: pointer;'}
-            %input#show_all_checkbox{type: 'checkbox', checked: @show_all, style: 'margin-right: 5px;'}
-            = t(:show_all_tags)
         .mainlist#tags_mainlist
           %ol
             - @tags.each do |tag|
@@ -25,11 +23,10 @@
                 = link_to tag.name, tag_path(tag.id)
                 %span.text-muted{style: 'font-size: 80%'}
                   = "(#{tag.approved_taggings_count})"
-                - if current_user&.editor? && current_user.has_bit?('moderate_tags')
+                - if is_editor
                   = link_to t(:edit), edit_tag_path(tag), class: 'by-button-secondary-v02 pad10rl', style: 'margin-right: 10px; font-size: 75%;'
-        - unless @show_all
-          .pagination-container{style: 'margin-top: 20px;'}
-            != paginate @tags
+        .pagination-container{style: 'margin-top: 20px;'}
+          != paginate @tags
 
 :javascript
   $(document).ready(function() {
@@ -38,18 +35,6 @@
       const url = new URL(window.location);
       url.searchParams.set('sort_by', sortBy);
       url.searchParams.delete('page'); // Reset to page 1 when sort changes
-      window.location = url.toString();
-    });
-
-    $('#show_all_checkbox').change(function(){
-      const showAll = $(this).is(':checked');
-      const url = new URL(window.location);
-      if (showAll) {
-        url.searchParams.set('show_all', 'true');
-        url.searchParams.delete('page'); // Remove page param when showing all
-      } else {
-        url.searchParams.delete('show_all');
-      }
       window.location = url.toString();
     });
   });

--- a/app/views/taggings/browse.html.haml
+++ b/app/views/taggings/browse.html.haml
@@ -25,7 +25,7 @@
                   = "(#{tag.approved_taggings_count})"
                 - if is_editor
                   = link_to t(:edit), edit_tag_path(tag), class: 'by-button-secondary-v02 pad10rl', style: 'margin-right: 10px; font-size: 75%;'
-        .pagination-container{style: 'margin-top: 20px;'}
+        .pagination-container{ style: 'margin-top: 20px;' }
           != paginate @tags
 
 :javascript

--- a/spec/system/tags_browse_spec.rb
+++ b/spec/system/tags_browse_spec.rb
@@ -74,47 +74,17 @@ describe 'Tags browse view' do
     end
   end
 
-  describe 'show all functionality', :js do
+  describe 'pagination' do
     before do
-      # Reduced from 30 to 26 - just enough to trigger pagination at 25 per page
+      # 26 approved tags is just enough to trigger pagination at 25 per page
       26.times do |i|
         create(:tag, name: "Tag#{i.to_s.rjust(3, '0')}", status: :approved)
       end
       visit tags_browse_path
     end
 
-    it 'shows pagination by default when there are many tags' do
+    it 'shows pagination when there are many tags' do
       expect(page).to have_css('.pagination-container')
-    end
-
-    it 'hides pagination when "show all" is checked' do
-      check 'show_all_checkbox'
-      # Use Capybara's built-in waiting instead of sleep
-      expect(page).not_to have_css('.pagination-container', wait: 2)
-    end
-
-    it 'displays all tags when "show all" is checked' do
-      check 'show_all_checkbox'
-
-      # Should show all 29 tags (3 from setup + 26 created in before block)
-      # Use Capybara's built-in waiting
-      within('#tags_mainlist ol', wait: 2) do
-        expect(page.all('li').count).to eq(29)
-      end
-    end
-
-    it 'maintains the checkbox state when navigating with show_all param' do
-      visit tags_browse_path(show_all: 'true')
-
-      expect(page).to have_checked_field('show_all_checkbox')
-      expect(page).not_to have_css('.pagination-container')
-    end
-
-    it 'shows pagination again when "show all" is unchecked' do
-      visit tags_browse_path(show_all: 'true')
-      uncheck 'show_all_checkbox'
-      # Use Capybara's built-in waiting instead of sleep
-      expect(page).to have_css('.pagination-container', wait: 2)
     end
   end
 end


### PR DESCRIPTION
## Summary
Removes the `show_all` tags handling from the taggings browse view and controller.

Closes #1255.

## Changes
- `app/controllers/taggings_controller.rb`: dropped `show_all` handling
- `app/views/taggings/browse.html.haml`: removed the show-all tags UI branch

## Test plan
- Verify the `/taggings/browse` page renders correctly without the show_all tags section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)