### PR TITLE
Files controller tweaks

### DIFF
--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -777,7 +777,10 @@ class AdminController < ApplicationController
       flash[:error] = I18n.t(:no_such_item)
       redirect_to url_for(action: :index)
     elsif @vp.update(sp_params)
-      @vp.images.attach(params[:static_page][:images]) if params[:static_page][:images].present?
+      if params[:static_page][:images].present?
+        @vp.images.attach(params[:static_page][:images])
+        @vp.clear_redirect_urls_cache
+      end
       flash[:notice] = I18n.t(:updated_successfully)
       redirect_to action: :static_page_show, id: @vp.id
     else

--- a/app/controllers/files_controller.rb
+++ b/app/controllers/files_controller.rb
@@ -19,19 +19,36 @@ class FilesController < ApplicationController
       return
     end
 
-    record = record_class.find_by(id: record_id)
-    if record.nil?
-      render plain: "Record not found: #{record_id}", status: :not_found
-      return
-    end
+    record_urls = redirect_urls(record_class, record_id)
 
-    blob = record.blob_by_filename(filename)
-    unless blob
+    redirect_url = record_urls[filename]
+    if redirect_url.nil?
       render plain: "File not found: #{filename}", status: :not_found
       return
     end
 
-    disposition = blob.image? ? 'inline' : 'attachment'
-    redirect_to rails_blob_url(blob, disposition: disposition)
+    redirect_to redirect_url
+  end
+
+  private
+
+  def redirect_urls_key(record_class, record_id)
+    "redirect_urls_#{record_class}:#{record_id}"
+  end
+
+  def redirect_urls(record_class, record_id)
+    Rails.cache.fetch(
+      redirect_urls_key(record_class, record_id), expires_in: 2.hours, race_condition_ttl: 10.seconds
+    ) do
+      record = record_class.find_by(id: record_id)
+
+      result = {}
+      record&.downloadable_attachments&.each do |attachment|
+        blob = attachment.blob
+        disposition = blob.image? ? 'inline' : 'attachment'
+        result[attachment.filename.to_s] = rails_blob_url(blob, disposition: disposition)
+      end
+      result
+    end
   end
 end

--- a/app/controllers/files_controller.rb
+++ b/app/controllers/files_controller.rb
@@ -5,6 +5,9 @@
 # Manifestations and StaticPages as well.
 # One limitation of this is that we assume all attachments attached to a given model are unique by filename.
 class FilesController < ApplicationController
+  skip_before_action :set_paper_trail_whodunnit
+  skip_before_action :set_base_user # Skip user initialization as it is a public URL
+
   # URL format: /files/:record_type/:record_id/:filename
   def download
     record_type = params.fetch(:record_type)
@@ -19,7 +22,7 @@ class FilesController < ApplicationController
       return
     end
 
-    record_urls = redirect_urls(record_class, record_id)
+    record_urls = cached_redirect_urls(record_class, record_id)
 
     redirect_url = record_urls[filename]
     if redirect_url.nil?
@@ -32,14 +35,9 @@ class FilesController < ApplicationController
 
   private
 
-  def redirect_urls_key(record_class, record_id)
-    "redirect_urls_#{record_class}:#{record_id}"
-  end
-
-  def redirect_urls(record_class, record_id)
-    Rails.cache.fetch(
-      redirect_urls_key(record_class, record_id), expires_in: 2.hours, race_condition_ttl: 10.seconds
-    ) do
+  def cached_redirect_urls(record_class, record_id)
+    cache_key = DownloadLink.redirect_urls_cache_key(record_class, record_id)
+    Rails.cache.fetch(cache_key, expires_in: 2.hours, race_condition_ttl: 10.seconds) do
       record = record_class.find_by(id: record_id)
 
       result = {}

--- a/app/controllers/manifestation_controller.rb
+++ b/app/controllers/manifestation_controller.rb
@@ -602,6 +602,7 @@ class ManifestationController < ApplicationController
     attachment = @m.images.find_by(id: params[:image_id])
     unless attachment.nil?
       attachment.purge
+      @m.clear_redirect_urls_cache
       @img_id = params[:image_id]
       respond_to do |format|
         format.js
@@ -754,6 +755,7 @@ class ManifestationController < ApplicationController
     @m = Manifestation.find(params[:id])
     prev_count = @m.images.count
     @m.images.attach(params.permit(images: [])[:images])
+    @m.clear_redirect_urls_cache
     new_count = @m.images.count
     flash[:notice] = I18n.t(:uploaded_images, images_added: new_count - prev_count, total: new_count)
     redirect_to action: :show, id: @m.id

--- a/app/controllers/manifestation_controller.rb
+++ b/app/controllers/manifestation_controller.rb
@@ -10,7 +10,7 @@ class ManifestationController < ApplicationController
   include PaperTrailHelpers
 
   before_action only: %i(list show remove_link edit_metadata add_aboutnesses versions version_diff
-                         restore_version preview_link_expression link_expression) do |c|
+                         restore_version preview_link_expression link_expression add_images remove_image) do |c|
     c.require_editor('edit_catalog')
   end
   before_action only: %i(edit update) do |c|
@@ -18,7 +18,8 @@ class ManifestationController < ApplicationController
   end
   before_action only: %i(all genre period by_tag), &:refuse_unreasonable_page
   before_action :set_manifestation,
-                only: %i(print read readmode dict dict_print dict_entry_print fetch_originating_task)
+                only: %i(print read readmode dict dict_print dict_entry_print fetch_originating_task
+                         add_images remove_image)
   before_action only: %i(fetch_originating_task) do |c|
     c.require_editor('edit_catalog')
   end
@@ -597,8 +598,6 @@ class ManifestationController < ApplicationController
   # editor actions
 
   def remove_image
-    @m = Manifestation.find(params[:id])
-
     attachment = @m.images.find_by(id: params[:image_id])
     unless attachment.nil?
       attachment.purge
@@ -752,7 +751,6 @@ class ManifestationController < ApplicationController
   end
 
   def add_images
-    @m = Manifestation.find(params[:id])
     prev_count = @m.images.count
     @m.images.attach(params.permit(images: [])[:images])
     @m.clear_redirect_urls_cache

--- a/app/models/concerns/download_link.rb
+++ b/app/models/concerns/download_link.rb
@@ -20,14 +20,17 @@ module DownloadLink
     URI::DEFAULT_PARSER.unescape(path)
   end
 
-  def blob_by_filename(filename)
+  def downloadable_attachments
     class_name = self.class.name
     type_data = RECORD_TYPES[class_name]
     raise "Unsupported class: #{class_name}" if type_data.nil?
 
     attachments_field = type_data[:attachments_field]
-    attachments = send(attachments_field).attachments.includes(:blob)
-    attachment = attachments.detect { |att| att.filename.to_s == filename }
+    send(attachments_field).attachments.includes(:blob)
+  end
+
+  def blob_by_filename(filename)
+    attachment = downloadable_attachments.detect { |att| att.filename.to_s == filename }
     attachment&.blob
   end
 

--- a/app/models/concerns/download_link.rb
+++ b/app/models/concerns/download_link.rb
@@ -49,4 +49,15 @@ module DownloadLink
     class_name = RECORD_TYPES.detect { |_class_name, data| data[:record_type] == record_type }&.first
     class_name&.constantize
   end
+
+  # Key used to cache redirect URLs specified for given model instance
+  def self.redirect_urls_cache_key(record_class, record_id)
+    "redirect_urls_#{record_class}:#{record_id}"
+  end
+
+  # Method to clear cached redirect URLs for given model instance
+  # Should be called every time we modify files attached to model
+  def clear_redirect_urls_cache
+    Rails.cache.delete(DownloadLink.redirect_urls_cache_key(self.class, id))
+  end
 end

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -14,7 +14,7 @@ class Rack::Attack
     BAD_IPS.include?(req.ip)
   end
 
-  ASSET_PATH_PREFIXES = ['/assets', '/rails/active_storage'].freeze
+  ASSET_PATH_PREFIXES = %w[/assets /rails/active_storage /files/].freeze
 
   def self.asset_request?(req)
     ASSET_PATH_PREFIXES.any? { |prefix| req.path.start_with?(prefix) }

--- a/spec/controllers/manifestations_controller_spec.rb
+++ b/spec/controllers/manifestations_controller_spec.rb
@@ -936,9 +936,14 @@ describe ManifestationController do
 
     describe '#remove_image' do
       subject(:call) { post :remove_image, params: { id: manifestation_id, image_id: image_id }, xhr: true }
+      let(:user) { create(:user, :edit_catalog) }
 
       let(:manifestation_id) { manifestation.id }
       let(:image_id) { image.id }
+
+      before do
+        session[:user_id] = user.id
+      end
 
       let!(:image) do
         manifestation.images.attach(

--- a/spec/requests/files_spec.rb
+++ b/spec/requests/files_spec.rb
@@ -104,7 +104,7 @@ describe '/files' do
 
         it 'fails with Not Found status' do
           expect(call).to eq(404)
-          expect(response.body).to eq("Record not found: #{record_id}")
+          expect(response.body).to eq("File not found: #{filename}")
         end
       end
 


### PR DESCRIPTION
This PR speedups FilesController#download action by:
- using caching to faster get URL to S3 cloud
- disabling some `before_actions` in controller, not really required .

So if cache is initialized, this action will do no SQL queries at all.

It also fix security issue: actions `add_images`/`remove_image` in ManifestationController had no permission checks, so anyone could call them (knowing right URL). Now those actions requires user with `edit_catalog` permission.

And it updates Rack_Attack settings to allow higher rate limits for urls started with /files/