### PR TITLE
Lexicon verification: better work↔publication matching, and reporting publications missing from the entry

### DIFF
--- a/.claude/rules/full-test-suite-runtime.md
+++ b/.claude/rules/full-test-suite-runtime.md
@@ -1,0 +1,42 @@
+# Running the Full Test Suite: Ask First
+
+## The rule
+
+**The full RSpec suite (`bundle exec rspec` with no arguments) takes OVER 40 MINUTES.**
+
+Do **NOT** run the full suite on your own initiative. Run it **only** when the
+user explicitly approves or asks for it.
+
+## What to do instead
+
+For ordinary feature/bugfix work, run only the specs that are relevant:
+
+```bash
+bundle exec rspec spec/models/foo_spec.rb spec/requests/lexicon/bar_spec.rb
+bundle exec rspec spec/system/lexicon/           # a targeted directory
+```
+
+Report exactly which specs you ran, and state plainly that the full suite was
+not run and needs the user's approval.
+
+## If the user does approve a full run
+
+- Budget **at least 45–60 minutes** (`timeout 3600`), and run it in the
+  background writing to a log file rather than piping to `tail` (a pipe buffers
+  everything until the process exits, so you can't monitor progress).
+- A `timeout 1500`-style cap will kill the run mid-way with exit code 143 and
+  produce no results.
+
+## Interaction with the testing-requirements rule
+
+`.claude/rules/testing-requirements.md` says to run `bundle exec rspec` before
+considering work complete. That instruction stands for *what* must eventually be
+verified, but the **timing is the user's call**: write the tests, run the
+targeted specs, and wait for approval before spending 40+ minutes on the full
+suite.
+
+## Historical context
+
+Added 2026-08-01 after a full-suite run was killed at the 25-minute mark and a
+second attempt was interrupted; the user clarified the suite takes over 40
+minutes and should only be run with their approval.

--- a/app/assets/javascripts/verification.js
+++ b/app/assets/javascripts/verification.js
@@ -246,11 +246,11 @@ function initVerification() {
         });
     });
 
-    // Handle per-work "missing work" report buttons
+    // Handle per-publication "missing work" report buttons
     $(document).on('click', '.monday-missing-work-btn', function() {
         var btn = $(this);
         var reportUrl = btn.data('report-url');
-        var workTitle = btn.data('work-title');
+        var publicationId = btn.data('publication-id');
 
         btn.prop('disabled', true);
         $.ajax({
@@ -258,9 +258,10 @@ function initVerification() {
             type: 'POST',
             dataType: 'json',
             headers: { 'X-CSRF-Token': $('meta[name="csrf-token"]').attr('content') },
-            data: { type: 'missing_work', work_title: workTitle },
+            data: { type: 'missing_work', publication_id: publicationId },
             success: function(data) {
                 showToast(data.message);
+                btn.remove();
             },
             error: function(xhr) {
                 var err = (xhr.responseJSON && xhr.responseJSON.error) || 'Error sending report';

--- a/app/assets/javascripts/verification.js
+++ b/app/assets/javascripts/verification.js
@@ -261,7 +261,10 @@ function initVerification() {
             data: { type: 'missing_work', publication_id: publicationId },
             success: function(data) {
                 showToast(data.message);
-                btn.remove();
+                // The report is persisted server-side, so replace the button with a static label
+                var label = $('<span class="text-muted ms-2 reported-missing-label"></span>')
+                    .text(btn.data('reported-label') || '');
+                btn.replaceWith(label);
             },
             error: function(xhr) {
                 var err = (xhr.responseJSON && xhr.responseJSON.error) || 'Error sending report';

--- a/app/controllers/lexicon/verification_controller.rb
+++ b/app/controllers/lexicon/verification_controller.rb
@@ -309,6 +309,8 @@ module Lexicon
       )
 
       if result[:success]
+        # Remember the report so the publication is not offered for reporting again
+        publication&.mark_reported_missing_from_lexicon!(current_user) if report_type == :missing_work
         render json: { success: true, message: I18n.t('lexicon.verification.monday.report_sent') }
       else
         render json: { success: false, error: result[:error] }, status: :unprocessable_content

--- a/app/controllers/lexicon/verification_controller.rb
+++ b/app/controllers/lexicon/verification_controller.rb
@@ -298,14 +298,14 @@ module Lexicon
     def report_to_monday
       report_type = params[:type] == 'missing_work' ? :missing_work : :general
       description = params[:description].presence
-      work_title = params[:work_title].presence
+      publication = Publication.find_by(id: params[:publication_id]) if params[:publication_id].present?
 
       result = Lexicon::MondayReport.call(
         entry: @entry,
         report_type: report_type,
         current_url: lexicon_verification_url(@entry),
         description: description,
-        work_title: work_title
+        publication: publication
       )
 
       if result[:success]

--- a/app/controllers/lexicon/verification_controller.rb
+++ b/app/controllers/lexicon/verification_controller.rb
@@ -327,6 +327,7 @@ module Lexicon
       # Auto-match works to publications if editing works section and authority exists
       if @section == 'works' && @item.is_a?(LexPerson) && @item.authority.present?
         @work_matches = auto_match_works_to_publications(@item)
+        @unmatched_publications = publications_absent_from_entry(@item, @work_matches)
       end
 
       render partial: "lexicon/verification/edit_#{@section}"
@@ -538,6 +539,12 @@ module Lexicon
       end
 
       matches
+    end
+
+    # Publications of the person's authority that neither belong to an existing work nor appear
+    # among the proposed matches: works we have in BYP that are missing from the lexicon entry.
+    def publications_absent_from_entry(person, work_matches)
+      person.unmatched_publications.where.not(id: work_matches.values.pluck(:publication_id))
     end
 
     # Find the best publication match for a work

--- a/app/controllers/lexicon/verification_controller.rb
+++ b/app/controllers/lexicon/verification_controller.rb
@@ -550,62 +550,23 @@ module Lexicon
     # Find the best publication match for a work
     # Returns { publication: Publication, similarity: Integer } or nil
     def find_best_publication_match(work, publications, authority_name)
-      work_title = work.title.to_s.strip
-      return nil if work_title.blank?
+      return nil if work.title.blank?
 
       best_match = nil
       best_similarity = 0
 
       publications.each do |pub|
-        pub_title = normalize_publication_title(pub.title, authority_name)
-        next if pub_title.blank?
+        next if pub.title.blank?
 
-        # Try exact match first
-        if work_title == pub_title
-          return { publication: pub, similarity: 100 }
-        end
-
-        # Try fuzzy match using DamerauLevenshtein
-        similarity = calculate_similarity(work_title, pub_title)
-
-        # Only consider matches with 70% or higher similarity
-        next unless similarity >= 70
-
-        next unless similarity > best_similarity
+        similarity = Lexicon::TitleSimilarity.call(work.title, pub.title, ignoring: authority_name)
+        return { publication: pub, similarity: similarity } if similarity == 100
+        next unless similarity >= Lexicon::TitleSimilarity::MATCH_THRESHOLD && similarity > best_similarity
 
         best_similarity = similarity
         best_match = pub
       end
 
       best_match ? { publication: best_match, similarity: best_similarity } : nil
-    end
-
-    # Normalize publication title by removing authority name and slashes
-    def normalize_publication_title(title, authority_name)
-      return '' if title.blank?
-
-      normalized = title.dup
-
-      # Remove authority name (case-insensitive)
-      if authority_name.present?
-        normalized = normalized.gsub(/#{Regexp.escape(authority_name)}/i, '')
-      end
-
-      # Remove forward slashes
-      normalized = normalized.gsub('/', '')
-
-      # Clean up whitespace
-      normalized.strip
-    end
-
-    # Calculate similarity percentage between two strings using DamerauLevenshtein
-    # Caps denominator at 20 to reduce false positives on long names
-    def calculate_similarity(str1, str2)
-      d = DamerauLevenshtein.distance(str1, str2)
-      l = [str1.length, str2.length].max.clamp(0, 20).to_f
-      return 0 if l.zero?
-
-      ((1 - (d / l)) * 100).round
     end
   end
 end

--- a/app/models/lex_person.rb
+++ b/app/models/lex_person.rb
@@ -16,6 +16,15 @@ class LexPerson < ApplicationRecord
     citations.where(lex_person_work_id: nil, subject: nil).includes(:authors, :manifestation)
   end
 
+  # Publications of the associated Authority that are not linked to any of this person's works,
+  # i.e. works we know of in BYP that are missing from the legacy lexicon entry.
+  def unmatched_publications
+    return Publication.none if authority.nil?
+
+    matched_ids = works.where.not(publication_id: nil).select(:publication_id)
+    authority.publications.where.not(id: matched_ids).order(:title)
+  end
+
   # Returns the intellectual_property string for display purposes.
   # Maps the boolean copyrighted field: true => 'copyrighted', false => 'public_domain', nil => nil
   def intellectual_property

--- a/app/models/publication.rb
+++ b/app/models/publication.rb
@@ -1,4 +1,7 @@
 class Publication < ApplicationRecord
+  # ListItem listkey marking a publication already reported to Monday as missing from its lexicon entry
+  LEX_REPORTED_MISSING_LISTKEY = 'lex_reported_missing'.freeze
+
   belongs_to :authority, inverse_of: :publications
   belongs_to :bib_source
   has_many :holdings, dependent: :destroy
@@ -21,6 +24,18 @@ class Publication < ApplicationRecord
   scope :has_volume, -> { joins(:volume) }
 
   after_save :check_lists
+
+  # Has this publication already been reported as missing from its lexicon entry?
+  def reported_missing_from_lexicon?
+    list_items.exists?(listkey: LEX_REPORTED_MISSING_LISTKEY)
+  end
+
+  # Flag this publication as reported, so the report button is not offered again. Idempotent.
+  def mark_reported_missing_from_lexicon!(user = nil)
+    list_items.find_or_create_by!(listkey: LEX_REPORTED_MISSING_LISTKEY) do |li|
+      li.user = user
+    end
+  end
 
   def self.update_publications_that_may_be_done_list
     coll = Publication.not_uploaded.not_maybe_done.not_false_positive_maybe_done.order(:authority_id)

--- a/app/services/lexicon/monday_report.rb
+++ b/app/services/lexicon/monday_report.rb
@@ -16,13 +16,13 @@ module Lexicon
     # @param report_type [Symbol] :general or :missing_work
     # @param current_url [String] full URL of the verification page
     # @param description [String, nil] free-text (only for :general reports)
-    # @param work_title [String, nil] title of the specific work (only for :missing_work)
-    def initialize(entry:, report_type:, current_url:, description: nil, work_title: nil)
+    # @param publication [Publication, nil] the publication missing from the lexicon (only for :missing_work)
+    def initialize(entry:, report_type:, current_url:, description: nil, publication: nil)
       @entry = entry
       @report_type = report_type
       @current_url = current_url
       @description = description
-      @work_title = work_title
+      @publication = publication
     end
 
     def call
@@ -50,13 +50,23 @@ module Lexicon
         'text_mm2tn5yc' => @entry.title,
         'link_mm2t7e9n' => { 'url' => @current_url, 'text' => I18n.t('lexicon.verification.monday.link_text') }
       }
-      values['long_text_mm2tzz8q'] = @description if @report_type == :general && @description.present?
+      long_text = @report_type == :missing_work ? publication_details : @description
+      values['long_text_mm2tzz8q'] = long_text if long_text.present?
       values
+    end
+
+    # Publisher and year of the reported publication, for the Monday item's description column.
+    def publication_details
+      return nil if @publication.nil?
+
+      I18n.t('lexicon.verification.monday.missing_work_details',
+             publisher: @publication.publisher_line.presence || I18n.t('unknown'),
+             year: @publication.pub_year.presence || I18n.t('unknown'))
     end
 
     def item_name_column
       if @report_type == :missing_work
-        I18n.t('lexicon.verification.monday.missing_work_name', title: @work_title || @entry.title)
+        I18n.t('lexicon.verification.monday.missing_work_name', title: @publication&.title || @entry.title)
       else
         I18n.t('lexicon.verification.monday.general_name')
       end

--- a/app/services/lexicon/title_similarity.rb
+++ b/app/services/lexicon/title_similarity.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+module Lexicon
+  # Scores how likely two bibliographic titles are to denote the same book, on a 0..100 scale.
+  #
+  # The legacy lexicon and the BYP bibliography describe the same book with different
+  # punctuation and with a different amount of subtitle, e.g.
+  #   "בלוק 23 : מכתבים מנס ציונה"  vs  "בלוק 23 ; מכתבים מנס ציונה : נובלות"
+  # so both titles are first reduced to their bare words, and then compared in two ways:
+  # character-wise, which catches typos and spelling variants, and word-wise, which catches
+  # an added subtitle or reordered words. The more forgiving of the two scores wins, since
+  # every proposal is confirmed by a human before anything is persisted.
+  class TitleSimilarity < ApplicationService
+    # Bibliographic separators carry no meaning for matching: the two databases punctuate
+    # the very same book differently (": " vs "; ", parentheses, dashes, quotes).
+    SEPARATORS = %r{[-–—/\\:;,.()\[\]"'״׳]+}
+
+    # In catalogue records " / " introduces the statement of responsibility -- the author,
+    # translator and editor credits, which are not part of the title and which the two
+    # databases spell out to a different extent ("חמור הזהב / לוקיוס אפוליאוס").
+    STATEMENT_OF_RESPONSIBILITY = %r{\s/.*\z}m
+
+    # Everything that is not a letter or a digit separates words.
+    WORD_RE = /[[:alnum:]]+/
+
+    # Below this score two titles are not similar enough to be worth an editor's attention.
+    MATCH_THRESHOLD = 70
+
+    # @param title_a [String]
+    # @param title_b [String]
+    # @param ignoring [String, nil] a name (usually the authority's) that appears in one of the
+    #   titles as an attribution rather than as part of the title itself
+    # @return [Integer] 0 (nothing in common) .. 100 (identical once normalized)
+    def call(title_a, title_b, ignoring: nil)
+      a = normalize(title_a, ignoring)
+      b = normalize(title_b, ignoring)
+      return 0 if a.blank? || b.blank?
+      return 100 if a == b
+
+      [character_similarity(a, b), word_similarity(a, b)].max
+    end
+
+    private
+
+    # Drops the credits, the given name and all bibliographic punctuation, and lowercases what
+    # is left, so that only the words of the title itself take part in the comparison.
+    def normalize(title, ignoring = nil)
+      normalized = title.to_s
+      # The name goes first: the lexicon writes "name / title" where the bibliography writes
+      # "title / name", so dropping it settles which side of the slash the title is on.
+      normalized = normalized.gsub(/#{Regexp.escape(ignoring)}/i, '') if ignoring.present?
+      # Keep the credits when they are all that is left, rather than comparing against nothing
+      without_credits = normalized.sub(STATEMENT_OF_RESPONSIBILITY, '')
+      normalized = without_credits if without_credits.present?
+      normalized.gsub(SEPARATORS, ' ').squish.downcase
+    end
+
+    # Damerau-Levenshtein distance relative to the length of the longer title: a fixed number
+    # of edits weighs less the longer the titles are, which is what we want for titles that
+    # differ only by a trailing subtitle.
+    #
+    # The gem gives up past its max_distance argument (10 by default!) and reports that bound
+    # instead of the real distance, which would read as near-identity for long titles -- so we
+    # pass the one bound an edit distance can never exceed.
+    def character_similarity(str_a, str_b)
+      longest = [str_a.length, str_b.length].max
+      return 0 if longest.zero?
+
+      distance = DamerauLevenshtein.distance(str_a, str_b, 1, longest)
+      ((1 - (distance / longest.to_f)) * 100).round.clamp(0, 100)
+    end
+
+    # Jaccard index over the words of both titles: insensitive to word order, and to a subtitle
+    # present on one side only, while still penalising titles that share just a word or two.
+    def word_similarity(str_a, str_b)
+      words_a = str_a.scan(WORD_RE).to_set
+      words_b = str_b.scan(WORD_RE).to_set
+      union = words_a | words_b
+      return 0 if union.empty?
+
+      ((words_a & words_b).size / union.size.to_f * 100).round
+    end
+  end
+end

--- a/app/services/lexicon/title_similarity.rb
+++ b/app/services/lexicon/title_similarity.rb
@@ -12,8 +12,13 @@ module Lexicon
   # every proposal is confirmed by a human before anything is persisted.
   class TitleSimilarity < ApplicationService
     # Bibliographic separators carry no meaning for matching: the two databases punctuate
-    # the very same book differently (": " vs "; ", parentheses, dashes, quotes).
-    SEPARATORS = %r{[-–—/\\:;,.()\[\]"'״׳]+}
+    # the very same book differently (": " vs "; ", parentheses, dashes, quotes). The maqaf
+    # belongs here rather than with the points below, since it stands between two words.
+    SEPARATORS = %r{[-–—־/\\:;,.()\[\]"'״׳]+}
+
+    # Hebrew points and cantillation marks are a typographical choice, not part of the title:
+    # "הֵלֵּבָּן" and "הלבן" are the same book. The maqaf (05BE) is excluded -- it is a separator.
+    POINTS = /[\u0591-\u05BD\u05BF-\u05C7]/
 
     # In catalogue records " / " introduces the statement of responsibility -- the author,
     # translator and editor credits, which are not part of the title and which the two
@@ -42,13 +47,14 @@ module Lexicon
 
     private
 
-    # Drops the credits, the given name and all bibliographic punctuation, and lowercases what
-    # is left, so that only the words of the title itself take part in the comparison.
+    # Drops the points, the credits, the given name and all bibliographic punctuation, and
+    # lowercases what is left, so that only the words of the title take part in the comparison.
     def normalize(title, ignoring = nil)
-      normalized = title.to_s
+      normalized = title.to_s.gsub(POINTS, '')
       # The name goes first: the lexicon writes "name / title" where the bibliography writes
       # "title / name", so dropping it settles which side of the slash the title is on.
-      normalized = normalized.gsub(/#{Regexp.escape(ignoring)}/i, '') if ignoring.present?
+      name = ignoring.to_s.gsub(POINTS, '')
+      normalized = normalized.gsub(/#{Regexp.escape(name)}/i, '') if name.present?
       # Keep the credits when they are all that is left, rather than comparing against nothing
       without_credits = normalized.sub(STATEMENT_OF_RESPONSIBILITY, '')
       normalized = without_credits if without_credits.present?

--- a/app/views/lexicon/verification/_edit_works.html.haml
+++ b/app/views/lexicon/verification/_edit_works.html.haml
@@ -31,6 +31,34 @@
             onclick: 'confirmWorkMatch(this)'
           }= t('lexicon.verification.edit.confirm_match')
 
+  -# Publications known in BYP but absent from the entry — reportable, not part of the checklist
+  - if @unmatched_publications.present?
+    %hr
+    %h5= t('lexicon.verification.sections.unmatched_publications_heading')
+    %p.text-muted= t('lexicon.verification.sections.unmatched_publications_intro')
+    - @unmatched_publications.each do |publication|
+      .match-row.unmatched-publication.border-bottom.py-2.d-flex.justify-content-between.align-items-start{
+        id: "unmatched-publication-#{publication.id}"
+      }
+        .match-info{ dir: text_dir(publication.title.to_s) }
+          %strong= publication.title
+          - pub_details = [publication.publisher_line, publication.pub_year].compact_blank.join(', ')
+          - if pub_details.present?
+            %span.text-muted.ms-2= pub_details
+        .match-actions.ms-3
+          - if publication.reported_missing_from_lexicon?
+            %span.text-muted.reported-missing-label= t('lexicon.verification.monday.missing_work_reported')
+          - else
+            %button.btn.btn-sm.btn-outline-warning.monday-missing-work-btn{
+              type: 'button',
+              data: {
+                'publication-id': publication.id,
+                'report-url': lexicon_report_to_monday_verification_path(@entry),
+                'reported-label': t('lexicon.verification.monday.missing_work_reported')
+              }
+            }
+              = t('lexicon.verification.monday.missing_work_button')
+
   .text-end.mt-3
     %button.btn.btn-secondary{ type: 'button', onclick: "$('#generalDlg').modal('hide')" }
       = t('lexicon.verification.sections.close')

--- a/app/views/lexicon/verification/_person_sections.html.haml
+++ b/app/views/lexicon/verification/_person_sections.html.haml
@@ -190,26 +190,6 @@
                 = t('lexicon.verification.migrated.mark_verified')
     - else
       %p.text-muted= t('lexicon.verification.sections.no_works')
-    -# Publications known in BYP but absent from the lexicon entry — reportable, not part of the checklist
-    - unmatched_publications = item.unmatched_publications
-    - if unmatched_publications.any?
-      %h5.mt-3.mb-1.work-type-heading= t('lexicon.verification.sections.unmatched_publications_heading')
-      .work-card#unmatched-publications-card
-        .work-content
-          %p.text-muted= t('lexicon.verification.sections.unmatched_publications_intro')
-          %ul.list-unstyled.mb-0
-            - unmatched_publications.each do |publication|
-              %li.unmatched-publication.mb-2{ id: "unmatched-publication-#{publication.id}" }
-                %span{ dir: text_dir(publication.title.to_s) }
-                  %strong= publication.title
-                  - pub_details = [publication.publisher_line, publication.pub_year].compact_blank.join(', ')
-                  - if pub_details.present?
-                    %span.text-muted= " #{pub_details}"
-                - if publication.reported_missing_from_lexicon?
-                  %span.text-muted.ms-2.reported-missing-label= t('lexicon.verification.monday.missing_work_reported')
-                - else
-                  %button.btn.btn-sm.btn-outline-warning.monday-missing-work-btn.ms-2{ type: 'button', data: { 'publication-id': publication.id, 'report-url': lexicon_report_to_monday_verification_path(entry), 'reported-label': t('lexicon.verification.monday.missing_work_reported') } }
-                    = t('lexicon.verification.monday.missing_work_button')
 
 -# Section 4: Citations (מראי מקום)
 .section.verification-section{id: 'section-citations', class: checklist['citations']&.dig('verified') ? 'verified' : 'not-verified'}

--- a/app/views/lexicon/verification/_person_sections.html.haml
+++ b/app/views/lexicon/verification/_person_sections.html.haml
@@ -205,8 +205,11 @@
                   - pub_details = [publication.publisher_line, publication.pub_year].compact_blank.join(', ')
                   - if pub_details.present?
                     %span.text-muted= " #{pub_details}"
-                %button.btn.btn-sm.btn-outline-warning.monday-missing-work-btn.ms-2{ type: 'button', data: { 'publication-id': publication.id, 'report-url': lexicon_report_to_monday_verification_path(entry) } }
-                  = t('lexicon.verification.monday.missing_work_button')
+                - if publication.reported_missing_from_lexicon?
+                  %span.text-muted.ms-2.reported-missing-label= t('lexicon.verification.monday.missing_work_reported')
+                - else
+                  %button.btn.btn-sm.btn-outline-warning.monday-missing-work-btn.ms-2{ type: 'button', data: { 'publication-id': publication.id, 'report-url': lexicon_report_to_monday_verification_path(entry), 'reported-label': t('lexicon.verification.monday.missing_work_reported') } }
+                    = t('lexicon.verification.monday.missing_work_button')
 
 -# Section 4: Citations (מראי מקום)
 .section.verification-section{id: 'section-citations', class: checklist['citations']&.dig('verified') ? 'verified' : 'not-verified'}

--- a/app/views/lexicon/verification/_person_sections.html.haml
+++ b/app/views/lexicon/verification/_person_sections.html.haml
@@ -165,6 +165,9 @@
               - if pub_detail
                 %br
                 %span.text-muted= pub_detail
+              - if work.comment.present?
+                %br
+                %span.text-muted!= render_person_work_comment(work.comment, work.comment_links)
               - if work.publication.present?
                 %br
                 %span.text-muted
@@ -178,9 +181,6 @@
               - work.linked_people.sort_by(&:sort_value).each do |linked_person|
                 %br
                 %span.text-muted!= render_linked_person(linked_person)
-              - if work.comment.present?
-                %br
-                %span.text-muted!= render_person_work_comment(work.comment, work.comment_links)
             .work-actions.mt-2
               %button.btn.btn-sm.btn-outline-primary{ onclick: "openWorkEditPanel('#{edit_lexicon_work_path(work)}', function() { reloadScrollingToSection('section-works'); })" }
                 ✏️

--- a/app/views/lexicon/verification/_person_sections.html.haml
+++ b/app/views/lexicon/verification/_person_sections.html.haml
@@ -204,7 +204,7 @@
                   %strong= publication.title
                   - pub_details = [publication.publisher_line, publication.pub_year].compact_blank.join(', ')
                   - if pub_details.present?
-                    %span.text-muted= pub_details
+                    %span.text-muted= " #{pub_details}"
                 %button.btn.btn-sm.btn-outline-warning.monday-missing-work-btn.ms-2{ type: 'button', data: { 'publication-id': publication.id, 'report-url': lexicon_report_to_monday_verification_path(entry) } }
                   = t('lexicon.verification.monday.missing_work_button')
 

--- a/app/views/lexicon/verification/_person_sections.html.haml
+++ b/app/views/lexicon/verification/_person_sections.html.haml
@@ -188,11 +188,25 @@
               %button.btn.btn-sm{ class: checklist['works']&.dig('items', work.id.to_s, 'verified') ? 'btn-success' : 'btn-outline-success', data: { action: 'click->verification#quickVerify', path: "works.items.#{work.id}" } }
                 ✓
                 = t('lexicon.verification.migrated.mark_verified')
-              - if work.publication.present?
-                %button.btn.btn-sm.btn-outline-warning.monday-missing-work-btn{ type: 'button', data: { 'work-title': work.title, 'report-url': lexicon_report_to_monday_verification_path(entry) } }
-                  = t('lexicon.verification.monday.missing_work_button')
     - else
       %p.text-muted= t('lexicon.verification.sections.no_works')
+    -# Publications known in BYP but absent from the lexicon entry — reportable, not part of the checklist
+    - unmatched_publications = item.unmatched_publications
+    - if unmatched_publications.any?
+      %h5.mt-3.mb-1.work-type-heading= t('lexicon.verification.sections.unmatched_publications_heading')
+      .work-card#unmatched-publications-card
+        .work-content
+          %p.text-muted= t('lexicon.verification.sections.unmatched_publications_intro')
+          %ul.list-unstyled.mb-0
+            - unmatched_publications.each do |publication|
+              %li.unmatched-publication.mb-2{ id: "unmatched-publication-#{publication.id}" }
+                %span{ dir: text_dir(publication.title.to_s) }
+                  %strong= publication.title
+                  - pub_details = [publication.publisher_line, publication.pub_year].compact_blank.join(', ')
+                  - if pub_details.present?
+                    %span.text-muted= pub_details
+                %button.btn.btn-sm.btn-outline-warning.monday-missing-work-btn.ms-2{ type: 'button', data: { 'publication-id': publication.id, 'report-url': lexicon_report_to_monday_verification_path(entry) } }
+                  = t('lexicon.verification.monday.missing_work_button')
 
 -# Section 4: Citations (מראי מקום)
 .section.verification-section{id: 'section-citations', class: checklist['citations']&.dig('verified') ? 'verified' : 'not-verified'}

--- a/config/locales/lexicon.en.yml
+++ b/config/locales/lexicon.en.yml
@@ -365,3 +365,4 @@ en:
         general_name: See extended description
         missing_work_name: "The work %{title} is known in the bibliography but does not appear in the lexicon entry."
         missing_work_details: "Publisher: %{publisher}. Year: %{year}."
+        missing_work_reported: "Already reported"

--- a/config/locales/lexicon.en.yml
+++ b/config/locales/lexicon.en.yml
@@ -287,6 +287,8 @@ en:
         close: "Close"
         work_from_publication: "From bibliography:"
         work_from_collection: "From title:"
+        unmatched_publications_heading: "Publications missing from the lexicon entry"
+        unmatched_publications_intro: "The following publications are associated with the authority record but are not matched to any work in the lexicon entry:"
       bio_comparison:
         title: "Biography comparison"
         note: "Both texts are shown with HTML tags and punctuation stripped, so they are not editable here. Differing words are highlighted. To fix a discrepancy, close this dialog and click Edit in the biography pane."
@@ -362,3 +364,4 @@ en:
         link_text: Link to entry under review
         general_name: See extended description
         missing_work_name: "The work %{title} is known in the bibliography but does not appear in the lexicon entry."
+        missing_work_details: "Publisher: %{publisher}. Year: %{year}."

--- a/config/locales/lexicon.he.yml
+++ b/config/locales/lexicon.he.yml
@@ -343,7 +343,7 @@ he:
           other: "%{count} יצירות הותאמו אוטומטית לפרסומים בהתבסס על דמיון בכותרת"
         confirm_match: אשר התאמה
         reject_match: דחה התאמה
-        proposed_collection: "(הצעה: %{title})"
+        proposed_collection: "(כותר: %{title})"
         date_of_manual_update:
           instructions: "הכנס את תאריך העדכון הידני האחרון כפי שמופיע בקובץ המקור. ניתן לתקן אם נקלט בצורה שגויה."
         external_identifiers:

--- a/config/locales/lexicon.he.yml
+++ b/config/locales/lexicon.he.yml
@@ -288,6 +288,8 @@ he:
         close: "סגור"
         work_from_publication: "משויך לביבליוגרפיה:"
         work_from_collection: "משויך לכותר:"
+        unmatched_publications_heading: "פרסומים שאינם בערך הלקסיקון"
+        unmatched_publications_intro: "הפרסומים הבאים משויכים לרשומת הסמכות אך אינם מותאמים לאף יצירה בערך הלקסיקון:"
       bio_comparison:
         title: "השוואת ביוגרפיה"
         note: "שני הטקסטים מוצגים ללא תגי HTML וללא סימני פיסוק, ולכן אינם ניתנים לעריכה כאן. מילים שונות מודגשות בצבע. לתיקון אי-התאמה, סגרו חלון זה ולחצו על ״עריכה״ בלוח הביוגרפיה."
@@ -363,3 +365,4 @@ he:
         link_text: קישורית לערך המוסב
         general_name: ראה תיאור נרחב
         missing_work_name: "החיבור %{title} ידוע בביבליוגרפיה אך לא מופיע בערך הלקסיקון."
+        missing_work_details: "מו״ל: %{publisher}. שנת הוצאה: %{year}."

--- a/config/locales/lexicon.he.yml
+++ b/config/locales/lexicon.he.yml
@@ -366,3 +366,4 @@ he:
         general_name: ראה תיאור נרחב
         missing_work_name: "החיבור %{title} ידוע בביבליוגרפיה אך לא מופיע בערך הלקסיקון."
         missing_work_details: "מו״ל: %{publisher}. שנת הוצאה: %{year}."
+        missing_work_reported: "דווח בעבר"

--- a/spec/models/lex_person_spec.rb
+++ b/spec/models/lex_person_spec.rb
@@ -3,6 +3,36 @@
 require 'rails_helper'
 
 describe LexPerson do
+  describe '#unmatched_publications' do
+    let(:authority) { create(:authority) }
+    let(:person) { create(:lex_person, authority: authority) }
+
+    it 'returns an empty relation when the person has no authority' do
+      person = create(:lex_person, authority: nil)
+      create(:publication)
+
+      expect(person.unmatched_publications).to be_empty
+    end
+
+    it "excludes publications linked to one of the person's works" do
+      matched = create(:publication, authority: authority)
+      unmatched = create(:publication, authority: authority)
+      create(:lex_person_work, person: person, publication: matched)
+      create(:lex_person_work, person: person, publication: nil)
+
+      expect(person.unmatched_publications).to contain_exactly(unmatched)
+    end
+
+    it 'ignores publications of other authorities and works of other people' do
+      unmatched = create(:publication, authority: authority)
+      other_authority_pub = create(:publication)
+      create(:lex_person_work, person: create(:lex_person), publication: unmatched)
+
+      expect(person.unmatched_publications).to contain_exactly(unmatched)
+      expect(person.unmatched_publications).not_to include(other_authority_pub)
+    end
+  end
+
   describe '.works_by_type' do
     let(:person) { create(:lex_person) }
     let!(:original_works) { create_list(:lex_person_work, 2, person: person, work_type: :original) }

--- a/spec/models/publication_spec.rb
+++ b/spec/models/publication_spec.rb
@@ -3,6 +3,38 @@
 require 'rails_helper'
 
 RSpec.describe Publication, type: :model do
+  describe 'reporting a publication as missing from its lexicon entry' do
+    let(:publication) { create(:publication) }
+
+    it 'is not reported by default' do
+      expect(publication).not_to be_reported_missing_from_lexicon
+    end
+
+    it 'is reported once flagged, and records the reporting user' do
+      user = create(:user)
+
+      publication.mark_reported_missing_from_lexicon!(user)
+
+      expect(publication.reload).to be_reported_missing_from_lexicon
+      expect(ListItem.find_by(listkey: described_class::LEX_REPORTED_MISSING_LISTKEY, item: publication).user)
+        .to eq(user)
+    end
+
+    it 'is idempotent' do
+      publication.mark_reported_missing_from_lexicon!
+      publication.mark_reported_missing_from_lexicon!
+
+      expect(ListItem.where(listkey: described_class::LEX_REPORTED_MISSING_LISTKEY, item: publication).count).to eq(1)
+    end
+
+    it 'does not flag other publications' do
+      other = create(:publication)
+      publication.mark_reported_missing_from_lexicon!
+
+      expect(other.reload).not_to be_reported_missing_from_lexicon
+    end
+  end
+
   describe '.update_publications_that_may_be_done_list' do
     subject(:run) { described_class.update_publications_that_may_be_done_list }
 

--- a/spec/requests/lexicon/verification_monday_report_spec.rb
+++ b/spec/requests/lexicon/verification_monday_report_spec.rb
@@ -28,10 +28,12 @@ RSpec.describe 'POST /lex/verification/:id/report_to_monday', type: :request do
     end
 
     it 'delegates to the MondayReport service for a missing_work report' do
-      post url, params: { type: 'missing_work', work_title: 'שיר ערש' }, as: :json
+      publication = create(:publication, title: 'שיר ערש')
+
+      post url, params: { type: 'missing_work', publication_id: publication.id }, as: :json
 
       expect(Lexicon::MondayReport).to have_received(:call).with(
-        hash_including(report_type: :missing_work, work_title: 'שיר ערש')
+        hash_including(report_type: :missing_work, publication: publication)
       )
     end
 

--- a/spec/requests/lexicon/verification_monday_report_spec.rb
+++ b/spec/requests/lexicon/verification_monday_report_spec.rb
@@ -37,6 +37,19 @@ RSpec.describe 'POST /lex/verification/:id/report_to_monday', type: :request do
       )
     end
 
+    it 'flags the publication as reported so it is not offered again' do
+      publication = create(:publication)
+
+      post url, params: { type: 'missing_work', publication_id: publication.id }, as: :json
+
+      expect(publication.reload).to be_reported_missing_from_lexicon
+    end
+
+    it 'does not flag anything for a general report' do
+      expect { post url, params: { type: 'general', description: 'notes' }, as: :json }
+        .not_to(change { ListItem.where(listkey: Publication::LEX_REPORTED_MISSING_LISTKEY).count })
+    end
+
     it 'returns 200 with success message on success' do
       post url, params: { type: 'general', description: 'notes' }, as: :json
 
@@ -64,6 +77,14 @@ RSpec.describe 'POST /lex/verification/:id/report_to_monday', type: :request do
 
       expect(response).to have_http_status(:unprocessable_content)
       expect(response.parsed_body['error']).to eq('API error')
+    end
+
+    it 'does not flag the publication as reported' do
+      publication = create(:publication)
+
+      post url, params: { type: 'missing_work', publication_id: publication.id }, as: :json
+
+      expect(publication.reload).not_to be_reported_missing_from_lexicon
     end
   end
 end

--- a/spec/requests/lexicon/verification_unmatched_publications_spec.rb
+++ b/spec/requests/lexicon/verification_unmatched_publications_spec.rb
@@ -43,6 +43,16 @@ RSpec.describe 'Lexicon::Verification unmatched publications card', type: :reque
       expect(response.body.scan('monday-missing-work-btn').size).to eq(1)
     end
 
+    it 'shows a label instead of the report button once the publication was reported' do
+      unmatched.mark_reported_missing_from_lexicon!
+
+      get "/lex/verification/#{entry.id}"
+
+      expect(response.body).to include('ספר לא מותאם')
+      expect(response.body).to include(I18n.t('lexicon.verification.monday.missing_work_reported'))
+      expect(response.body).not_to include('monday-missing-work-btn')
+    end
+
     it 'does not count the unmatched publication in the works checklist' do
       get "/lex/verification/#{entry.id}"
 

--- a/spec/requests/lexicon/verification_unmatched_publications_spec.rb
+++ b/spec/requests/lexicon/verification_unmatched_publications_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe 'Lexicon::Verification unmatched publications card', type: :request do
+RSpec.describe 'Lexicon::Verification unmatched publications', type: :request do
   before { login_as_lexicon_editor }
 
   let(:authority) { create(:authority, name: 'משה כהן') }
@@ -13,6 +13,7 @@ RSpec.describe 'Lexicon::Verification unmatched publications card', type: :reque
     e
   end
   let(:heading) { I18n.t('lexicon.verification.sections.unmatched_publications_heading') }
+  let(:works_popup_path) { "/lex/verification/#{entry.id}/edit_section?section=works" }
 
   context 'when the authority has a publication not matched to any work' do
     let!(:unmatched) do
@@ -23,30 +24,31 @@ RSpec.describe 'Lexicon::Verification unmatched publications card', type: :reque
 
     before { create(:lex_person_work, person: person, title: 'ספר מותאם', publication: matched) }
 
-    it 'lists only the unmatched publication, with its details and a report button' do
-      get "/lex/verification/#{entry.id}"
+    it 'lists only the unmatched publication in the works popup, with its details and a report button' do
+      get works_popup_path
 
       expect(response.body).to include(heading)
       expect(response.body).to include('ספר לא מותאם')
       expect(response.body).to include('הוצאת דביר, 1948')
       expect(response.body).to include("unmatched-publication-#{unmatched.id}")
+      expect(response.body).to include('monday-missing-work-btn')
       expect(response.body).not_to include("unmatched-publication-#{matched.id}")
     end
 
-    it 'does not render a report button on the regular work cards' do
+    it 'does not render the list, nor any report button, on the verification page itself' do
       work = person.works.first
 
       get "/lex/verification/#{entry.id}"
 
       expect(response.body).to include("work-#{work.id}")
-      # The only missing-work button on the page belongs to the unmatched publication list
-      expect(response.body.scan('monday-missing-work-btn').size).to eq(1)
+      expect(response.body).not_to include(heading)
+      expect(response.body).not_to include('monday-missing-work-btn')
     end
 
     it 'shows a label instead of the report button once the publication was reported' do
       unmatched.mark_reported_missing_from_lexicon!
 
-      get "/lex/verification/#{entry.id}"
+      get works_popup_path
 
       expect(response.body).to include('ספר לא מותאם')
       expect(response.body).to include(I18n.t('lexicon.verification.monday.missing_work_reported'))
@@ -61,13 +63,28 @@ RSpec.describe 'Lexicon::Verification unmatched publications card', type: :reque
     end
   end
 
+  context 'when a publication is already offered as an auto-match proposal' do
+    let!(:proposed) { create(:publication, authority: authority, title: 'ספר מוצע') }
+    let!(:absent) { create(:publication, authority: authority, title: 'ספר נעדר') }
+
+    before { create(:lex_person_work, person: person, title: 'ספר מוצע', publication: nil) }
+
+    it 'lists it among the proposals only, not again as absent from the entry' do
+      get works_popup_path
+
+      expect(assigns(:work_matches).values.pluck(:publication_id)).to include(proposed.id)
+      expect(response.body).to include("unmatched-publication-#{absent.id}")
+      expect(response.body).not_to include("unmatched-publication-#{proposed.id}")
+    end
+  end
+
   context 'when every publication of the authority is matched' do
     let!(:publication) { create(:publication, authority: authority, title: 'ספר מותאם') }
 
     before { create(:lex_person_work, person: person, title: 'ספר מותאם', publication: publication) }
 
-    it 'does not render the card' do
-      get "/lex/verification/#{entry.id}"
+    it 'does not render the list' do
+      get works_popup_path
 
       expect(response.body).not_to include(heading)
     end
@@ -78,8 +95,8 @@ RSpec.describe 'Lexicon::Verification unmatched publications card', type: :reque
 
     before { create(:publication, title: 'ספר של מישהו אחר') }
 
-    it 'does not render the card' do
-      get "/lex/verification/#{entry.id}"
+    it 'does not render the list' do
+      get works_popup_path
 
       expect(response.body).not_to include(heading)
     end

--- a/spec/requests/lexicon/verification_unmatched_publications_spec.rb
+++ b/spec/requests/lexicon/verification_unmatched_publications_spec.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Lexicon::Verification unmatched publications card', type: :request do
+  before { login_as_lexicon_editor }
+
+  let(:authority) { create(:authority, name: 'משה כהן') }
+  let(:person) { create(:lex_person, authority: authority) }
+  let(:entry) do
+    e = create(:lex_entry, :person, lex_item: person, status: :verifying)
+    e.start_verification!('editor@example.com')
+    e
+  end
+  let(:heading) { I18n.t('lexicon.verification.sections.unmatched_publications_heading') }
+
+  context 'when the authority has a publication not matched to any work' do
+    let!(:unmatched) do
+      create(:publication, authority: authority, title: 'ספר לא מותאם',
+                           publisher_line: 'הוצאת דביר', pub_year: '1948')
+    end
+    let!(:matched) { create(:publication, authority: authority, title: 'ספר מותאם') }
+
+    before { create(:lex_person_work, person: person, title: 'ספר מותאם', publication: matched) }
+
+    it 'lists only the unmatched publication, with its details and a report button' do
+      get "/lex/verification/#{entry.id}"
+
+      expect(response.body).to include(heading)
+      expect(response.body).to include('ספר לא מותאם')
+      expect(response.body).to include('הוצאת דביר, 1948')
+      expect(response.body).to include("unmatched-publication-#{unmatched.id}")
+      expect(response.body).not_to include("unmatched-publication-#{matched.id}")
+    end
+
+    it 'does not render a report button on the regular work cards' do
+      work = person.works.first
+
+      get "/lex/verification/#{entry.id}"
+
+      expect(response.body).to include("work-#{work.id}")
+      # The only missing-work button on the page belongs to the unmatched publication list
+      expect(response.body.scan('monday-missing-work-btn').size).to eq(1)
+    end
+
+    it 'does not count the unmatched publication in the works checklist' do
+      get "/lex/verification/#{entry.id}"
+
+      expect(entry.reload.verification_progress.dig('checklist', 'works', 'items').keys)
+        .to contain_exactly(person.works.first.id.to_s)
+    end
+  end
+
+  context 'when every publication of the authority is matched' do
+    let!(:publication) { create(:publication, authority: authority, title: 'ספר מותאם') }
+
+    before { create(:lex_person_work, person: person, title: 'ספר מותאם', publication: publication) }
+
+    it 'does not render the card' do
+      get "/lex/verification/#{entry.id}"
+
+      expect(response.body).not_to include(heading)
+    end
+  end
+
+  context 'when the person has no authority' do
+    let(:person) { create(:lex_person, authority: nil) }
+
+    before { create(:publication, title: 'ספר של מישהו אחר') }
+
+    it 'does not render the card' do
+      get "/lex/verification/#{entry.id}"
+
+      expect(response.body).not_to include(heading)
+    end
+  end
+end

--- a/spec/services/lexicon/monday_report_spec.rb
+++ b/spec/services/lexicon/monday_report_spec.rb
@@ -119,7 +119,9 @@ RSpec.describe Lexicon::MondayReport do
     end
 
     context 'with a missing_work report' do
-      let(:work_title) { 'שיר ערש' }
+      let(:publication) do
+        create(:publication, title: 'שיר ערש', publisher_line: 'הוצאת דביר', pub_year: '1948')
+      end
 
       it 'returns success when Monday API succeeds' do
         stub_monday_success
@@ -127,33 +129,48 @@ RSpec.describe Lexicon::MondayReport do
           entry: entry,
           report_type: :missing_work,
           current_url: current_url,
-          work_title: work_title
+          publication: publication
         )
 
         expect(result[:success]).to be true
       end
 
-      it 'includes the work title in the missing_work_name text' do
+      it 'includes the publication title in the missing_work_name text' do
         captured_body = nil
         stub_monday_success { |req| captured_body = req.body }
-        expected = I18n.t('lexicon.verification.monday.missing_work_name', title: work_title)
+        expected = I18n.t('lexicon.verification.monday.missing_work_name', title: publication.title)
 
         described_class.call(
-          entry: entry, report_type: :missing_work, current_url: current_url, work_title: work_title
+          entry: entry, report_type: :missing_work, current_url: current_url, publication: publication
         )
 
         expect(captured_body).to include(expected)
       end
 
-      it 'omits long_text column' do
+      it 'includes the publisher and year in the long_text column' do
         captured_body = nil
         stub_monday_success { |req| captured_body = req.body }
 
         described_class.call(
-          entry: entry, report_type: :missing_work, current_url: current_url, work_title: work_title
+          entry: entry, report_type: :missing_work, current_url: current_url, publication: publication
         )
 
-        expect(captured_body).not_to include('long_text_mm2tzz8q')
+        expect(captured_body).to include('long_text_mm2tzz8q')
+        expect(JSON.parse(captured_body)['query']).to include('הוצאת דביר').and include('1948')
+      end
+
+      it 'falls back to the unknown label when publisher and year are blank' do
+        publication.update!(publisher_line: nil, pub_year: nil)
+        captured_body = nil
+        stub_monday_success { |req| captured_body = req.body }
+
+        described_class.call(
+          entry: entry, report_type: :missing_work, current_url: current_url, publication: publication
+        )
+
+        expected = I18n.t('lexicon.verification.monday.missing_work_details',
+                          publisher: I18n.t('unknown'), year: I18n.t('unknown'))
+        expect(JSON.parse(captured_body)['query']).to include(expected)
       end
     end
 

--- a/spec/services/lexicon/title_similarity_spec.rb
+++ b/spec/services/lexicon/title_similarity_spec.rb
@@ -33,6 +33,14 @@ RSpec.describe Lexicon::TitleSimilarity do
       .to eq(100)
   end
 
+  it 'ignores Hebrew points' do
+    expect(similarity('הלבן', 'הֵלֵּבָּן')).to eq(100)
+  end
+
+  it 'reads the maqaf as separating two words rather than as a point' do
+    expect(similarity('לין יו־טאנג', 'לין יו-טאנג')).to eq(100)
+  end
+
   it 'ignores word order' do
     expect(similarity('מכתבים אל אמא', 'אל אמא : מכתבים')).to eq(100)
   end

--- a/spec/services/lexicon/title_similarity_spec.rb
+++ b/spec/services/lexicon/title_similarity_spec.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Lexicon::TitleSimilarity do
+  # The score a match proposal must reach to be shown to the editor
+  let(:threshold) { described_class::MATCH_THRESHOLD }
+
+  def similarity(title_a, title_b, ignoring: nil)
+    described_class.call(title_a, title_b, ignoring: ignoring)
+  end
+
+  it 'scores identical titles 100' do
+    expect(similarity('ספר התענוגות', 'ספר התענוגות')).to eq(100)
+  end
+
+  it 'ignores differences in bibliographic punctuation' do
+    expect(similarity('מחזות : חברים מספרים על ישו : כי עודני מאמין בך',
+                      'מחזות: חברים מספרים על ישו ; כי עודני מאמין בך')).to eq(100)
+  end
+
+  it 'ignores the statement of responsibility after the slash' do
+    expect(similarity('חמור הזהב / לוקיוס אפוליאוס', 'חמור הזהב')).to eq(100)
+  end
+
+  it 'ignores the given name wherever it appears' do
+    expect(similarity('Another Book', 'Test Author: Another Book', ignoring: 'Test Author')).to eq(100)
+  end
+
+  # The bibliography credits the author after the title, the lexicon files before it
+  it 'finds the title on either side of the slash' do
+    expect(similarity('ספר התענוגות / עמוס קינן.', 'עמוס קינן / ספר התענוגות', ignoring: 'עמוס קינן'))
+      .to eq(100)
+  end
+
+  it 'ignores word order' do
+    expect(similarity('מכתבים אל אמא', 'אל אמא : מכתבים')).to eq(100)
+  end
+
+  # The case that prompted this scoring: same book, differently punctuated, with a subtitle
+  # present on the bibliography side only.
+  it 'proposes a title that the other side extends with a subtitle' do
+    expect(similarity('בלוק 23 : מכתבים מנס ציונה', 'בלוק 23 ; מכתבים מנס ציונה : נובלות'))
+      .to be >= threshold
+  end
+
+  it 'proposes a title with a spelling variant' do
+    expect(similarity('אין לי עכשיו', 'אין לי עכשו / אבות ישורון')).to be >= threshold
+  end
+
+  it 'proposes a title with a typo' do
+    expect(similarity('The Great Book', 'The Grate Book')).to be >= threshold
+  end
+
+  it 'does not propose unrelated titles' do
+    expect(similarity('Completely Unrelated Title', 'Different Title')).to be < threshold
+  end
+
+  # DamerauLevenshtein#distance gives up at its max_distance argument (10 by default) and
+  # reports that bound rather than the real distance; taken at face value for long titles it
+  # reads as near-identity, and every long publication title matched every work.
+  it 'does not propose unrelated long titles' do
+    expect(similarity('מסע אל תוך הלילה הארוך של אירופה בשנות המלחמה הגדולה',
+                      'שירים מן הגליל העליון ומן העמק בימי ראשית ההתיישבות')).to be < threshold
+  end
+
+  it 'does not propose a title that the other side merely begins with' do
+    expect(similarity('שירים', 'שירים ופזמונות לילדים ולנוער')).to be < threshold
+  end
+
+  it 'scores a blank title 0' do
+    expect(similarity('', 'ספר התענוגות')).to eq(0)
+    expect(similarity(nil, 'ספר התענוגות')).to eq(0)
+  end
+
+  it 'compares the credits themselves when there is nothing else to compare' do
+    expect(similarity(' / אבות ישורון', ' / אבות ישורון')).to eq(100)
+  end
+end

--- a/spec/system/lexicon/verification_missing_publication_report_spec.rb
+++ b/spec/system/lexicon/verification_missing_publication_report_spec.rb
@@ -28,17 +28,28 @@ describe 'Reporting a publication missing from the lexicon entry', :js do
 
   after { FileUtils.rm_f(lex_file.full_path) }
 
-  it 'lists the unmatched publication and removes its report button once reported' do
+  it 'lists the unmatched publication and replaces its report button with a label once reported' do
     expect(page).to have_content(I18n.t('lexicon.verification.sections.unmatched_publications_heading'))
     expect(page).to have_css("#unmatched-publication-#{publication.id} .monday-missing-work-btn")
 
     find("#unmatched-publication-#{publication.id} .monday-missing-work-btn").click
 
     expect(page).to have_no_css("#unmatched-publication-#{publication.id} .monday-missing-work-btn", wait: 5)
-    # The publication itself stays listed, only the button goes away
-    expect(page).to have_css("#unmatched-publication-#{publication.id}")
+    # The publication itself stays listed, with a label in place of the button
+    expect(page).to have_css("#unmatched-publication-#{publication.id} .reported-missing-label",
+                             text: I18n.t('lexicon.verification.monday.missing_work_reported'))
     expect(Lexicon::MondayReport).to have_received(:call).with(
       hash_including(report_type: :missing_work, publication: publication)
     )
+  end
+
+  it 'does not offer the button again after a reload' do
+    find("#unmatched-publication-#{publication.id} .monday-missing-work-btn").click
+    expect(page).to have_css("#unmatched-publication-#{publication.id} .reported-missing-label", wait: 5)
+
+    visit "/lex/verification/#{entry.id}"
+
+    expect(page).to have_css("#unmatched-publication-#{publication.id} .reported-missing-label")
+    expect(page).to have_no_css('.monday-missing-work-btn')
   end
 end

--- a/spec/system/lexicon/verification_missing_publication_report_spec.rb
+++ b/spec/system/lexicon/verification_missing_publication_report_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe 'Reporting a publication missing from the lexicon entry', :js do
+  let!(:authority) { create(:authority, name: 'Test Author') }
+  let!(:person) { create(:lex_person, authority: authority, birthdate: '1900', deathdate: '1980', gender: :male) }
+  let!(:entry) { create(:lex_entry, title: 'Test Author', lex_item: person, status: :draft) }
+  let!(:publication) { create(:publication, authority: authority, title: 'Unmatched Publication') }
+
+  let!(:lex_file) do
+    file_path = Rails.root.join('tmp/test_author_missing_publication.php')
+    File.write(file_path, '<html><body><h1>Test Author</h1></body></html>')
+    create(:lex_file,
+           lex_entry: entry,
+           fname: 'test_author_missing_publication.php',
+           full_path: file_path.to_s,
+           status: :ingested,
+           entrytype: :person)
+  end
+
+  before do
+    skip 'WebDriver not available or misconfigured' unless webdriver_available?
+    allow(Lexicon::MondayReport).to receive(:call).and_return({ success: true })
+    login_as_lexicon_editor
+    visit "/lex/verification/#{entry.id}"
+  end
+
+  after { FileUtils.rm_f(lex_file.full_path) }
+
+  it 'lists the unmatched publication and removes its report button once reported' do
+    expect(page).to have_content(I18n.t('lexicon.verification.sections.unmatched_publications_heading'))
+    expect(page).to have_css("#unmatched-publication-#{publication.id} .monday-missing-work-btn")
+
+    find("#unmatched-publication-#{publication.id} .monday-missing-work-btn").click
+
+    expect(page).to have_no_css("#unmatched-publication-#{publication.id} .monday-missing-work-btn", wait: 5)
+    # The publication itself stays listed, only the button goes away
+    expect(page).to have_css("#unmatched-publication-#{publication.id}")
+    expect(Lexicon::MondayReport).to have_received(:call).with(
+      hash_including(report_type: :missing_work, publication: publication)
+    )
+  end
+end

--- a/spec/system/lexicon/verification_missing_publication_report_spec.rb
+++ b/spec/system/lexicon/verification_missing_publication_report_spec.rb
@@ -19,6 +19,8 @@ describe 'Reporting a publication missing from the lexicon entry', :js do
            entrytype: :person)
   end
 
+  let(:row_selector) { "#generalDlgBody #unmatched-publication-#{publication.id}" }
+
   before do
     skip 'WebDriver not available or misconfigured' unless webdriver_available?
     allow(Lexicon::MondayReport).to receive(:call).and_return({ success: true })
@@ -28,15 +30,22 @@ describe 'Reporting a publication missing from the lexicon entry', :js do
 
   after { FileUtils.rm_f(lex_file.full_path) }
 
+  # The list lives at the bottom of the works auto-match popup
+  def open_works_popup
+    click_button I18n.t('lexicon.verification.sections.auto_match_works_btn')
+    expect(page).to have_css('#generalDlgBody',
+                             text: I18n.t('lexicon.verification.sections.unmatched_publications_heading'))
+  end
+
   it 'lists the unmatched publication and replaces its report button with a label once reported' do
-    expect(page).to have_content(I18n.t('lexicon.verification.sections.unmatched_publications_heading'))
-    expect(page).to have_css("#unmatched-publication-#{publication.id} .monday-missing-work-btn")
+    open_works_popup
+    expect(page).to have_css("#{row_selector} .monday-missing-work-btn", visible: :visible)
 
-    find("#unmatched-publication-#{publication.id} .monday-missing-work-btn").click
+    find("#{row_selector} .monday-missing-work-btn").click
 
-    expect(page).to have_no_css("#unmatched-publication-#{publication.id} .monday-missing-work-btn", wait: 5)
+    expect(page).to have_no_css("#{row_selector} .monday-missing-work-btn", wait: 5)
     # The publication itself stays listed, with a label in place of the button
-    expect(page).to have_css("#unmatched-publication-#{publication.id} .reported-missing-label",
+    expect(page).to have_css("#{row_selector} .reported-missing-label",
                              text: I18n.t('lexicon.verification.monday.missing_work_reported'))
     expect(Lexicon::MondayReport).to have_received(:call).with(
       hash_including(report_type: :missing_work, publication: publication)
@@ -44,12 +53,14 @@ describe 'Reporting a publication missing from the lexicon entry', :js do
   end
 
   it 'does not offer the button again after a reload' do
-    find("#unmatched-publication-#{publication.id} .monday-missing-work-btn").click
-    expect(page).to have_css("#unmatched-publication-#{publication.id} .reported-missing-label", wait: 5)
+    open_works_popup
+    find("#{row_selector} .monday-missing-work-btn").click
+    expect(page).to have_css("#{row_selector} .reported-missing-label", wait: 5)
 
     visit "/lex/verification/#{entry.id}"
+    open_works_popup
 
-    expect(page).to have_css("#unmatched-publication-#{publication.id} .reported-missing-label")
+    expect(page).to have_css("#{row_selector} .reported-missing-label")
     expect(page).to have_no_css('.monday-missing-work-btn')
   end
 end


### PR DESCRIPTION
## Problem

The `missing_work` (report-to-Monday) button was rendered on every `LexPersonWork` card **that had a linked `Publication`** — i.e. exactly the works that *are* present in the lexicon. That's backwards and not the intended feature.

## What we actually want

Report **Publications we hold in BYP that are absent from the legacy PHP lexicon files** — and, while we are in the works-matching workflow, propose the near-matches the old scoring was missing.

## Changes

### Reporting publications missing from the entry

- **Removed** the per-work button from regular `LexPersonWork` cards.
- **`LexPerson#unmatched_publications`** — the associated Authority's `Publication`s not linked to any of that person's works (ordered by title; empty relation when there is no Authority).
- **Listed at the bottom of the works auto-match popup**, below the proposed matches and separated by an `hr`: title, publisher, year, and a report button per line. Publications already offered as a match proposal above are excluded, so each publication appears once. Rendered only when the person has an Authority *and* something is left over. The list is **not** part of the works checklist, so reporting never affects verification status or counts.
- **`Lexicon::MondayReport`** now takes `publication:` instead of `work_title:`: the publication's title goes into the Monday item name, and publisher/year into the description column (falling back to the `unknown` label when blank). The controller resolves `publication_id` from params.
- **Reports are persisted** so the button does not come back on reload: a successful report flags the publication with a `ListItem` (`listkey: 'lex_reported_missing'`, recording the reporting user), following the existing `pubs_maybe_done` pattern — no migration needed. The flag is set only after the Monday call succeeds. Reported publications stay listed (the gap is still real) but show an "already reported" label instead of the button, both server-rendered and immediately after the AJAX call.

### Matching work titles to publication titles

The two databases describe the same book differently, and comparing the raw strings missed obvious matches — `בלוק 23 : מכתבים מנס ציונה` scored 50% against the same book catalogued as `בלוק 23 ; מכתבים מנס ציונה : נובלות`.

- **New `Lexicon::TitleSimilarity`** (extracted from the controller's `normalize_publication_title` / `calculate_similarity`). Titles are reduced to their bare words — authority name dropped, statement of responsibility after the slash dropped (on either side of it, since the lexicon writes `name / title` where the bibliography writes `title / name`), punctuation flattened, points stripped, case folded — and then scored two ways: character-wise via Damerau-Levenshtein, which catches typos and spelling variants, and word-wise via a Jaccard index, which catches an added subtitle or reordered words. The more forgiving score wins, since the editor confirms every proposal before anything is persisted.
- **Fixes a latent bug** found while checking the new scoring against real data: `DamerauLevenshtein#distance` gives up at its `max_distance` argument — **10 by default** — and reports that bound rather than the real distance. The old code was rescued from it only by capping the denominator at 20 characters, which is also precisely what made it blind to longer titles. The distance is now computed with an explicit bound it can never reach.
- Threshold is unchanged at 70%.

Measured over the first 400 entries in development: **23 more proposals, none lost, and no proposal retargeted** to a different publication. Newly proposed pairs are things like `חמור הזהב / לוקיוס אפוליאוס` → `חמור הזהב`, `אין לי עכשיו` → `אין לי עכשו / אבות ישורון`, `שירי אסתר ראב` → `שירי אסתר ראב`, and `הֵלֵּבָּן` → `הלבן`.

### Other

- New i18n keys in both `lexicon.he.yml` and `lexicon.en.yml`; the auto-match proposed collection is now labelled `כותר`.
- Added `.claude/rules/full-test-suite-runtime.md` documenting that the full RSpec suite takes 40+ minutes and should only be run with the maintainer's approval.

## Tests

New/updated, all passing:

- `spec/services/lexicon/title_similarity_spec.rb` — punctuation, Hebrew points (and the maqaf, which separates rather than decorates), subtitle, credits on either side of the slash, word order, typos and spelling variants, plus guards that unrelated titles (**including long ones**, the `max_distance` regression) stay below the threshold
- `spec/models/lex_person_spec.rb` — `#unmatched_publications` (no authority, matched excluded, other authorities/people ignored)
- `spec/models/publication_spec.rb` — the reported flag: default off, idempotent, records the user, doesn't leak to other publications
- `spec/requests/lexicon/verification_unmatched_publications_spec.rb` — the popup lists only what is left over, with details and a button; the verification page itself renders neither; label instead of button once reported; a publication already proposed as a match is not listed twice; nothing added to the works checklist; absent when everything is matched or there is no Authority
- `spec/requests/lexicon/verification_monday_report_spec.rb` — controller passes the `Publication` to the service; flags it on success; does not flag on failure or for general reports
- `spec/system/lexicon/verification_missing_publication_report_spec.rb` (`js: true`) — opening the popup, reporting, the button swapped for a label, and still gone after a reload
- `spec/services/lexicon/monday_report_spec.rb` — publication title in the item name, publisher/year in the long_text column, `unknown` fallback

```
bundle exec rspec spec/requests/lexicon/ spec/services/lexicon/   # 418 examples, 0 failures
bundle exec rspec spec/models/lex_person_spec.rb spec/models/publication_spec.rb
bundle exec rspec spec/system/lexicon/verification_auto_matching_spec.rb \
  spec/system/lexicon/verification_works_modal_spec.rb \
  spec/system/lexicon/verification_workbench_spec.rb \
  spec/system/lexicon/verification_section_shortcuts_spec.rb \
  spec/system/lexicon/verification_missing_publication_report_spec.rb   # 0 failures
```

RuboCop and haml-lint clean on all touched lines.

**Not run:** the full suite — it takes 40+ minutes and was left for CI / maintainer approval.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

