### PR TITLE
Fix author multiselect filter being lost after the first round-trip

### DIFF
--- a/app/views/collections/_browse_filters.html.haml
+++ b/app/views/collections/_browse_filters.html.haml
@@ -31,7 +31,9 @@
     = render layout: 'shared/collapsible_block', locals: { container_name: 'collfauthorities', title: t(:by_involved_authorities) } do
       .multi-name-sort.desktop-only.pointer
         %span.linkcolor.pointer{ data: { toggle: :modal, target: '#authoritiesDlg' } }= t(:multiselect)
-      = hidden_field_tag(:authorities, @authorities, id: 'authority_ids')
+      -# join: the controller parses this param with split(','), and hidden_field_tag would otherwise
+         space-join the @authorities array into "1 2 3", losing all but the first id on the next submit
+      = hidden_field_tag(:authorities, @authorities&.join(','), id: 'authority_ids')
       = hidden_field_tag(:authorities_names, @authorities_names, id: 'authorities_names')
 
     = render layout: 'shared/collapsible_block', locals: { container_name: 'collftags', title: t(:tags) } do

--- a/app/views/collections/_browse_list.html.haml
+++ b/app/views/collections/_browse_list.html.haml
@@ -87,7 +87,7 @@
       } else if ($(this).attr('data-which') == 'authoritylist') {
         $('#collections_filters #authority_ids').val('');
         $('#collections_filters #authorities_names').val('');
-        $('#collections_filters input[name="ckb_authorities[]"]').prop('checked', false);
+        $('input[name="ckb_authorities[]"]').prop('checked', false); // checkboxes live in #authoritiesDlg, not the form
       } else if (field.startsWith('tag_')) {
         // Handle tag filters - remove the specific tag ID from the comma-separated list
         const tagId = field.replace('tag_', '');

--- a/app/views/manifestation/_browse_filters.html.haml
+++ b/app/views/manifestation/_browse_filters.html.haml
@@ -25,7 +25,9 @@
       = hidden_field_tag :author_id, @author_id
       .multi-name-sort.desktop-only.pointer
         %span.linkcolor.pointer{ data: { toggle: :modal, target: '#authorsDlg' } }= t(:multiselect)
-      = hidden_field_tag(:authors, @authors, id: 'author_ids')
+      -# join: the controller parses this param with split(','), and hidden_field_tag would otherwise
+         space-join the @authors array into "1 2 3", losing all but the first id on the next submit
+      = hidden_field_tag(:authors, @authors&.join(','), id: 'author_ids')
       = hidden_field_tag(:authors_names, @authors_names, id: 'authors_names')
 
       = hidden_field_tag(:search_type, id: 'search_type')

--- a/app/views/manifestation/_browse_list.html.haml
+++ b/app/views/manifestation/_browse_list.html.haml
@@ -137,7 +137,7 @@
       } else if ($(this).attr('data-which') == 'authorlist') {
         $('#works_filters #author_ids').val('');
         $('#works_filters #authors_names').val('');
-        $('#works_filters input[name="ckb_authors[]"]').prop('checked', false);
+        $('input[name="ckb_authors[]"]').prop('checked', false); // checkboxes live in #authorsDlg, not the form
       } else if (field.startsWith('tag_')) {
         // Handle tag filters - remove the specific tag ID from the comma-separated list
         const tagId = field.replace('tag_', '');

--- a/spec/requests/collections_browse_authorities_filter_spec.rb
+++ b/spec/requests/collections_browse_authorities_filter_spec.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# Regression coverage for the /collections browse "filter by authors" multiselect.
+#
+# The popup writes a comma-separated list of authority ids into the hidden
+# `authorities` field and submits the filters form; the controller parses it back
+# with `split(',')`. If the re-rendered hidden field does not round-trip in that
+# same comma-separated form, the filter silently degrades on the *next* filter
+# interaction (e.g. typing a title, ticking a collection type).
+RSpec.describe 'Collections browse - authorities filter', type: :request do
+  let!(:alice) { create(:authority, name: 'Alice Author') }
+  let!(:bob) { create(:authority, name: 'Bob Author') }
+  let!(:carol) { create(:authority, name: 'Carol Author') }
+
+  let!(:alice_volume) do
+    create(:collection, title: 'Alice Volume', collection_type: :volume, sort_title: 'alice volume').tap do |c|
+      c.involved_authorities.create!(authority: alice, role: :author)
+    end
+  end
+  let!(:bob_volume) do
+    create(:collection, title: 'Bob Volume', collection_type: :volume, sort_title: 'bob volume').tap do |c|
+      c.involved_authorities.create!(authority: bob, role: :author)
+    end
+  end
+  let!(:carol_volume) do
+    create(:collection, title: 'Carol Volume', collection_type: :volume, sort_title: 'carol volume').tap do |c|
+      c.involved_authorities.create!(authority: carol, role: :author)
+    end
+  end
+
+  # The popup's JS emits a trailing comma ("1,2,"), so exercise that exact shape.
+  let(:authorities_param) { "#{alice.id},#{bob.id}," }
+
+  before do
+    import_and_await(CollectionsIndex, [alice_volume, bob_volume, carol_volume])
+  end
+
+  after do
+    Chewy.massacre
+  end
+
+  it 'filters the list down to collections of the selected authorities' do
+    get collections_browse_path, params: { authorities: authorities_param }
+
+    expect(response.body).to include('Alice Volume')
+    expect(response.body).to include('Bob Volume')
+    expect(response.body).not_to include('Carol Volume')
+  end
+
+  it 'round-trips the selection into the hidden field as a comma-separated list' do
+    get collections_browse_path, params: { authorities: authorities_param }
+
+    hidden_value = response.body[/id="authority_ids" value="([^"]*)"/, 1] ||
+                   response.body[/name="authorities"[^>]*value="([^"]*)"/, 1]
+
+    expect(hidden_value).to be_present
+    expect(hidden_value.split(',').map(&:to_i)).to contain_exactly(alice.id, bob.id)
+  end
+
+  it 'retains all selected authorities when another filter is subsequently applied' do
+    # Simulate the second round-trip: the browser resubmits whatever the hidden
+    # field was re-rendered with, alongside the newly changed filter.
+    get collections_browse_path, params: { authorities: authorities_param }
+    resubmitted = response.body[/id="authority_ids" value="([^"]*)"/, 1]
+
+    get collections_browse_path, params: { authorities: resubmitted, ckb_collection_types: ['volume'] }
+
+    expect(response.body).to include('Alice Volume')
+    expect(response.body).to include('Bob Volume')
+    expect(response.body).not_to include('Carol Volume')
+  end
+
+  it 'keeps the selected authorities checked in the multiselect popup' do
+    get collections_browse_path, params: { authorities: authorities_param }
+
+    # Haml emits attributes in alphabetical order, so `checked` precedes `id`.
+    checkboxes = response.body.scan(/<input[^>]*name="ckb_authorities\[\]"[^>]*>/)
+    checked_ids = checkboxes.grep(/checked/).map { |tag| tag[/value="(\d+)"/, 1].to_i }
+
+    expect(checked_ids).to contain_exactly(alice.id, bob.id)
+  end
+end

--- a/spec/requests/works_browse_authors_filter_spec.rb
+++ b/spec/requests/works_browse_authors_filter_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# Regression coverage for the /works browse "filter by authors" multiselect.
+#
+# The popup writes a comma-separated list of author ids into the hidden `authors`
+# field and submits the filters form; the controller parses it back with
+# `split(',')`. If the re-rendered hidden field does not round-trip in that same
+# comma-separated form, the selection silently collapses to its first id on the
+# next filter interaction -- which also makes any subsequently added filter (genre,
+# period, ...) appear broken, since it is then combined with the wrong author set.
+RSpec.describe 'Works browse - authors filter', type: :request do
+  let!(:alice) { create(:authority, name: 'Alice Author') }
+  let!(:bob) { create(:authority, name: 'Bob Author') }
+
+  let!(:alice_poem) { create_work(alice, 'Alice Poem', :poetry) }
+  let!(:bob_prose) { create_work(bob, 'Bob Prose', :prose) }
+
+  # The popup's JS emits a trailing comma ("1,2,"), so exercise that exact shape.
+  let(:authors_param) { "#{alice.id},#{bob.id}," }
+
+  before do
+    import_and_await(ManifestationsIndex, [alice_poem, bob_prose])
+  end
+
+  after do
+    Chewy.massacre
+  end
+
+  def create_work(authority, title, genre)
+    create(:manifestation, title: title, genre: genre).tap do |m|
+      m.expression.work.involved_authorities.create!(authority: authority, role: :author)
+    end
+  end
+
+  it 'round-trips the selection into the hidden field as a comma-separated list' do
+    get works_path, params: { authors: authors_param }
+
+    hidden_value = response.body[/id="author_ids" value="([^"]*)"/, 1]
+
+    expect(hidden_value).to be_present
+    expect(hidden_value.split(',').map(&:to_i)).to contain_exactly(alice.id, bob.id)
+  end
+
+  it 'keeps all selected authors when a genre filter is subsequently added' do
+    # Simulate the second round-trip: the browser resubmits whatever the hidden
+    # field was re-rendered with, alongside the newly ticked genre checkbox.
+    get works_path, params: { authors: authors_param }
+    resubmitted = response.body[/id="author_ids" value="([^"]*)"/, 1]
+
+    get works_path, params: { authors: resubmitted, ckb_genres: ['prose'] }
+
+    # Bob's prose is only reachable if Bob survived the round-trip; before the fix
+    # the author set collapsed to Alice alone and this list came back empty.
+    expect(response.body).to include('Bob Prose')
+    expect(response.body).not_to include('Alice Poem')
+  end
+end

--- a/spec/support/es_helpers.rb
+++ b/spec/support/es_helpers.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+# Helpers for specs that import into Elasticsearch and then immediately query it.
+#
+# `Chewy.massacre` (used by `clean_tables` and by many specs' `after` hooks) deletes
+# every index in the cluster. A spec that recreates an index via `.import` can then
+# race ES's shard allocation and get a transient
+# `no_shard_available_action_exception` on the very next query. Blocking until the
+# index reports at least "yellow" health removes that race deterministically -- no
+# sleeps involved.
+module EsHelpers
+  def import_and_await(index, records)
+    index.import(records)
+    Chewy.client.cluster.health(index: index.index_name, wait_for_status: 'yellow', timeout: '30s')
+  end
+end
+
+RSpec.configure do |config|
+  config.include EsHelpers
+end

--- a/spec/system/collections_browse_authorities_filter_spec.rb
+++ b/spec/system/collections_browse_authorities_filter_spec.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# End-to-end coverage for the /collections browse "filter by authors" multiselect popup:
+# picking authors in the popup must filter the list, and the selection must survive
+# subsequent filter interactions (which resubmit the same form).
+describe 'Collections browse authorities filter', :js do
+  let!(:alice) { create(:authority, name: 'Alice Author') }
+  let!(:bob) { create(:authority, name: 'Bob Author') }
+  let!(:carol) { create(:authority, name: 'Carol Author') }
+
+  let!(:alice_volume) do
+    create(:collection, title: 'Alice Volume', collection_type: :volume, sort_title: 'alice volume').tap do |c|
+      c.involved_authorities.create!(authority: alice, role: :author)
+    end
+  end
+  let!(:bob_volume) do
+    create(:collection, title: 'Bob Volume', collection_type: :volume, sort_title: 'bob volume').tap do |c|
+      c.involved_authorities.create!(authority: bob, role: :author)
+    end
+  end
+  let!(:carol_volume) do
+    create(:collection, title: 'Carol Volume', collection_type: :volume, sort_title: 'carol volume').tap do |c|
+      c.involved_authorities.create!(authority: carol, role: :author)
+    end
+  end
+
+  before do
+    skip 'WebDriver not available or misconfigured' unless webdriver_available?
+
+    import_and_await(CollectionsIndex, [alice_volume, bob_volume, carol_volume])
+  end
+
+  after do
+    Chewy.massacre
+  end
+
+  def select_authorities_in_popup(*authorities)
+    find('#filters_panel .multi-name-sort span', text: I18n.t(:multiselect)).click
+    expect(page).to have_css('#authoritiesDlg.show', wait: 5)
+
+    authorities.each { |authority| find("#auth_#{authority.id}", visible: :all).click }
+
+    click_button I18n.t(:add_authorities_to_filter)
+  end
+
+  it 'filters the list to the authors picked in the popup, and keeps the filter afterwards' do
+    visit collections_browse_path
+    expect(page).to have_css('#thelist', text: 'Carol Volume', wait: 5)
+
+    select_authorities_in_popup(alice, bob)
+
+    expect(page).to have_css('#thelist', text: 'Alice Volume', wait: 5)
+    expect(page).to have_css('#thelist', text: 'Bob Volume')
+    expect(page).to have_no_css('#thelist', text: 'Carol Volume')
+
+    # A further filter interaction resubmits the form; both authorities must survive it.
+    # Tick the "volume" collection type: its filter chip appearing tells us the second
+    # round-trip has actually landed, so the assertions below can't pass on stale markup.
+    find('#collection_type_volume', visible: :all).click
+    volume_label = ApplicationController.helpers.textify_collection_type('volume')
+    expect(page).to have_css('.filters', text: volume_label, wait: 5)
+
+    expect(page).to have_css('#thelist', text: 'Alice Volume')
+    expect(page).to have_css('#thelist', text: 'Bob Volume')
+    expect(page).to have_no_css('#thelist', text: 'Carol Volume')
+  end
+end


### PR DESCRIPTION
## Problem

On **/collections** and **/works**, selecting authors in the multiselect popup applied the filter once, but the selection collapsed to just its **first** author on the very next filter interaction.

## Root cause

The popup writes a comma-separated list of ids into the hidden `authors`/`authorities` field, and the controllers parse it back with `split(',')`. The re-rendered hidden field, however, was handed the `@authors` / `@authorities` **array**, and Rails space-joins array attribute values:

```ruby
hidden_field_tag(:authorities, [1, 2, 3])
#=> <input type="hidden" name="authorities" value="1 2 3" />
```

On the next submit, `"1 2 3".split(',').map(&:to_i)` → `[1]`, dropping every author but the first.

This is also the whole story behind the reported *"combining an author filter with another filter returns an empty list"* symptom — by the time the second filter was ticked, the author set had already collapsed. Verified against dev data:

| filter | results |
|---|---|
| authorities `[1092, 17, 1053, 16]` + genre `prose` | **17** |
| authority `1092` alone + genre `prose` | **0** |

The user saw the second row while expecting the first.

## Changes

- `collections/_browse_filters.html.haml`, `manifestation/_browse_filters.html.haml` — join the ids with `,` so the field round-trips in the form the controller parses.
- `collections/_browse_list.html.haml`, `manifestation/_browse_list.html.haml` — the filter-chip removal handler scoped its checkbox selector to the filters form, but the popup checkboxes live in the modal, outside it.

## Tests

- `spec/requests/collections_browse_authorities_filter_spec.rb` (4 examples)
- `spec/requests/works_browse_authors_filter_spec.rb` (2 examples)
- `spec/system/collections_browse_authorities_filter_spec.rb` — Capybara, drives the popup end-to-end

All 5 behavioural examples **fail without the fix** and pass with it (verified by stashing the view changes). Stable across 6 randomized seeds.

`spec/support/es_helpers.rb` adds `import_and_await`, which blocks on ES index health after import — without it these specs intermittently race shard allocation right after another spec's `Chewy.massacre` (no sleeps involved).

## Test plan

Full suite run before and after on this machine: **15 failures on a clean tree vs 14 with the change**, with the two failure sets almost entirely disjoint — this suite has a pre-existing per-run flakiness baseline (e.g. `search_manifestations_spec.rb`, a pure service spec my view-only diff cannot touch, gave 1 then 2 failures on consecutive identical runs). No spec in any file touched here fails in isolation, and none of the new specs fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)