### PR TITLE
Author TOC: scroll to the top of the page on every filter refresh

### DIFF
--- a/app/views/authors/_generated_toc.html.haml
+++ b/app/views/authors/_generated_toc.html.haml
@@ -221,6 +221,9 @@
         // active pane filters (which also re-syncs the genre chips via apply()).
         window.TocFilters.reset();
       }
+      // The list was just rebuilt (and entering flat mode shrinks it a lot), so
+      // return the reader to the top of the page as the filters do.
+      if(window.TocFilters) { window.TocFilters.scrollToTop(); }
     });
     prune_collections();
     var orig_mainlist = $('#browse_mainlist').html();
@@ -366,19 +369,16 @@
         if (window.syncGenreChips) { window.syncGenreChips(); }
       }
 
-      // After a filter interaction shrinks the flat list, the (few) remaining
-      // results can sit above the current scroll position, leaving the viewport
-      // apparently empty. Bring the top of the list back into view (mirrors the
-      // /works browse scroll-to-top). Only scrolls up, never down.
-      function scrollListIntoView() {
-        var list = document.getElementById('browse_mainlist');
-        if (!list) { return; }
-        var top = list.getBoundingClientRect().top + window.pageYOffset;
-        if (window.pageYOffset > top) { window.scrollTo(0, top); }
+      // A filter interaction can shrink the flat list dramatically, leaving a
+      // reader who had scrolled down facing an apparently empty main area (the
+      // long side column keeps the page tall). Go back to the top of the page
+      // so the remaining results are what the reader sees.
+      function scrollToTop() {
+        window.scrollTo(0, 0);
       }
 
       // apply() triggered by a user filter interaction: re-filter, then reveal results.
-      function applyFromUser() { apply(); scrollListIntoView(); }
+      function applyFromUser() { apply(); scrollToTop(); }
 
       // ---- date histogram + range slider ----
       function positionSlider() {
@@ -468,7 +468,12 @@
         $('#toc-date-handle-left').on('mousedown touchstart', function(e) { dragging = 'left'; e.preventDefault(); });
         $('#toc-date-handle-right').on('mousedown touchstart', function(e) { dragging = 'right'; e.preventDefault(); });
         $(document).on('mousemove touchmove', onMove);
-        $(document).on('mouseup touchend', function() { dragging = null; });
+        $(document).on('mouseup touchend', function() {
+          if (!dragging) { return; }
+          dragging = null;
+          // Only once the drag ends, so the list doesn't jump while dragging.
+          scrollToTop();
+        });
 
         $('#toc-date-from, #toc-date-to').on('change', function() {
           var f = parseInt($('#toc-date-from').val(), 10);
@@ -476,7 +481,7 @@
           if (isNaN(f)) { f = minYear; }
           if (isNaN(t)) { t = maxYear; }
           setRange(f, t);
-          scrollListIntoView();
+          scrollToTop();
         });
 
         $('.toc-date-type').on('click', function() {
@@ -499,7 +504,7 @@
           applyFromUser();
         });
         $('#toc_filters_pane').on('change', 'input[type=checkbox]', applyFromUser);
-        $('#toc-filter-reset').on('click', function(e) { e.preventDefault(); reset(); scrollListIntoView(); });
+        $('#toc-filter-reset').on('click', function(e) { e.preventDefault(); reset(); scrollToTop(); });
       }
 
       function clearInputs() {
@@ -532,7 +537,8 @@
         init: function() { bindInputs(); bindSlider(); },
         activate: activate,
         reapply: reapply,
-        reset: reset
+        reset: reset,
+        scrollToTop: scrollToTop
       };
     })();
     window.TocFilters.init();

--- a/spec/system/author_toc_filters_spec.rb
+++ b/spec/system/author_toc_filters_spec.rb
@@ -40,6 +40,12 @@ describe 'Author TOC flat-list filters', :js do
     find("#sort_by option[value='#{value}']").select_option
   end
 
+  # Any filter/sort refresh must return the reader to the top of the page, or a
+  # shrunken list leaves them facing an empty main area.
+  def scroll_offset
+    page.evaluate_script('Math.round(window.pageYOffset)')
+  end
+
   it 'swaps the navbar for the filters pane when sorting away from the default, and back' do
     visit authority_path(author)
     expect(page).to have_css('#browse_mainlist')
@@ -186,7 +192,7 @@ describe 'Author TOC flat-list filters', :js do
     end
   end
 
-  it 'scrolls the shrunk list back into view after filtering while scrolled down' do
+  it 'scrolls back to the top of the page after filtering while scrolled down' do
     # enough works to make the flat list taller than the viewport
     Chewy.strategy(:atomic) do
       create_list(:manifestation, 15, status: :published, author: author,
@@ -199,17 +205,65 @@ describe 'Author TOC flat-list filters', :js do
 
     # scroll to the bottom so the results sit above the viewport
     page.execute_script('window.scrollTo(0, document.body.scrollHeight)')
-    expect(page.evaluate_script('window.pageYOffset')).to be > 0
+    expect(scroll_offset).to be > 0
 
     # filter down to the single translated work; the list shrinks dramatically
     check 'toc-filter-translated'
     within('#sorted_card') { expect(page).to have_content('Beta Story') }
 
-    # the top of the list is now at or above the viewport top (no empty space)
-    list_top = page.evaluate_script(
-      "Math.round(document.getElementById('browse_mainlist').getBoundingClientRect().top + window.pageYOffset)"
-    )
-    expect(page.evaluate_script('Math.round(window.pageYOffset)')).to be <= list_top
+    expect(scroll_offset).to eq 0
+  end
+
+  it 'scrolls back to the top of the page when activating filter mode while scrolled down' do
+    # enough works to make the list taller than the viewport
+    Chewy.strategy(:atomic) do
+      create_list(:manifestation, 15, status: :published, author: author,
+                                      genre: 'poetry', orig_lang: 'he', language: 'he')
+    end
+
+    visit authority_path(author)
+    expect(page).to have_css('#browse_mainlist .manifestation-node', minimum: 15)
+
+    page.execute_script('window.scrollTo(0, document.body.scrollHeight)')
+    expect(scroll_offset).to be > 0
+
+    # the sort/filter toggle stays reachable in the sticky header while scrolled
+    find('#toc-filter-toggle').click
+    expect(page).to have_css('#sorted_card .manifestation-node', minimum: 15)
+
+    expect(scroll_offset).to eq 0
+  end
+
+  it 'scrolls back to the top of the page after dragging the date-range slider' do
+    # uploaded well before the other two works, so narrowing the range from the
+    # left drops all of them at once and the list shrinks dramatically
+    Chewy.strategy(:atomic) do
+      create_list(:manifestation, 15, status: :published, author: author,
+                                      genre: 'poetry', orig_lang: 'he', language: 'he',
+                                      publication_date: '2000-01-01')
+    end
+
+    visit authority_path(author)
+    choose_sort('title')
+    expect(page).to have_css('#sorted_card .manifestation-node', minimum: 15)
+
+    # upload-year is the field that actually spans a range in this fixture
+    btn = find(".toc-date-type[data-datefield='upload-year']")
+    scroll_to(btn)
+    btn.click
+    expect(page).to have_css('#toc-date-histogram .toc-hist-bar', minimum: 2)
+
+    # The filters pane is sticky with its own overflow; scroll the date slider
+    # into the pane's visible area, then scroll the window down to the bottom.
+    page.execute_script("document.getElementById('toc-date-handle-left').scrollIntoView({block: 'nearest'})")
+    page.execute_script('window.scrollTo(0, document.body.scrollHeight)')
+    expect(scroll_offset).to be > 0
+
+    # drag the left handle to the middle of the track, narrowing the range
+    find('#toc-date-handle-left').drag_to(find('#toc-date-range'), delay: 0.05)
+    expect(page).to have_css('#sorted_card .manifestation-node', maximum: 5, visible: :visible)
+
+    expect(scroll_offset).to eq 0
   end
 
   it 'clears all filters via the reset link' do


### PR DESCRIPTION
## Problem

On the Authority TOC page, applying a filter that greatly shortens the list left a reader who had scrolled down staring at an empty main area — the long right-hand column keeps the page tall even when the list is nearly empty.

## What changed

The filters pane already scrolled the list back into view for most interactions (#1446), but two paths that rebuild or shrink the list were never wired in:

* **Entering/leaving flat-filter mode** — the `#sort_by` dropdown and the sort/filter toggle button. This is the biggest shrink of all (grouped collection cards → flat de-duplicated list).
* **Dragging the date-range slider handles** — the date *text fields* already scrolled, so the two halves of the same control behaved differently. The scroll happens on drag end (`mouseup`), not on every `mousemove`, so the list doesn't jump under the cursor mid-drag.

Both now go through the same helper, and that helper scrolls all the way to the top of the page rather than just to the top of the list (`scrollListIntoView` → `scrollToTop`).

## Test plan

Three system specs in `spec/system/author_toc_filters_spec.rb`, each scrolling to the bottom of the page before interacting and asserting `window.pageYOffset == 0` afterwards:

* filtering via a checkbox (updated existing spec)
* activating filter mode via the sort/filter toggle (new)
* dragging the date-range slider (new)

All three were verified to fail with the view change stashed, and the full file passes (12 examples, 0 failures).

Note: the wider suite could not be run to completion locally — Elasticsearch keeps re-applying its flood-stage read-only block because the dev machine's disk is at 97%. That is an environment issue, unrelated to this change; CI should cover it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)