### PR TITLE
Fix submit button staying styled disabled after picking from the full tag list

### DIFF
--- a/app/views/taggings/listall_tags.html.haml
+++ b/app/views/taggings/listall_tags.html.haml
@@ -11,7 +11,9 @@
       e.preventDefault();
       $('#tag_id').val($(this).attr('id'));
       $('#tag').val($(this).text().replace(/\s*\(\d*\)/,''));
-      $('#tag').change();
+      // this partial is shared: the tag-proposal popup listens on 'input',
+      // the admin merge-tag dialog listens on 'change'
+      $('#tag').trigger('input').change();
       if($('#with_tag').length > 0) {
         $('#with_tag').val($(this).attr('id'));
       }

--- a/spec/system/tag_proposal_mobile_spec.rb
+++ b/spec/system/tag_proposal_mobile_spec.rb
@@ -235,6 +235,19 @@ RSpec.describe 'Tag proposal popup on mobile', :js, type: :system do
       end
     end
 
+    # the list used to fire only 'change', while the popup enables the submit
+    # button on 'input', so the button kept looking unavailable after a pick
+    it 'enables the submit button once a tag is picked' do
+      expect(page).to have_css('#submit_tagging.disabled', visible: :all)
+
+      expect(page).to have_css('#tag_list .full-tags-list .list-group-item', minimum: 3, wait: 5)
+      within('#tag_list .full-tags-list') do
+        find('.list-group-item', text: 'פילוסופיה של הלשון').click
+      end
+
+      expect(page).to have_css('#submit_tagging:not(.disabled)', visible: :all)
+    end
+
     it 'proposes a tag selected from the full list' do
       expect(page).to have_css('#tag_list .full-tags-list .list-group-item', minimum: 3, wait: 5)
       within('#tag_list .full-tags-list') do


### PR DESCRIPTION
Fixes bead by-tw0 (discovered while working on by-lz1 / #1490).

## The bug

`app/views/taggings/listall_tags.html.haml` fired `$('#tag').change()` after a tag was picked from the full list, but `add_tagging_popup` binds its enable/disable logic to the `input` event. So `#submit_tagging` kept its `disabled` CSS class after a pick.

The class is purely cosmetic here — the input is not actually disabled — so the proposal still submitted. The button just looked unavailable.

## The fix

Fire both events instead of swapping one for the other. The bead suggested triggering `input` *instead* of `change`, but `listall_tags` is a shared partial: `admin/merge_tag.html.haml` also loads it and binds its own enable/disable logic to `change` (and clears `#with_tag` there). Dropping `change` would have broken the admin merge-tag dialog.

## Test plan

- New regression spec in `spec/system/tag_proposal_mobile_spec.rb`: asserts `#submit_tagging` starts out `.disabled` and loses the class once a tag is picked from the full list. Verified it fails on master (`expected to find css "#submit_tagging:not(.disabled)" but there were no matches`) and passes with the fix.
- `spec/system/tag_editing_spec.rb` (admin tag editing / merge) — 28 examples, 0 failures, 2 pre-existing pending.
- Full suite: 2208 examples, 0 failures, 14 pending (all pre-existing).
- `haml-lint` on the changed partial reports the same 10 pre-existing lints as before the change (trailing whitespace, hash-attribute spacing, etc. — all on lines untouched here); `rubocop` on the changed spec is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)