### PR TITLE
Fix tag-proposal popup layout on mobile

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1169,6 +1169,82 @@ p.by-genre-name-v02.headline-2-v02 {
   min-width: 122px;
 }
 
+/* Tag-proposal popup: the mode toggle (suggest / pick from full list) and the
+   tag-suggestion heuristic strip. Both are jQuery UI tab navs; the layout that
+   used to be set inline on the <ul> lives here so mobile can override it. */
+.tag-mode-tabs {
+  display: flex;
+}
+
+.tag-heuristic-tabs {
+  display: flex;
+  flex-wrap: wrap;
+  font-size: 80%;
+}
+
+/* .by-card-content-v02 ul sets list-style: disc, which leaks into the strips
+   wherever the jQuery UI tab stylesheet loses the cascade */
+.tag-mode-tabs > li,
+.tag-heuristic-tabs > li {
+  list-style: none;
+}
+
+@media screen and (max-width: 767px) {
+  /* mode toggle becomes a full-width, two-up segmented control */
+  .ui-tabs .tag-mode-tabs {
+    width: 100%;
+    margin: 0 0 12px;
+    padding: 0;
+    border: 0;
+    background: none;
+  }
+
+  .ui-tabs .tag-mode-tabs > li {
+    float: none;
+    flex: 1 1 50%;
+    min-width: 0;
+    margin: 0;
+    text-align: center;
+    white-space: normal;
+  }
+
+  .ui-tabs .tag-mode-tabs > li .ui-tabs-anchor {
+    float: none;
+    display: block;
+    padding: 10px 6px;
+    white-space: normal;
+  }
+
+  /* heuristics become wrapping chips, so all of them stay visible */
+  .ui-tabs .tag-heuristic-tabs {
+    flex-wrap: wrap;
+    gap: 6px;
+    width: 100%;
+    margin: 0 0 12px;
+    padding: 0;
+    border: 0;
+    background: none;
+  }
+
+  .ui-tabs .tag-heuristic-tabs > li {
+    float: none;
+    flex: 0 0 auto;
+    margin: 0;
+    border-radius: 14px;
+    white-space: normal;
+  }
+
+  .ui-tabs .tag-heuristic-tabs > li .ui-tabs-anchor {
+    float: none;
+    display: block;
+    padding: 6px 12px;
+  }
+
+  #add_tagging_tabs .ui-tabs-panel {
+    padding: 0;
+  }
+}
+
 .author-card-v02.periodical-with-cover {
   overflow: hidden;
   border-radius: 3px;

--- a/app/views/taggings/add_tagging_popup.html.haml
+++ b/app/views/taggings/add_tagging_popup.html.haml
@@ -4,21 +4,20 @@
       .modal-header
         .popup-top
           .row{style: "padding:15px;margin: 0"}
-            .col-4{style: "padding: 0;"}
+            .col-auto{style: "padding: 0;"}
               %button.btn-small-outline-v02{'data-dismiss'=>'modal'}
                 .btn-text-v02
                   %span.right-arrow 2
                   %span= t(:back)
-            .col-4{style: "padding: 0;"}
+            .col{style: "padding: 0 8px;"}
               .headline-2-v02{:style => "text-align: center;margin: 0; padding-top: 3px;"}= t(:add_tag)
-            .col-4
       .modal-body
         .by-popup-v02.narrow-popup
           .by-card-header-v02.desktop-only
             %span.headline-1-v02.desktop-only= t(:add_tag)
             %a.popup-x-v02{'data-dismiss'=>'modal'} -
           %div#add_tagging_tabs
-            %ul{style: 'display: flex;'}
+            %ul.tag-mode-tabs
               %li
                 %a{href: "#add-tag-form"}= t(:i_want_to_suggest_a_tag)
               %li

--- a/app/views/taggings/suggest.html.haml
+++ b/app/views/taggings/suggest.html.haml
@@ -1,5 +1,5 @@
 %div#suggestion_heuristics
-  %ul{style: 'display: flex; flex-wrap: wrap;font-size:80%'}
+  %ul.tag-heuristic-tabs
     - @tag_suggestions.keys.each do |key|
       %li
         %a{href: '#'+key.to_s}

--- a/spec/system/tag_proposal_mobile_spec.rb
+++ b/spec/system/tag_proposal_mobile_spec.rb
@@ -1,0 +1,275 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# Regression coverage for the tag-proposal popup on narrow (mobile) viewports:
+# the mode toggle (propose a tag / pick from the full list) used to overflow the
+# popup, and the suggestion-heuristic tabs used to render as a plain list rather
+# than a usable tab strip.
+RSpec.describe 'Tag proposal popup on mobile', :js, type: :system do
+  let(:user) { create(:user) }
+  let!(:base_user) { BaseUser.create!(user: user) }
+  let(:author) { create(:authority, toc: create(:toc)) }
+  let(:manifestation) { create(:manifestation, author: author) }
+  let(:other_work) { create(:manifestation, author: author) }
+  let!(:tag_by_author) { create(:tag, status: :approved, name: 'שירה עברית') }
+  let!(:popular_tag) { create(:tag, status: :approved, name: 'ספרות ילדים ונוער') }
+  let!(:unrelated_tag) { create(:tag, status: :approved, name: 'פילוסופיה של הלשון') }
+
+  let(:viewport_width) { 390 }
+  let(:viewport_height) { 844 }
+
+  before do
+    skip 'WebDriver not available or misconfigured' unless webdriver_available?
+
+    # populate all four suggestion heuristics: tags used on the author's other
+    # works, the user's frequent tags, the user's recent tags, and popular tags
+    create(:tagging, taggable: other_work, tag: tag_by_author, status: :approved, suggester: user)
+    create(:tagging, taggable: other_work, tag: popular_tag, status: :approved, suggester: user)
+    create(:tagging, taggable: create(:manifestation), tag: unrelated_tag, status: :approved, suggester: user)
+
+    base_user.set_preference(:accepted_tag_policy, 'true')
+    # same logged-in-user stubbing the project's own spec/support/test_helpers.rb uses
+    # rubocop:disable RSpec/AnyInstance
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
+    allow_any_instance_of(ApplicationController).to receive(:base_user).and_return(base_user)
+    # rubocop:enable RSpec/AnyInstance
+
+    resize_window(viewport_width, viewport_height)
+    visit manifestation_path(manifestation)
+  end
+
+  after do
+    resize_window(1400, 1400)
+  end
+
+  def resize_window(width, height)
+    page.driver.browser.manage.window.resize_to(width, height)
+  end
+
+  def open_tag_popup
+    find('#initiate-add-tag').click
+    expect(page).to have_css('#add_tagging_tabs > ul > li', count: 2, wait: 5)
+  end
+
+  # geometry and computed styles of the elements matching +selector+
+  def boxes(selector)
+    page.evaluate_script(<<~JS)
+      Array.from(document.querySelectorAll('#{selector}')).map(function (el) {
+        var r = el.getBoundingClientRect();
+        var s = getComputedStyle(el);
+        return { left: r.left, right: r.right, top: r.top, bottom: r.bottom,
+                 width: r.width, height: r.height,
+                 marker: s.listStyleType, display: s.display };
+      })
+    JS
+  end
+
+  # how much wider the scrollable content of +selector+ is than its visible box
+  def horizontal_overflow(selector)
+    page.evaluate_script(
+      "(function (el) { return el.scrollWidth - el.clientWidth; })(document.querySelector('#{selector}'))"
+    )
+  end
+
+  # width the text of +selector+ needs, compared to the width it actually gets.
+  # An element clipped with text-overflow: ellipsis still reports its full text
+  # in the DOM, so the text has to be measured off-screen to detect truncation.
+  def text_width_vs_available(selector)
+    page.evaluate_script(<<~JS)
+      (function (el) {
+        var style = getComputedStyle(el);
+        var probe = document.createElement('span');
+        probe.textContent = el.textContent;
+        probe.style.font = style.font;
+        probe.style.fontSize = style.fontSize;
+        probe.style.fontFamily = style.fontFamily;
+        probe.style.fontWeight = style.fontWeight;
+        probe.style.whiteSpace = 'nowrap';
+        probe.style.position = 'absolute';
+        probe.style.visibility = 'hidden';
+        document.body.appendChild(probe);
+        var needed = probe.getBoundingClientRect().width;
+        probe.remove();
+        return [needed, el.clientWidth];
+      })(document.querySelector('#{selector}'))
+    JS
+  end
+
+  shared_examples 'a usable popup layout' do
+    before { open_tag_popup }
+
+    it 'shows the popup title in full rather than truncating it' do
+      expect(find('#generalDlg .popup-top .headline-2-v02')).to have_text(I18n.t(:add_tag), exact: true)
+
+      needed, available = text_width_vs_available('#generalDlg .popup-top .headline-2-v02')
+      expect(needed).to be <= available + 1
+    end
+
+    it 'lays out the mode toggle as a two-up segmented control inside the viewport' do
+      tabs = boxes('#add_tagging_tabs > ul > li')
+      expect(tabs.size).to eq 2
+
+      tabs.each do |tab|
+        expect(tab['left']).to be >= 0
+        expect(tab['right']).to be <= viewport_width
+        expect(tab['width']).to be > 0
+      end
+
+      # both halves sit on the same row and share the width evenly
+      expect(tabs[0]['top']).to be_within(2).of(tabs[1]['top'])
+      expect(tabs[0]['width']).to be_within(2).of(tabs[1]['width'])
+      expect(horizontal_overflow('#add_tagging_tabs > ul')).to be <= 1
+    end
+
+    it 'renders the suggestion heuristics as chips, not as a bulleted list' do
+      expect(page).to have_css('#suggestion_heuristics > ul > li', minimum: 3, wait: 5)
+
+      boxes('#suggestion_heuristics > ul > li').each do |chip|
+        expect(chip['marker']).to eq 'none'
+        expect(chip['left']).to be >= 0
+        expect(chip['right']).to be <= viewport_width
+      end
+    end
+
+    it 'keeps every heuristic chip reachable without horizontal scrolling' do
+      expect(page).to have_css('#suggestion_heuristics > ul > li', minimum: 3, wait: 5)
+      expect(horizontal_overflow('#suggestion_heuristics > ul')).to be <= 1
+    end
+
+    it 'does not make the page scroll sideways' do
+      expect(horizontal_overflow('html')).to be <= 1
+    end
+  end
+
+  context 'when on a small phone (320px)' do
+    let(:viewport_width) { 320 }
+    let(:viewport_height) { 640 }
+
+    it_behaves_like 'a usable popup layout'
+  end
+
+  context 'when on a common Android phone (360px)' do
+    let(:viewport_width) { 360 }
+    let(:viewport_height) { 740 }
+
+    it_behaves_like 'a usable popup layout'
+  end
+
+  context 'when on a large phone (390px)' do
+    it_behaves_like 'a usable popup layout'
+  end
+
+  describe 'suggesting a tag' do
+    before { open_tag_popup }
+
+    it 'switches between suggestion heuristics' do
+      expect(page).to have_css('#used_on_other_works', visible: :visible, wait: 5)
+      expect(page).to have_css('#popular_tags', visible: :hidden)
+
+      find('#suggestion_heuristics > ul a', text: I18n.t(:popular_tags)).click
+
+      expect(page).to have_css('#popular_tags', visible: :visible)
+      expect(page).to have_css('#used_on_other_works', visible: :hidden)
+    end
+
+    it 'fills the tag field when a suggested tag is tapped' do
+      within('#used_on_other_works') do
+        click_button 'שירה עברית'
+      end
+
+      expect(find('#tag').value).to eq 'שירה עברית'
+      expect(find('#tag_id', visible: :all).value).to eq tag_by_author.id.to_s
+      expect(page).to have_css('#submit_tagging:not(.disabled)')
+    end
+
+    it 'proposes a suggested tag and shows it as pending on the page' do
+      within('#used_on_other_works') do
+        click_button 'שירה עברית'
+      end
+      find('#submit_tagging').click
+
+      expect(page).to have_css('#generalDlg', visible: :hidden, wait: 5)
+      within('.tags-area') do
+        expect(page).to have_link('שירה עברית')
+      end
+      expect(Tagging.where(tag: tag_by_author, taggable: manifestation).pending.count).to eq 1
+    end
+
+    it 'proposes a brand new tag typed by hand' do
+      fill_in 'tag', with: 'תגית חדשה לגמרי'
+      expect(page).to have_css('#submit_tagging:not(.disabled)')
+      find('#submit_tagging').click
+
+      expect(page).to have_css('#generalDlg', visible: :hidden, wait: 5)
+      within('.tags-area') do
+        expect(page).to have_content('תגית חדשה לגמרי')
+      end
+      expect(Tag.find_by(name: 'תגית חדשה לגמרי')).to be_present
+    end
+
+    it 'closes the popup with the mobile back button' do
+      find('#generalDlg .popup-top button[data-dismiss="modal"]').click
+      expect(page).to have_css('#generalDlg', visible: :hidden, wait: 5)
+    end
+  end
+
+  describe 'picking from the full tag list' do
+    before do
+      open_tag_popup
+      find('#add_tagging_tabs > ul a', text: I18n.t(:select_from_full_list)).click
+    end
+
+    it 'shows the full list panel and hides the suggestion panel' do
+      expect(page).to have_css('#tag_list', visible: :visible)
+      expect(page).to have_css('#add-tag-form', visible: :hidden)
+      expect(page).to have_css('#tag_list .full-tags-list .list-group-item', minimum: 3, wait: 5)
+    end
+
+    it 'keeps the full list inside the viewport' do
+      expect(page).to have_css('#tag_list .full-tags-list .list-group-item', minimum: 3, wait: 5)
+
+      boxes('#tag_list .full-tags-list .list-group-item').each do |item|
+        expect(item['left']).to be >= 0
+        expect(item['right']).to be <= viewport_width
+      end
+    end
+
+    it 'proposes a tag selected from the full list' do
+      expect(page).to have_css('#tag_list .full-tags-list .list-group-item', minimum: 3, wait: 5)
+      within('#tag_list .full-tags-list') do
+        find('.list-group-item', text: 'פילוסופיה של הלשון').click
+      end
+      expect(find('#tag', visible: :all).value).to eq 'פילוסופיה של הלשון'
+
+      find('#add_tagging_tabs > ul a', text: I18n.t(:i_want_to_suggest_a_tag)).click
+      find('#submit_tagging').click
+
+      expect(page).to have_css('#generalDlg', visible: :hidden, wait: 5)
+      expect(Tagging.where(tag: unrelated_tag, taggable: manifestation).pending.count).to eq 1
+    end
+  end
+
+  describe 'desktop layout is unaffected' do
+    let(:viewport_width) { 1400 }
+    let(:viewport_height) { 1000 }
+
+    before { open_tag_popup }
+
+    it 'still shows the mode tabs side by side, hugging their labels' do
+      tabs = boxes('#add_tagging_tabs > ul > li')
+      expect(tabs.size).to eq 2
+      expect(tabs[0]['top']).to be_within(2).of(tabs[1]['top'])
+      # unlike mobile, desktop tabs are as wide as their labels, not half the popup
+      expect(tabs[0]['width']).not_to be_within(2).of(tabs[1]['width'])
+    end
+
+    it 'still renders the heuristics as a tab strip without bullets' do
+      expect(page).to have_css('#suggestion_heuristics > ul > li', minimum: 3, wait: 5)
+
+      boxes('#suggestion_heuristics > ul > li').each do |chip|
+        expect(chip['marker']).to eq 'none'
+      end
+    end
+  end
+end

--- a/spec/system/tag_proposal_mobile_spec.rb
+++ b/spec/system/tag_proposal_mobile_spec.rb
@@ -111,8 +111,8 @@ RSpec.describe 'Tag proposal popup on mobile', :js, type: :system do
       expect(tabs.size).to eq 2
 
       tabs.each do |tab|
-        expect(tab['left']).to be >= 0
-        expect(tab['right']).to be <= viewport_width
+        expect(tab['left']).to be >= -1
+        expect(tab['right']).to be <= viewport_width + 1
         expect(tab['width']).to be > 0
       end
 


### PR DESCRIPTION
## Problem

On phone-width viewports the add-tagging popup fell apart:

- the popup title was clipped to `הוספ...` (a `.col-4` cell plus `text-overflow: ellipsis`);
- the propose-a-tag / pick-from-the-full-list mode toggle overflowed the popup — the two Hebrew labels never fit side by side, and below ~360px the second tab ran off the edge of the screen;
- the tag-suggestion heuristics rendered as a ragged multi-row strip, and — wherever the jQuery UI tab stylesheet lost the cascade to `.by-card-content-v02 ul { list-style: disc }` — as a plain bulleted list rather than tabs (this is what the reported screenshot shows).

The root cause of the last two is that both tab strips had their layout set **inline** on the `<ul>` (`display: flex` / `display: flex; flex-wrap: wrap; font-size: 80%`), so no stylesheet could adapt them for narrow screens.

## Fix

- Moved that inline layout into `application.scss` under two new classes, `.tag-mode-tabs` and `.tag-heuristic-tabs`. The desktop rules are the same declarations that were inline, so **desktop rendering is unchanged**.
- Added a `max-width: 767px` block that gives mobile a coherent equivalent of the desktop UI:
  - the mode toggle becomes a full-width, two-up segmented control whose labels wrap inside their half instead of overflowing;
  - the heuristics become wrapping chips — every heuristic stays visible and inside the viewport, no horizontal scrolling;
  - `list-style: none` is asserted on both strips so the `disc` markers can't leak in.
- The popup header row now sizes the back button to its content and gives the remaining width to the title, so the title is no longer truncated.

Same functionality as desktop, same JS (jQuery UI tabs) — presentation only.

## Testing

New `spec/system/tag_proposal_mobile_spec.rb` (25 examples, all passing):

- layout, run at **320px, 360px and 390px**: title shown in full (measured against the text's natural width, since ellipsis-clipped text still reads back in full from the DOM), mode toggle two-up and inside the viewport with no nav overflow, heuristic chips with no list markers and no horizontal overflow, no sideways page scroll;
- interaction: switching between heuristics, tapping a suggested tag (fills the field, enables submit), submitting a suggested tag (pending tag appears on the page + `Tagging` row created), typing and submitting a brand-new tag, closing via the mobile back button;
- full-list mode: panel swap, list items inside the viewport, selecting a tag from the list and submitting it;
- desktop guards: mode tabs still side by side hugging their labels, heuristics still bullet-free.

Verification that this is real regression coverage: with the fix reverted, 6 of these examples fail (title truncated at every width; mode toggle uneven at 360/390 and running off-screen at 320). With the fix, all 25 pass.

Full suite: `bundle exec rspec` → **2207 examples, 0 failures, 14 pending** (pre-existing skips).

RuboCop clean on the new spec; haml-lint reports only pre-existing offences on untouched lines.

## Follow-up filed separately

`by-tw0`: picking a tag from the full list leaves `#submit_tagging` with the `disabled` class (cosmetic only — submission works), because `listall_tags.html.haml` fires `change()` while the popup listens for `input`. Pre-existing on desktop too, left out of this PR.

Closes by-lz1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)