### PR TITLE
Verification view: section shortcut links in the migrated pane header

### DIFF
--- a/app/assets/javascripts/verification.js
+++ b/app/assets/javascripts/verification.js
@@ -307,6 +307,16 @@ function initVerification() {
         }
     });
 
+    // Nothing left to jump to: drop the whole nav, otherwise a lone "Jump to:" label
+    // would sit in the header. Only reachable for an item type the migrated pane does
+    // not know how to render (it shows the "unsupported type" alert and no sections);
+    // both LexPerson and LexPublication always render at least the links section.
+    $('.migrated-shortcuts').each(function() {
+        if ($(this).find('.migrated-shortcut:visible').length === 0) {
+            $(this).hide();
+        }
+    });
+
     $('.migrated-shortcut').on('click', function(e) {
         e.preventDefault();
         const section = document.getElementById($(this).data('section-target'));

--- a/app/assets/javascripts/verification.js
+++ b/app/assets/javascripts/verification.js
@@ -299,6 +299,22 @@ function initVerification() {
         });
     });
 
+    // Header shortcuts: hide the ones whose section is not rendered for this item type,
+    // and scroll the migrated pane to the section on click.
+    $('.migrated-shortcut').each(function() {
+        if (document.getElementById($(this).data('section-target')) === null) {
+            $(this).hide();
+        }
+    });
+
+    $('.migrated-shortcut').on('click', function(e) {
+        e.preventDefault();
+        const section = document.getElementById($(this).data('section-target'));
+        if (section) {
+            scrollMigratedPaneTo(section);
+        }
+    });
+
     // Handle checklist label clicks - close the checklist modal then scroll to section
     $('.checklist-items label').on('click', function(e) {
         // Only scroll if clicked on label text, not checkbox
@@ -432,6 +448,20 @@ function updateChecklistItem(url, path, verified, sectionId, callback) {
             showToast((container.data('error-updating-checklist-text') || 'Error updating checklist') + statusInfo);
         }
     });
+}
+
+// Scroll the migrated pane so that `el` is at its top. The window itself does not scroll
+// in this layout, so .migrated-content must be scrolled directly.
+function scrollMigratedPaneTo(el) {
+    const scrollParent = el.closest('.migrated-content');
+    if (!scrollParent) {
+        el.scrollIntoView({ behavior: 'smooth', block: 'start' });
+        return;
+    }
+    const offset = el.getBoundingClientRect().top
+                 - scrollParent.getBoundingClientRect().top
+                 + scrollParent.scrollTop;
+    scrollParent.scrollTo({ top: Math.max(0, offset - 8), behavior: 'smooth' });
 }
 
 function updateProgressBar(percentage) {

--- a/app/assets/stylesheets/verification.scss
+++ b/app/assets/stylesheets/verification.scss
@@ -217,11 +217,39 @@ body:has(.verification-container) {
     padding: 1rem;
     background: #f8f9fa;
     border-bottom: 1px solid #dee2e6;
+    display: flex;
+    align-items: baseline;
+    flex-wrap: wrap;
+    gap: 0.5rem 0.75rem;
 
     .migrated-title {
       margin: 0;
       font-size: 1rem;
       font-weight: 600;
+    }
+
+    .migrated-shortcuts {
+      display: flex;
+      align-items: baseline;
+      flex-wrap: wrap;
+      gap: 0.5rem;
+      font-size: 0.85rem;
+
+      .shortcuts-label {
+        color: #6c757d;
+      }
+
+      .migrated-shortcut {
+        cursor: pointer;
+        text-decoration: none;
+        border-bottom: 1px dotted currentColor;
+
+        &:hover,
+        &:focus {
+          text-decoration: none;
+          border-bottom-style: solid;
+        }
+      }
     }
   }
 

--- a/app/views/lexicon/verification/_edit_az_navbar.html.haml
+++ b/app/views/lexicon/verification/_edit_az_navbar.html.haml
@@ -2,11 +2,9 @@
 = form_with model: @item, url: lexicon_update_section_verification_path(@entry), method: :patch, local: false, html: { class: 'verification-edit-form' } do |f|
   = hidden_field_tag :section, 'az_navbar'
 
-  .form-group
-    = f.label :az_navbar, t('lexicon.verification.sections.az_navbar_section'), class: 'form-label'
-    = f.text_area :az_navbar, class: 'form-control', rows: 10, dir: 'rtl'
-    .form-text.text-muted
-      = t('lexicon.verification.edit.html_allowed')
+  .form-group.form-check
+    = f.check_box :az_navbar, class: 'form-check-input'
+    = f.label :az_navbar, t('activerecord.attributes.lex_publication.az_navbar'), class: 'form-check-label'
 
   .form-check.mt-3
     = check_box_tag :mark_verified, '1', false, class: 'form-check-input'

--- a/app/views/lexicon/verification/_migrated_entry.html.haml
+++ b/app/views/lexicon/verification/_migrated_entry.html.haml
@@ -1,6 +1,15 @@
 .migrated-card
   .migrated-header
     %h4.migrated-title= t('lexicon.verification.migrated.header')
+    -# Shortcuts scrolling the migrated pane to a section. Rendered for all item types;
+      shortcuts whose target section is absent (e.g. bio/works/citations for publications)
+      are hidden by verification.js.
+    %nav.migrated-shortcuts{ 'aria-label': t('lexicon.verification.migrated.jump_to') }
+      %span.shortcuts-label= t('lexicon.verification.migrated.jump_to')
+      - { 'section-bio' => 'biography', 'section-works' => 'works_section',
+          'section-citations' => 'citations_section', 'section-links' => 'links_section' }.each do |section_id, key|
+        %a.migrated-shortcut{ href: "##{section_id}", data: { 'section-target': section_id } }
+          = t("lexicon.verification.sections.#{key}")
 
   .migrated-content
     - if item.is_a?(LexPerson)

--- a/app/views/lexicon/verification/_publication_sections.html.haml
+++ b/app/views/lexicon/verification/_publication_sections.html.haml
@@ -64,8 +64,10 @@
     .verification-badge{class: checklist['az_navbar']&.dig('verified') ? 'verified' : 'not-verified'}
       = checklist['az_navbar']&.dig('verified') ? '✓ ' + t('lexicon.verification.migrated.verified') : t('lexicon.verification.migrated.not_verified')
   .section-content
-    - if item.az_navbar.present?
-      .az-navbar-content!= MarkdownToHtml.call(item.az_navbar)
+    -# az_navbar is a boolean flag ("show an A-Z navigation bar for this publication?"),
+      not markdown content.
+    - if item.az_navbar?
+      %p.az-navbar-content= t('lexicon.verification.sections.has_az_navbar')
     - else
       %p.text-muted= t('lexicon.verification.sections.no_az_navbar')
   .section-actions

--- a/app/views/lexicon/verification/_publication_sections.html.haml
+++ b/app/views/lexicon/verification/_publication_sections.html.haml
@@ -64,8 +64,9 @@
     .verification-badge{class: checklist['az_navbar']&.dig('verified') ? 'verified' : 'not-verified'}
       = checklist['az_navbar']&.dig('verified') ? '✓ ' + t('lexicon.verification.migrated.verified') : t('lexicon.verification.migrated.not_verified')
   .section-content
-    -# az_navbar is a boolean flag ("show an A-Z navigation bar for this publication?"),
-      not markdown content.
+    -# az_navbar is a boolean flag, not markdown content. Nothing currently reads it —
+      Lexicon::IngestPublication sets it to true for every record and no view consults
+      it — so the wording states the flag's value rather than claiming a rendered effect.
     - if item.az_navbar?
       %p.az-navbar-content= t('lexicon.verification.sections.has_az_navbar')
     - else

--- a/config/locales/lexicon.en.yml
+++ b/config/locales/lexicon.en.yml
@@ -264,6 +264,7 @@ en:
         no_date_of_manual_update: "(No manual update date)"
         no_description: "(No description)"
         no_toc: "(No table of contents)"
+        has_az_navbar: An A-Z navigation bar is shown for this publication
         no_az_navbar: "(No A-Z navigation)"
         external_identifiers_section: Authority Control Identifiers
         no_external_identifiers: "(No authority control identifiers)"

--- a/config/locales/lexicon.en.yml
+++ b/config/locales/lexicon.en.yml
@@ -232,6 +232,7 @@ en:
         file_not_found: "⚠️ Source file not found"
       migrated:
         header: Migrated Entry
+        jump_to: "Jump to:"
         edit: Edit
         add_citation: Add Citation
         add_link: Add Link

--- a/config/locales/lexicon.en.yml
+++ b/config/locales/lexicon.en.yml
@@ -264,8 +264,8 @@ en:
         no_date_of_manual_update: "(No manual update date)"
         no_description: "(No description)"
         no_toc: "(No table of contents)"
-        has_az_navbar: An A-Z navigation bar is shown for this publication
-        no_az_navbar: "(No A-Z navigation)"
+        has_az_navbar: "A-Z navigation bar: enabled"
+        no_az_navbar: "A-Z navigation bar: disabled"
         external_identifiers_section: Authority Control Identifiers
         no_external_identifiers: "(No authority control identifiers)"
         citation_from_publication: "From:"

--- a/config/locales/lexicon.he.yml
+++ b/config/locales/lexicon.he.yml
@@ -265,6 +265,7 @@ he:
         no_date_of_manual_update: "(אין תאריך עדכון ידני)"
         no_description: "(אין תיאור)"
         no_toc: "(אין תוכן עניינים)"
+        has_az_navbar: מוצג סרגל ניווט א-ב עבור פרסום זה
         no_az_navbar: "(אין ניווט א-ב)"
         external_identifiers_section: מזהים חיצוניים
         no_external_identifiers: "(אין מזהים חיצוניים)"

--- a/config/locales/lexicon.he.yml
+++ b/config/locales/lexicon.he.yml
@@ -233,6 +233,7 @@ he:
         file_not_found: "⚠️ קובץ מקור לא נמצא"
       migrated:
         header: הערך המוסב
+        jump_to: "קפיצה אל:"
         edit: ערוך
         add_citation: הוסף מראה מקום
         add_link: הוסף קישור

--- a/config/locales/lexicon.he.yml
+++ b/config/locales/lexicon.he.yml
@@ -265,8 +265,8 @@ he:
         no_date_of_manual_update: "(אין תאריך עדכון ידני)"
         no_description: "(אין תיאור)"
         no_toc: "(אין תוכן עניינים)"
-        has_az_navbar: מוצג סרגל ניווט א-ב עבור פרסום זה
-        no_az_navbar: "(אין ניווט א-ב)"
+        has_az_navbar: "סרגל ניווט א-ב: מסומן"
+        no_az_navbar: "סרגל ניווט א-ב: לא מסומן"
         external_identifiers_section: מזהים חיצוניים
         no_external_identifiers: "(אין מזהים חיצוניים)"
         citation_from_publication: "ממקור:"

--- a/spec/requests/lexicon/verification_spec.rb
+++ b/spec/requests/lexicon/verification_spec.rb
@@ -109,6 +109,61 @@ RSpec.describe 'Lexicon::Verification', type: :request do
     end
   end
 
+  # az_navbar is a boolean column ("show an A-Z navigation bar?"). The verification view
+  # used to render it as markdown, which raised TypeError for every publication ingested
+  # with the default az_navbar = true, and offered a free-text edit form for it.
+  describe 'az_navbar, a boolean publication flag' do
+    let(:entry) do
+      e = create(:lex_entry, status: :verifying, lex_item: build(:lex_publication, az_navbar: true))
+      e.start_verification!('editor@example.com')
+      e
+    end
+
+    it 'renders the verification page for a publication with az_navbar set' do
+      get "/lex/verification/#{entry.id}"
+
+      expect(response).to have_http_status(:success)
+      expect(response.body).to include(I18n.t('lexicon.verification.sections.has_az_navbar'))
+    end
+
+    it 'renders the verification page for a publication without az_navbar' do
+      entry.lex_item.update!(az_navbar: false)
+
+      get "/lex/verification/#{entry.id}"
+
+      expect(response).to have_http_status(:success)
+      expect(response.body).to include(I18n.t('lexicon.verification.sections.no_az_navbar'))
+    end
+
+    it 'offers a checkbox rather than a free-text field in the edit form' do
+      get "/lex/verification/#{entry.id}/edit_section", params: { section: 'az_navbar' }, xhr: true
+
+      expect(response).to have_http_status(:success)
+      expect(response.body).to include('type="checkbox"')
+      expect(response.body).not_to include('<textarea')
+    end
+
+    it 'turns the flag off when the checkbox is submitted unchecked' do
+      patch "/lex/verification/#{entry.id}/update_section",
+            params: { section: 'az_navbar', lex_publication: { az_navbar: '0' } },
+            as: :json
+
+      expect(response).to have_http_status(:success)
+      expect(entry.lex_item.reload.az_navbar).to be false
+    end
+
+    it 'turns the flag on when the checkbox is submitted checked' do
+      entry.lex_item.update!(az_navbar: false)
+
+      patch "/lex/verification/#{entry.id}/update_section",
+            params: { section: 'az_navbar', lex_publication: { az_navbar: '1' } },
+            as: :json
+
+      expect(response).to have_http_status(:success)
+      expect(entry.lex_item.reload.az_navbar).to be true
+    end
+  end
+
   describe 'PATCH /lex/verification/:id/update_checklist' do
     context 'when verifying the title section for a LexPerson' do
       let(:entry) do

--- a/spec/system/lexicon/verification_section_shortcuts_spec.rb
+++ b/spec/system/lexicon/verification_section_shortcuts_spec.rb
@@ -127,11 +127,9 @@ RSpec.describe 'Verification migrated pane section shortcuts', :js, type: :syste
   end
 
   context 'with a publication entry' do
-    # az_navbar is a boolean column but the publication verification view feeds it to
-    # MarkdownToHtml, which raises on a non-String; pin it to false to avoid that path.
     let!(:entry) do
       create(:lex_entry, title: 'Test Publication', status: :draft,
-                         lex_item: build(:lex_publication, az_navbar: false))
+                         lex_item: build(:lex_publication, az_navbar: true))
     end
 
     let!(:lex_file) do

--- a/spec/system/lexicon/verification_section_shortcuts_spec.rb
+++ b/spec/system/lexicon/verification_section_shortcuts_spec.rb
@@ -11,6 +11,8 @@ RSpec.describe 'Verification migrated pane section shortcuts', :js, type: :syste
   end
 
   # Poll until .migrated-content scrollTop stops changing (smooth scrolling has settled).
+  # scrollTop can be fractional and jitter by well under a pixel, so "unchanged" is an
+  # epsilon comparison rather than strict equality.
   def settled_migrated_scroll_top_js
     <<~JS
       var done = arguments[0];
@@ -20,7 +22,8 @@ RSpec.describe 'Verification migrated pane section shortcuts', :js, type: :syste
       var deadline = Date.now() + 5000;
       function check() {
         var top = el ? el.scrollTop : 0;
-        if (top === last) { stable++; } else { stable = 0; last = top; }
+        if (Math.abs(top - last) < 0.5) { stable++; } else { stable = 0; }
+        last = top;
         if (stable >= 3 || Date.now() > deadline) { done(top); }
         else { setTimeout(check, 100); }
       }
@@ -158,6 +161,10 @@ RSpec.describe 'Verification migrated pane section shortcuts', :js, type: :syste
 
     it 'keeps the links shortcut, which publications do have' do
       expect(page).to have_css('.migrated-shortcut[data-section-target="section-links"]', visible: :visible)
+    end
+
+    it 'keeps the shortcuts nav itself visible' do
+      expect(page).to have_css('.migrated-shortcuts', visible: :visible)
     end
   end
 end

--- a/spec/system/lexicon/verification_section_shortcuts_spec.rb
+++ b/spec/system/lexicon/verification_section_shortcuts_spec.rb
@@ -1,0 +1,163 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Verification migrated pane section shortcuts', :js, type: :system do
+  let(:php_content) do
+    lines = ['<html><body><h1>Test Person</h1>']
+    20.times { |i| lines << "<p>Content paragraph #{i + 1}.</p>" }
+    lines << '</body></html>'
+    lines.join("\n")
+  end
+
+  # Poll until .migrated-content scrollTop stops changing (smooth scrolling has settled).
+  def settled_migrated_scroll_top_js
+    <<~JS
+      var done = arguments[0];
+      var el = document.querySelector('.migrated-content');
+      var last = -1;
+      var stable = 0;
+      var deadline = Date.now() + 5000;
+      function check() {
+        var top = el ? el.scrollTop : 0;
+        if (top === last) { stable++; } else { stable = 0; last = top; }
+        if (stable >= 3 || Date.now() > deadline) { done(top); }
+        else { setTimeout(check, 100); }
+      }
+      check();
+    JS
+  end
+
+  def section_offset_in_pane(section_id)
+    page.evaluate_script(<<~JS)
+      (function() {
+        var el = document.getElementById('#{section_id}');
+        var pane = document.querySelector('.migrated-content');
+        return Math.round(el.getBoundingClientRect().top - pane.getBoundingClientRect().top);
+      })()
+    JS
+  end
+
+  before do
+    skip 'WebDriver not available or misconfigured' unless webdriver_available?
+    login_as_lexicon_editor
+  end
+
+  context 'with a person entry' do
+    let!(:person) do
+      create(:lex_person,
+             birthdate: '1138',
+             deathdate: '1204',
+             bio: (['<p>A long biography paragraph.</p>'] * 40).join("\n"),
+             gender: :male)
+    end
+
+    let!(:entry) { create(:lex_entry, title: 'Test Person', lex_item: person, status: :draft) }
+
+    let!(:lex_file) do
+      file_path = Rails.root.join('tmp/test_shortcuts_person.php')
+      File.write(file_path, php_content)
+      create(:lex_file,
+             lex_entry: entry,
+             fname: 'test_shortcuts_person.php',
+             full_path: file_path.to_s,
+             status: :ingested,
+             entrytype: :person)
+    end
+
+    let!(:citations) do
+      6.times.map { |i| create(:lex_citation, person: person, title: "Citation #{i}", from_publication: "Pub #{i}") }
+    end
+
+    after { FileUtils.rm_f(lex_file.full_path) }
+
+    before do
+      entry.start_verification!('test@example.com')
+      visit "/lex/verification/#{entry.id}"
+      find('.migrated-content', wait: 5)
+    end
+
+    it 'shows a shortcut in the header for each of the four sections' do
+      within '.migrated-header .migrated-shortcuts' do
+        %w(section-bio section-works section-citations section-links).each do |section_id|
+          expect(page).to have_css(%(.migrated-shortcut[data-section-target="#{section_id}"]), visible: :visible)
+        end
+      end
+    end
+
+    it 'labels the shortcuts with the section names' do
+      within '.migrated-header .migrated-shortcuts' do
+        expect(page).to have_link(I18n.t('lexicon.verification.sections.biography'))
+        expect(page).to have_link(I18n.t('lexicon.verification.sections.works_section'))
+        expect(page).to have_link(I18n.t('lexicon.verification.sections.citations_section'))
+        expect(page).to have_link(I18n.t('lexicon.verification.sections.links_section'))
+      end
+    end
+
+    it 'scrolls the migrated pane to the citations section when its shortcut is clicked' do
+      expect(page.evaluate_script("document.querySelector('.migrated-content').scrollTop")).to eq(0)
+
+      find('.migrated-shortcut[data-section-target="section-citations"]').click
+
+      expect(page.evaluate_async_script(settled_migrated_scroll_top_js)).to be > 0
+      # The section should end up at the top of the pane (8px margin allowed for by the JS)
+      expect(section_offset_in_pane('section-citations')).to be_within(12).of(8)
+    end
+
+    it 'scrolls back up to the biography section' do
+      find('.migrated-shortcut[data-section-target="section-links"]').click
+      expect(page.evaluate_async_script(settled_migrated_scroll_top_js)).to be > 0
+
+      find('.migrated-shortcut[data-section-target="section-bio"]').click
+      page.evaluate_async_script(settled_migrated_scroll_top_js)
+
+      expect(section_offset_in_pane('section-bio')).to be_within(12).of(8)
+    end
+
+    it 'does not change the page URL' do
+      url_before = page.current_url
+      find('.migrated-shortcut[data-section-target="section-works"]').click
+      page.evaluate_async_script(settled_migrated_scroll_top_js)
+
+      expect(page.current_url).to eq(url_before)
+    end
+  end
+
+  context 'with a publication entry' do
+    # az_navbar is a boolean column but the publication verification view feeds it to
+    # MarkdownToHtml, which raises on a non-String; pin it to false to avoid that path.
+    let!(:entry) do
+      create(:lex_entry, title: 'Test Publication', status: :draft,
+                         lex_item: build(:lex_publication, az_navbar: false))
+    end
+
+    let!(:lex_file) do
+      file_path = Rails.root.join('tmp/test_shortcuts_publication.php')
+      File.write(file_path, php_content)
+      create(:lex_file,
+             lex_entry: entry,
+             fname: 'test_shortcuts_publication.php',
+             full_path: file_path.to_s,
+             status: :ingested,
+             entrytype: :text)
+    end
+
+    after { FileUtils.rm_f(lex_file.full_path) }
+
+    before do
+      entry.start_verification!('test@example.com')
+      visit "/lex/verification/#{entry.id}"
+      find('.migrated-content', wait: 5)
+    end
+
+    it 'hides shortcuts whose section is not rendered for publications' do
+      %w(section-bio section-works section-citations).each do |section_id|
+        expect(page).to have_css(%(.migrated-shortcut[data-section-target="#{section_id}"]), visible: :hidden)
+      end
+    end
+
+    it 'keeps the links shortcut, which publications do have' do
+      expect(page).to have_css('.migrated-shortcut[data-section-target="section-links"]', visible: :visible)
+    end
+  end
+end


### PR DESCRIPTION
## What

Adds "jump to" shortcut links to the title row of the **left (migrated) pane** in the lexicon verification workbench, right after the pane title: **biography**, **works**, **citations**, **links**.

Clicking one smooth-scrolls that pane to the corresponding section (with the same 8px top margin the existing section-scroll code uses). The window itself does not scroll in this layout — `.migrated-content` is the scroll container — so the links are handled in JS and do not change the URL hash.

## How

- `_migrated_entry.html.haml`: `.migrated-shortcuts` nav in `.migrated-header`, one anchor per section with `data-section-target`.
- `verification.js`: new `scrollMigratedPaneTo(el)` helper + click handler. Because the header partial is shared between person and publication entries, all four links are rendered and the ones whose target section is not in the DOM (bio/works/citations for publications) are hidden on init.
- `verification.scss`: header becomes a wrapping flex row; small, unobtrusive link styling.
- I18n: new `lexicon.verification.migrated.jump_to` in he/en; the link labels reuse the existing `lexicon.verification.sections.*` names.

## Tests

New system spec `spec/system/lexicon/verification_section_shortcuts_spec.rb` (7 examples, all passing): shortcuts render and are labelled, clicking scrolls the pane so the target section lands at the top, scrolling back up works, the URL is unchanged, and for a publication entry the bio/works/citations shortcuts are hidden while links stays visible.

`spec/system/lexicon`, `spec/requests/lexicon` and `spec/helpers/lexicon` — 398 examples, 0 failures.

The full suite run had 19 failures, all in unrelated areas (authors/collections controllers, search, ingest rake) and all caused by the local Elasticsearch cluster going read-only under the disk flood-stage watermark (`cluster_block_exception`, disk at 97%), not by this change.

## Also fixed: az_navbar treated as markdown

`az_navbar` is a **boolean** column, but `_publication_sections.html.haml` passed it to `MarkdownToHtml`, which raises `TypeError: wrong argument type true (expected String)`. Since `Lexicon::IngestPublication` sets `az_navbar: true` on every ingested record, the verification page was broken for **every ingested publication**. `_edit_az_navbar.html.haml` also offered a 10-row "HTML allowed" textarea for a boolean (any typed text casts to `true`, an empty box to `nil`).

Display now reports the flag's state and the edit form uses a checkbox.

Worth knowing for review: **the flag is currently write-only.** It is set by `IngestPublication` (hardcoded `true`) and editable in two forms, but no view reads it — the lexicon entry sidebar (`entries/_navbar.html.haml`) renders unconditionally and is not an A-Z bar. The labels therefore state the flag's value ("A-Z navigation bar: enabled" / "disabled") rather than claiming a rendered effect. Whether the verification checklist should keep asking editors to tick off a dead flag is a separate question, not addressed here.

New request specs cover both rendering paths, the edit-form markup, and toggling the flag off and on; they were verified to fail against the previous code with the original `TypeError`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

