### PR TITLE
added libvips to docker image used for CI

### DIFF
--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -4,7 +4,7 @@ ADD https://github.com/jgm/pandoc/releases/download/3.8.2.1/pandoc-3.8.2.1-1-amd
 
 RUN apt-get update -qq \
     && apt-get install -y curl cmake git yaz libyaz-dev libmagickwand-dev \
-       mysql-client libmysqlclient-dev libpcap-dev libyaml-dev \
+       mysql-client libmysqlclient-dev libpcap-dev libyaml-dev libvips-dev \
     && dpkg -i /tmp/pandoc.deb
 
 # Ubuntu uses snap for chromium, but snap doesn't work in docker, so we need to install chromium from PPA


### PR DESCRIPTION
I've recently added couple of specs invloving image resizing with ActiveStorage.
Such functionality requires libvips, so I've added it to docker image used in CI pipeline