### PR TITLE
Verification workbench: "release lock" button

### DIFF
--- a/app/controllers/lexicon/verification_controller.rb
+++ b/app/controllers/lexicon/verification_controller.rb
@@ -71,7 +71,7 @@ module Lexicon
       end
     end
 
-    # PATCH /lexicon/verification/:id/unlock
+    # PATCH /lex/verification/:id/unlock
     # Lets an editor deliberately release the lock they hold on the entry they are verifying.
     # Always returns to the queue: redirecting back to the workbench would immediately re-lock.
     def unlock

--- a/app/controllers/lexicon/verification_controller.rb
+++ b/app/controllers/lexicon/verification_controller.rb
@@ -8,7 +8,7 @@ module Lexicon
     EXTERNAL_IDENTIFIER_KEYS = LexiconHelper::EXTERNAL_IDENTIFIER_LABELS.keys.freeze
 
     before_action :set_entry, except: %i(index)
-    before_action :try_to_lock_record, except: %i(index)
+    before_action :try_to_lock_record, except: %i(index unlock)
     before_action do |c|
       c.require_editor('edit_lexicon')
     end
@@ -68,6 +68,18 @@ module Lexicon
         elsif @item.authority.present?
           @item.update!(copyrighted: authority_copyrighted?(@item.authority.intellectual_property))
         end
+      end
+    end
+
+    # PATCH /lexicon/verification/:id/unlock
+    # Lets an editor deliberately release the lock they hold on the entry they are verifying.
+    # Always returns to the queue: redirecting back to the workbench would immediately re-lock.
+    def unlock
+      if @entry.locked_by_user == current_user
+        @entry.release_lock!
+        redirect_to lexicon_verification_queue_path, notice: t('.success')
+      else
+        redirect_to lexicon_verification_queue_path, alert: t('.not_locked_by_you')
       end
     end
 

--- a/app/views/lexicon/verification/show.html.haml
+++ b/app/views/lexicon/verification/show.html.haml
@@ -55,6 +55,12 @@
             = t('lexicon.verification.show.mark_verified')
         %button.btn#escalate-btn{ type: 'button', style: 'background-color: #f8d7da; border-color: #f5c6cb;' }
           = t('lexicon.verification.show.escalate')
+        = button_to t('lexicon.verification.show.release_lock'),
+                    lexicon_unlock_verification_path(@entry),
+                    method: :patch,
+                    class: 'btn btn-warning',
+                    id: 'release-lock-btn',
+                    data: { confirm: t('lexicon.entries.index.unlock_confirm') }
         - monday_report_url = lexicon_report_to_monday_verification_path(@entry)
         %button.btn.btn-outline-info#monday-report-btn{ type: 'button', data: { 'report-url': monday_report_url } }
           = t('lexicon.verification.monday.report_button')

--- a/config/locales/lexicon.en.yml
+++ b/config/locales/lexicon.en.yml
@@ -204,6 +204,10 @@ en:
         escalate_confirm: This entry will be escalated for further review. You can provide notes explaining the reason for escalation.
         progress: Progress
         hide_verified: Hide Verified Items
+        release_lock: Release Lock
+      unlock:
+        success: Lock released successfully!
+        not_locked_by_you: This entry is not locked by you!
       checklist:
         title: Verification Checklist
         overall_notes: Overall Notes

--- a/config/locales/lexicon.he.yml
+++ b/config/locales/lexicon.he.yml
@@ -205,6 +205,10 @@ he:
         escalate_confirm: הערך יועבר לבדיקה נוספת. ניתן להוסיף הערות המסבירות את הסיבה להעברה.
         progress: התקדמות
         hide_verified: הסתר פריטים בדוקים
+        release_lock: שחרר נעילה
+      unlock:
+        success: הנעילה שוחררה בהצלחה!
+        not_locked_by_you: הרשומה אינה נעולה על ידך!
       checklist:
         title: רשימת בדיקה
         overall_notes: הערות כלליות

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -108,6 +108,7 @@ Bybeconv::Application.routes.draw do
     scope :verification do
       get ':id', to: 'verification#show', as: :verification
       get ':id/source', to: 'verification#source', as: :verification_source
+      patch ':id/unlock', to: 'verification#unlock', as: :unlock_verification
       patch ':id/update_checklist', to: 'verification#update_checklist', as: :update_checklist_verification
       patch ':id/save_progress', to: 'verification#save_progress', as: :save_progress_verification
       patch ':id/set_profile_image', to: 'verification#set_profile_image', as: :set_profile_image_verification

--- a/spec/requests/lexicon/verification_unlock_spec.rb
+++ b/spec/requests/lexicon/verification_unlock_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Lexicon::Verification unlock', type: :request do
+  let(:entry) { create(:lex_entry, :person, status: :verifying) }
+
+  describe 'PATCH /lex/verification/:id/unlock' do
+    context 'when the entry is locked by the current user' do
+      it 'releases the lock and redirects to the verification queue' do
+        editor = login_as_lexicon_editor
+        entry.obtain_lock?(editor)
+
+        patch "/lex/verification/#{entry.id}/unlock"
+
+        expect(response).to redirect_to(lexicon_verification_queue_path)
+        expect(flash[:notice]).to eq(I18n.t('lexicon.verification.unlock.success'))
+        expect(entry.reload).not_to be_locked
+        expect(entry.locked_by_user).to be_nil
+      end
+    end
+
+    context 'when the entry is locked by another user' do
+      it 'leaves the lock alone and redirects to the queue with an alert' do
+        # NB: not create_lexicon_editor, which memoizes and would hand back the logged-in user
+        other_editor = create(:user, editor: true)
+        entry.obtain_lock?(other_editor)
+        login_as_lexicon_editor
+
+        patch "/lex/verification/#{entry.id}/unlock"
+
+        expect(response).to redirect_to(lexicon_verification_queue_path)
+        expect(flash[:alert]).to eq(I18n.t('lexicon.verification.unlock.not_locked_by_you'))
+        expect(entry.reload).to be_locked
+        expect(entry.locked_by_user).to eq(other_editor)
+      end
+    end
+  end
+
+  describe 'GET /lex/verification/:id' do
+    it 'renders the release-lock button' do
+      login_as_lexicon_editor
+      entry.start_verification!('editor@example.com')
+
+      get "/lex/verification/#{entry.id}"
+
+      expect(response.body).to include(I18n.t('lexicon.verification.show.release_lock'))
+      expect(response.body).to include("/lex/verification/#{entry.id}/unlock")
+    end
+  end
+end

--- a/spec/system/lexicon/verification_release_lock_spec.rb
+++ b/spec/system/lexicon/verification_release_lock_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Verification release lock button', :js, type: :system do
+  before do
+    skip 'WebDriver not available or misconfigured' unless webdriver_available?
+    login_as_lexicon_editor
+  end
+
+  let!(:person) { create(:lex_person, birthdate: '1138', deathdate: '1204', gender: :male) }
+  let!(:entry) { create(:lex_entry, title: 'Test Person', lex_item: person, status: :draft) }
+
+  it 'releases the lock and returns to the verification queue' do
+    visit "/lex/verification/#{entry.id}"
+
+    # Visiting the workbench acquires the lock for the current editor.
+    expect(entry.reload).to be_locked
+
+    accept_confirm { click_button I18n.t('lexicon.verification.show.release_lock') }
+
+    expect(page).to have_content(I18n.t('lexicon.verification.unlock.success'))
+    expect(page).to have_current_path(lexicon_verification_queue_path)
+    expect(entry.reload).not_to be_locked
+  end
+
+  it 'keeps the lock when the confirmation is dismissed' do
+    visit "/lex/verification/#{entry.id}"
+    expect(entry.reload).to be_locked
+
+    dismiss_confirm { click_button I18n.t('lexicon.verification.show.release_lock') }
+
+    expect(page).to have_current_path("/lex/verification/#{entry.id}")
+    expect(entry.reload).to be_locked
+  end
+end


### PR DESCRIPTION
## Summary

Adds a **שחרר נעילה** ("release lock") button to the lexicon migration verification screen. It releases the editor's lock on the `LexEntry` and returns to the verification queue. Design emulates the Ingestibles unlock button (`btn btn-warning`, confirm dialog).

Previously an editor who opened the workbench held the lock until the 15-minute `Lockable` timeout expired, with no way to hand it back.

## Why a new controller action

Reusing `Lexicon::EntriesController#unlock` does not work here. That action redirects via `redirect_back_or_to`, which from the workbench lands back on `verification#show` — whose `before_action :try_to_lock_record` would *immediately re-acquire* the lock, making the button appear to do nothing. `Lexicon::VerificationController#unlock` therefore redirects to the queue unconditionally.

`try_to_lock_record` is skipped for the new action. The action's own `locked_by_user == current_user` check is the guard: hitting the endpoint for an entry locked by another editor leaves that lock intact and shows an alert.

## Changes

- `config/routes.rb`: `patch ':id/unlock' → verification#unlock` (`lexicon_unlock_verification_path`)
- `app/controllers/lexicon/verification_controller.rb`: new `unlock` action; `unlock` added to the `try_to_lock_record` exception list
- `app/views/lexicon/verification/show.html.haml`: button in the header `.actions` group, using `button_to` to match the adjacent "mark verified" button
- `config/locales/lexicon.{he,en}.yml`: `verification.show.release_lock` plus `verification.unlock.{success,not_locked_by_you}`

New label key rather than the global `t(:unlock)`, whose Hebrew is "שחרר נעילת העלאה" (ingestion-specific).

## Test plan

New specs, all passing:

- `spec/requests/lexicon/verification_unlock_spec.rb` (3 examples) — lock released + redirect + notice when held by current user; lock preserved + alert when held by another editor; button rendered on the show page
- `spec/system/lexicon/verification_release_lock_spec.rb` (2 examples, `js: true`) — end-to-end through rails-ujs: accepting the confirm unlocks and lands on the queue; dismissing it keeps both the lock and the page

`bundle exec rubocop` and `bundle exec haml-lint` clean on all changed files (haml-lint offense count on `show.html.haml` unchanged from baseline — the remaining ones are pre-existing).

⚠️ **The full `bundle exec rspec` suite was not run** — it was interrupted before completion. Only the specs above were executed.

Closes beads_by-lb7

🤖 Generated with [Claude Code](https://claude.com/claude-code)