### PR TITLE
Lexicon: don't let an outer <li> steal a nested citation's backup file

### DIFF
--- a/app/services/lexicon/parse_citations.rb
+++ b/app/services/lexicon/parse_citations.rb
@@ -135,7 +135,8 @@ PROMPT
       doc = Nokogiri::HTML::DocumentFragment.parse(html)
       modified = false
       doc.css('li').each do |li|
-        asterisk_links = li.css('a').select { |a| a.text =~ /\A[[:space:]]*\*[[:space:]]*\z/ }
+        anchors = own_anchors(li)
+        asterisk_links = anchors.select { |a| a.text =~ /\A[[:space:]]*\*[[:space:]]*\z/ }
         next if asterisk_links.empty?
 
         modified = true
@@ -147,17 +148,34 @@ PROMPT
         # the strongest join key back to the LLM-parsed citation.
         if href.present?
           li['data-file-link'] = href
-          inline_hrefs = (li.css('a').to_a - asterisk_links).filter_map { |a| a['href'].presence }
+          inline_hrefs = (anchors - asterisk_links).filter_map { |a| a['href'].presence }
           @asterisk_backups << {
             backup_href: href,
             inline_hrefs: inline_hrefs.reject { |h| h.end_with?('.php') || h.start_with?('#') },
-            text: normalize_text(li.text)
+            text: own_text(li)
           }
         end
 
         asterisk_links.each(&:remove)
       end
       modified ? doc.to_html : html
+    end
+
+    # Anchors belonging to this <li> itself, excluding those of any nested <li>.
+    # Legacy pages nest a sub-list of citations inside the <li> of the work they
+    # are about, so a plain descendant selector would credit an inner citation's
+    # asterisk link (and its inline links) to the outer <li> — and, since the
+    # anchor is then removed, the inner <li> would never be recorded at all.
+    def own_anchors(list_item)
+      list_item.css('a').select { |a| a.ancestors('li').first == list_item }
+    end
+
+    # Text of this <li> without the text of any nested <li>, so that match_by_text
+    # cannot match a nested citation's title against its containing work's <li>.
+    def own_text(list_item)
+      copy = list_item.dup
+      copy.css('li').each(&:remove)
+      normalize_text(copy.text)
     end
 
     # Deterministically assign backup_url to the citation each asterisk link came

--- a/spec/services/lexicon/parse_citations_spec.rb
+++ b/spec/services/lexicon/parse_citations_spec.rb
@@ -287,6 +287,76 @@ describe Lexicon::ParseCitations do
     end
   end
 
+  # Regression: legacy pages nest a sub-list of citations inside the <li> of the work
+  # they are about (e.g. 00156.php). The outer <li> used to swallow the nested
+  # citation's asterisk link, so the backup file was attributed both to the work and
+  # to the first nested citation carrying an inline link — and never to its real owner.
+  context 'when an asterisk link sits in a <li> nested inside another <li>' do
+    let(:html) do
+      <<~HTML
+        <ul>
+          <li><b>גרץ, נורית.</b> <b>על דעת עצמו</b> : ארבעה פרקי חיים של עמוס קינן (תל־אביב : עם עובד, 2008)
+            <font color="#FF0000">על הספר:</font>
+            <ul>
+              <li><b>גלסנר, אריק.</b> <a href="http://www.nrg.co.il/online/5/ART1/807/536.html">עד הקצה.</a>
+                מעריב, 2008, עמ' 28.</li>
+              <li><b>Keydar, Renana.</b> כותרת ייחודית ארוכה של המאמר. Jewish social studies, 2012, pp. 212-224.
+                <a href="/files/lex/5181/00156200.pdf">*</a></li>
+            </ul>
+          </li>
+        </ul>
+      HTML
+    end
+
+    let(:works) do
+      [
+        { title: 'על דעת עצמו', authors: [{ name: 'גרץ, נורית', link: nil }],
+          from_publication: 'עם עובד, 2008', pages: nil, link: nil, backup_url: nil, notes: nil },
+        { title: 'עד הקצה', authors: [{ name: 'גלסנר, אריק', link: nil }],
+          from_publication: 'מעריב, 2008', pages: '28',
+          link: 'http://www.nrg.co.il/online/5/ART1/807/536.html', backup_url: nil, notes: nil },
+        { title: 'כותרת ייחודית ארוכה של המאמר', authors: [{ name: 'Keydar, Renana', link: nil }],
+          from_publication: 'Jewish social studies, 2012', pages: '212-224',
+          link: nil, backup_url: nil, notes: nil }
+      ]
+    end
+
+    # `sent` collects the HTML actually handed to the LLM, so specs can assert on it.
+    def stub_llm_capturing(works, sent = [])
+      chat_double = instance_double(RubyLLM::Chat)
+      allow(RubyLLM).to receive(:chat).and_return(chat_double)
+      allow(chat_double).to receive_messages(with_instructions: chat_double, with_params: chat_double)
+      allow(chat_double).to receive(:ask) do |html_arg|
+        sent << html_arg
+        instance_double(RubyLLM::Message, content: { result: [{ subject: nil, works: works }] }.to_json)
+      end
+    end
+
+    it 'assigns backup_url only to the nested citation the asterisk belongs to' do
+      stub_llm_capturing(works)
+
+      result = described_class.call(html)
+
+      expect(result.map(&:backup_url)).to eq([nil, nil, '/files/lex/5181/00156200.pdf'])
+    end
+
+    it 'marks data-file-link on the nested <li> only, not on the containing work' do
+      sent = []
+      stub_llm_capturing(works, sent)
+
+      described_class.call(html)
+
+      doc = Nokogiri::HTML::DocumentFragment.parse(sent.first)
+      tagged = doc.css('li[data-file-link]')
+      expect(tagged.size).to eq(1)
+      # The outer <li> contains the nested one, so identify the tagged <li> by what it
+      # does NOT contain: the containing work, and any nested citation of its own.
+      expect(tagged.first.css('li')).to be_empty
+      expect(tagged.first.text).to include('Keydar, Renana')
+      expect(tagged.first.text).not_to include('גרץ, נורית')
+    end
+  end
+
   context 'when the LLM returns citations with blank titles' do
     let(:html) { '<ul><li>some html</li></ul>' }
 


### PR DESCRIPTION
## Problem

On the dev server, entry 5181 (עמוס קינן) had `/files/lex/5181/00156200.pdf` attached as the `backup_file` of **two** citations — "על דעת עצמו" and "עד הקצה" — and it belonged to neither.

## Root cause

`Lexicon::ParseCitations#preprocess_asterisk_links` used `li.css('a')`, a **descendant** selector. Legacy pages nest a sub-list of citations inside the `<li>` of the work they are about:

```html
<li> גרץ, נורית. על דעת עצמו : ...            ← outer <li> (the BOOK)
  <font color="#FF0000">על הספר:</font>
  <ul>
    <li> גלסנר, אריק. <a href="…nrg…807/536.html">עד הקצה.</a> …
    …10 more…
    <li> Keydar, Renana. ״I was in a war…״ … <a href="00156_files/00156200.pdf">*</a>  ← TRUE owner
  </ul>
</li>
```

`doc.css('li')` visits the outer `<li>` first, and it matched the inner citation's asterisk anchor. Three consequences:

1. `data-file-link` was set on the **outer** `<li>`, so the LLM reported the backup file as the work's own → "על דעת עצמו" got it.
2. `inline_hrefs` harvested every nested citation's href, so `recover_backup_urls` → `match_by_link` matched the **first** nested citation carrying a link → "עד הקצה" got it too.
3. `asterisk_links.each(&:remove)` deleted the anchor, so when the loop reached the Keydar `<li>` there was no asterisk left — its true owner was skipped entirely and got nothing.

The two assignments came from **two independent code paths** (LLM output vs. deterministic recovery), which is why the existing "each backup is assigned at most once" guard did not prevent the duplicate.

`match_by_text` had the same defect for a related reason: `normalize_text(li.text)` included all nested `<li>` text, letting an outer `<li>` text-match a nested citation's title.

## Fix

Scope both anchor collection and the `match_by_text` source text to the `<li>`'s **own** content, excluding nested `<li>` subtrees (`own_anchors` / `own_text`).

## Blast radius

- **19 of 4950** legacy php files contain this markup (37 asterisk links): `00156, 00186, 00397, 00400z21, 00409, 00459, 00731101, 01205, 01382, 02005, 02016, 02020, 02023, 02031, 02047, 03192, 03235, 03249, 03342`.
- Only `00156.php` (entry 5181) had been ingested; the other 18 are still `classified`/`unclassified`, so this fix prevents the problem for them entirely.
- DB-wide there was exactly one duplicated `(person, backup_url)` pair — the reported one.

## Data repair

Entry 5181 was re-ingested (`release_lock!` → `reset_ingestion!` → `Lexicon::IngestFile`). No verification work was lost: the checklist was auto-initialized with every item `verified: false`, no notes, and no citation or work had been manually edited. After re-ingest:

- `00156200.pdf` is attached to the Keydar citation only — its true owner.
- "על דעת עצמו" and "עד הקצה" have no backup file.
- The unrelated blogspot backup on "עמוס, עוזי ושות׳" is preserved.
- Zero duplicate `(person, backup_url)` pairs remain in the DB.
- Counts match the previous ingest: 53 citations, 32 works, 1 link, 5 attachments.

## Test plan

Two regression specs in `spec/services/lexicon/parse_citations_spec.rb` built from the real 00156.php markup. Verified **red before the fix** (`got: [nil, "/files/lex/5181/00156200.pdf", nil]` — the exact misattribution) and green after.

- `bundle exec rspec spec/services/lexicon spec/models/lex_citation_spec.rb spec/helpers/lexicon_helper_spec.rb` → 201 examples, 0 failures
- `bundle exec rspec spec/controllers/lexicon/entries_controller_spec.rb` → 62 examples, 0 failures
- `bundle exec rspec spec/requests/lexicon spec/controllers/lexicon` → 6 failures, but the **identical** failure set occurs on a clean tree at the same seed (pre-existing cross-file test-order pollution, unrelated to this change)
- RuboCop clean on both changed files

Full suite was not run, per instruction to run the lexicon specs only.

Closes beads_by-mkz

🤖 Generated with [Claude Code](https://claude.com/claude-code)