### PR TITLE
Verification: delete links, works tally placement, translated-works headers

### DIFF
--- a/app/assets/stylesheets/verification.scss
+++ b/app/assets/stylesheets/verification.scss
@@ -298,6 +298,14 @@ body:has(.verification-container) {
       font-weight: 600;
     }
 
+    // Title plus its verified/total tally, kept together at the start of the header
+    // (Bootstrap 4 has no gap-* utilities, hence the explicit gap here).
+    .section-title-group {
+      display: flex;
+      align-items: center;
+      gap: 1rem;
+    }
+
     .verification-badge {
       font-size: 0.85rem;
       padding: 0.25rem 0.75rem;

--- a/app/controllers/lexicon/links_controller.rb
+++ b/app/controllers/lexicon/links_controller.rb
@@ -47,7 +47,9 @@ module Lexicon
     end
 
     def destroy
+      link_id = @link.id
       @link.destroy!
+      @item.entry&.remove_link_from_checklist!(link_id)
     end
 
     private

--- a/app/models/lex_entry.rb
+++ b/app/models/lex_entry.rb
@@ -270,6 +270,25 @@ class LexEntry < ApplicationRecord
     end
   end
 
+  # Remove a single link from the verification checklist (called synchronously when a link is destroyed),
+  # so the deleted link stops counting towards the section's verified/total tally.
+  def remove_link_from_checklist!(link_id)
+    with_lock do
+      return if verification_progress.blank?
+
+      progress = verification_progress.deep_dup
+      checklist = progress['checklist']
+      return unless checklist&.dig('links', 'items')&.key?(link_id.to_s)
+
+      checklist['links']['items'].delete(link_id.to_s)
+      # When the last link is deleted, keep whatever verified state the section had:
+      # a zero-link section can legitimately be marked verified by hand.
+      auto_verify_collections!(checklist) if checklist['links']['items'].any?
+      progress['last_updated_at'] = Time.current.iso8601
+      update!(verification_progress: progress)
+    end
+  end
+
   # Mark all works as verified (called when marking entire works section as verified)
   def mark_all_works_verified!(notes = '')
     return unless lex_item_type == 'LexPerson'

--- a/app/services/lexicon/extract_person_works.rb
+++ b/app/services/lexicon/extract_person_works.rb
@@ -7,7 +7,10 @@ module Lexicon
 
     WORK_TYPE_HEADERS = {
       'edited' => ['כתיבה, עריכה ושכתוב:', 'עריכה:', 'עריכה: (מבחר)'],
-      'translated' => ['תרגום:'],
+      # 'תרגומים לשפות זרות:' and its kin are deliberately absent — those sections list
+      # translations *of* the person's works, which stay 'original'.
+      'translated' => ['תרגום:', 'תרגומים:', 'תרגומיו:', 'תרגומיה:',
+                       'ספרים בתרגומו:', 'ספרים בתרגומה:'],
       'festschrift' => ['ספר זכרון:', 'ספרי יובל', 'ספרי יובל:',
                         'ספרי יובל וזכרון', 'ספרי יובל וזכרון:', 'ספרי יובל וזיכרון:']
     }.freeze

--- a/app/views/lexicon/links/destroy.js
+++ b/app/views/lexicon/links/destroy.js
@@ -1,1 +1,7 @@
-reloadContent($('#links'));
+if ($('#links').length) {
+  // Entry-edit view: lazy-reload just the links section
+  reloadContent($('#links'));
+} else {
+  // Verification view: the deleted card lives in the migrated pane, so reload the page
+  reloadPage();
+}

--- a/app/views/lexicon/verification/_person_sections.html.haml
+++ b/app/views/lexicon/verification/_person_sections.html.haml
@@ -139,14 +139,16 @@
 -# Section 3: Works — one card per work, like citations
 .section.verification-section{id: 'section-works', class: checklist['works']&.dig('verified') ? 'verified' : 'not-verified'}
   .section-header
-    %h5= t('lexicon.verification.sections.works_section')
-    .d-flex.align-items-center.gap-2
+    -# The verified/total tally sits next to the section title, not beside the auto-match button,
+    -# so it reads as a property of the section rather than of the button.
+    .section-title-group
+      %h5= t('lexicon.verification.sections.works_section')
       .verification-badge{ class: checklist['works']&.dig('verified') ? 'verified' : 'not-verified' }
         - verified_count = checklist['works']&.dig('items')&.count { |_k, v| v['verified'] } || 0
         - total_count = checklist['works']&.dig('items')&.size || 0
         = total_count > 0 ? "#{verified_count}/#{total_count} #{t('lexicon.verification.migrated.verified')}" : t('lexicon.verification.migrated.verified')
-      %button.btn.btn-sm.btn-outline-secondary{ onclick: "openModal('#{lexicon_edit_section_verification_path(entry, section: 'works')}', function() { reloadScrollingToSection('section-works'); })" }
-        = t('lexicon.verification.sections.auto_match_works_btn')
+    %button.btn.btn-sm.btn-outline-secondary{ onclick: "openModal('#{lexicon_edit_section_verification_path(entry, section: 'works')}', function() { reloadScrollingToSection('section-works'); })" }
+      = t('lexicon.verification.sections.auto_match_works_btn')
   .section-content
     - all_works = item.works.includes(:publication, :collection)
     - works_size = all_works.size
@@ -313,6 +315,7 @@
             %button.btn.btn-sm{class: checklist['links']&.dig('items', link.id.to_s, 'verified') ? 'btn-success' : 'btn-outline-success', data: {action: 'click->verification#quickVerify', path: "links.items.#{link.id}"}}
               ✓
               = t('lexicon.verification.migrated.mark_verified')
+            = link_to t('lexicon.verification.migrated.delete_link'), lexicon_link_path(link), remote: true, method: :delete, class: 'btn btn-sm btn-outline-danger delete-link', data: { confirm: t('lexicon.verification.migrated.delete_link_confirm') }
     - else
       %p.text-muted= t('lexicon.verification.sections.no_links')
   .section-actions

--- a/app/views/lexicon/verification/_publication_sections.html.haml
+++ b/app/views/lexicon/verification/_publication_sections.html.haml
@@ -133,6 +133,7 @@
             %button.btn.btn-sm{class: checklist['links']&.dig('items', link.id.to_s, 'verified') ? 'btn-success' : 'btn-outline-success', data: {action: 'click->verification#quickVerify', path: "links.items.#{link.id}"}}
               ✓
               = t('lexicon.verification.migrated.mark_verified')
+            = link_to t('lexicon.verification.migrated.delete_link'), lexicon_link_path(link), remote: true, method: :delete, class: 'btn btn-sm btn-outline-danger delete-link', data: { confirm: t('lexicon.verification.migrated.delete_link_confirm') }
     - else
       %p.text-muted= t('lexicon.verification.sections.no_links')
   .section-actions

--- a/config/locales/lexicon.en.yml
+++ b/config/locales/lexicon.en.yml
@@ -240,6 +240,8 @@ en:
         edit: Edit
         add_citation: Add Citation
         add_link: Add Link
+        delete_link: Delete Link
+        delete_link_confirm: Permanently delete this link?
         upload_file: Upload File
         remove_attachment: Remove
         profile_image_badge: Profile Image

--- a/config/locales/lexicon.he.yml
+++ b/config/locales/lexicon.he.yml
@@ -241,6 +241,8 @@ he:
         edit: ערוך
         add_citation: הוסף מראה מקום
         add_link: הוסף קישור
+        delete_link: מחק קישור
+        delete_link_confirm: למחוק את הקישורית לצמיתות?
         upload_file: העלה קובץ
         remove_attachment: הסר קובץ
         profile_image_badge: תמונת פרופיל

--- a/spec/models/lex_entry_spec.rb
+++ b/spec/models/lex_entry_spec.rb
@@ -140,6 +140,52 @@ RSpec.describe LexEntry, type: :model do
       end
     end
 
+    describe '#remove_link_from_checklist!' do
+      let!(:link1) { create(:lex_link, item: person) }
+      let!(:link2) { create(:lex_link, item: person) }
+
+      before do
+        person.reload
+        entry.start_verification!('test@example.com')
+      end
+
+      it 'removes the link ID from checklist items' do
+        link1.destroy!
+        entry.remove_link_from_checklist!(link1.id)
+
+        items = entry.reload.verification_progress.dig('checklist', 'links', 'items')
+        expect(items[link1.id.to_s]).to be_nil
+        expect(items[link2.id.to_s]).to be_present
+      end
+
+      it 'does nothing when the link ID is not in the checklist' do
+        expect { entry.remove_link_from_checklist!(999_999) }.not_to raise_error
+      end
+
+      it 'auto-verifies the section when all remaining links are verified' do
+        entry.update_checklist_item("links.items.#{link2.id}", true)
+
+        link1.destroy!
+        entry.remove_link_from_checklist!(link1.id)
+
+        expect(entry.reload.verification_progress.dig('checklist', 'links', 'verified')).to be true
+      end
+
+      it 'keeps the links section verified when the last verified link goes' do
+        entry.update_checklist_item("links.items.#{link1.id}", true)
+        entry.update_checklist_item("links.items.#{link2.id}", true)
+
+        [link1, link2].each do |link|
+          link.destroy!
+          entry.remove_link_from_checklist!(link.id)
+        end
+
+        progress = entry.reload.verification_progress
+        expect(progress.dig('checklist', 'links', 'items')).to be_empty
+        expect(progress.dig('checklist', 'links', 'verified')).to be true
+      end
+    end
+
     describe '#verification_percentage' do
       let!(:work1) { create(:lex_person_work, person: person, title: 'Work 1') }
       let!(:work2) { create(:lex_person_work, person: person, title: 'Work 2') }

--- a/spec/requests/lexicon/links_spec.rb
+++ b/spec/requests/lexicon/links_spec.rb
@@ -153,5 +153,28 @@ describe '/lexicon/links' do
       expect { call }.to change { person.links.count }.by(-1)
       expect(call).to eq(200)
     end
+
+    it 'reloads the whole page when not in the entry-edit view' do
+      call
+      expect(response.body).to include('reloadPage()')
+    end
+
+    context 'when the entry is under verification' do
+      before { entry.start_verification!('editor@example.com') }
+
+      it 'drops the deleted link from the verification checklist' do
+        expect { call }
+          .to change { entry.reload.verification_progress.dig('checklist', 'links', 'items').keys }
+          .from(match_array(links.map { |l| l.id.to_s }))
+          .to(match_array(links.drop(1).map { |l| l.id.to_s }))
+      end
+
+      it 'verifies the links section once only verified links remain' do
+        links.drop(1).each { |l| entry.update_checklist_item("links.items.#{l.id}", true) }
+        expect { call }
+          .to change { entry.reload.verification_progress.dig('checklist', 'links', 'verified') }
+          .from(false).to(true)
+      end
+    end
   end
 end

--- a/spec/requests/lexicon/verification_spec.rb
+++ b/spec/requests/lexicon/verification_spec.rb
@@ -829,5 +829,47 @@ RSpec.describe 'Lexicon::Verification', type: :request do
 
       expect(response.body).to include('1/2')
     end
+
+    it 'places the verified-count badge alongside the section title, not beside the auto-match button' do
+      get "/lex/verification/#{entry.id}"
+
+      header = Nokogiri::HTML(response.body).at_css('#section-works .section-header')
+      title_group = header.element_children.first
+
+      expect(title_group.at_css('h5')).to be_present
+      expect(title_group.at_css('.verification-badge')).to be_present
+      # The auto-match button stays at the opposite end of the header
+      expect(header.element_children.last.name).to eq('button')
+    end
+
+    context 'when the person has both original and translated works' do
+      let!(:translated_work) do
+        create(:lex_person_work, person: person, title: 'A Translation', work_type: 'translated', seqno: 1)
+      end
+
+      before { entry.add_work_to_checklist!(translated_work.id) }
+
+      it 'separates the two kinds under their own headings' do
+        get "/lex/verification/#{entry.id}"
+
+        doc = Nokogiri::HTML(response.body)
+        headings = doc.css('#section-works .work-type-heading').map { |h| h.text.strip }
+
+        expect(headings).to eq([LexPersonWork.human_enum_name(:work_type, 'original'),
+                                LexPersonWork.human_enum_name(:work_type, 'translated')])
+      end
+
+      it 'renders the translated work under the translations heading' do
+        get "/lex/verification/#{entry.id}"
+
+        doc = Nokogiri::HTML(response.body)
+        nodes = doc.css('#section-works .work-type-heading, #section-works .work-card')
+        translated_heading = LexPersonWork.human_enum_name(:work_type, 'translated')
+        translated_heading_index = nodes.index { |n| n.text.strip == translated_heading }
+        translated_card_index = nodes.index { |n| n['id'] == "work-#{translated_work.id}" }
+
+        expect(translated_card_index).to be > translated_heading_index
+      end
+    end
   end
 end

--- a/spec/services/lexicon/extract_person_works_spec.rb
+++ b/spec/services/lexicon/extract_person_works_spec.rb
@@ -96,6 +96,75 @@ describe Lexicon::ExtractPersonWorks do
     end
   end
 
+  context 'when the translations section is headed תרגומים: (plural)' do
+    # Mirrors 00156.php, where the plural header was not recognized and all works
+    # were classified as original, so the pane showed no original/translation split.
+    let(:html) do
+      <<~HTML
+        <p><a name="Books">ספריו:</a></p>
+        <span dir="rtl">
+          <ul>
+            <li>ספר מקורי (תל אביב : דביר, 1990)</li>
+          </ul>
+          <p><font size="4" color="#0000FF">תרגומים:</font></p>
+          <ul>
+            <li>חמור הזהב / לוקיוס אפוליאוס (תל־אביב : ישראל, 1954)</li>
+            <li>מבחר הסיפור הסיני / לין יו־טאנג (תל־אביב : הדר, 1954)</li>
+          </ul>
+        </span>
+      HTML
+    end
+
+    it 'classifies the works under it as translated' do
+      expect(lex_person.works.select(&:work_type_original?).size).to eq(1)
+      expect(lex_person.works.select(&:work_type_translated?).map(&:title))
+        .to contain_exactly('חמור הזהב / לוקיוס אפוליאוס', 'מבחר הסיפור הסיני / לין יו־טאנג')
+    end
+  end
+
+  context 'when the translations section is headed תרגומיו:' do
+    let(:html) do
+      <<~HTML
+        <p><a name="Books">ספריו:</a></p>
+        <span dir="rtl">
+          <ul>
+            <li>ספר מקורי (תל אביב : דביר, 1990)</li>
+          </ul>
+          <p><font>תרגומיו:</font></p>
+          <ul>
+            <li>ספר מתורגם (תל אביב : הוצאה, 2010)</li>
+          </ul>
+        </span>
+      HTML
+    end
+
+    it 'classifies the works under it as translated' do
+      expect(lex_person.works.select(&:work_type_translated?).size).to eq(1)
+    end
+  end
+
+  context 'when a section lists translations of the person’s works into foreign languages' do
+    let(:html) do
+      <<~HTML
+        <p><a name="Books">ספריו:</a></p>
+        <span dir="rtl">
+          <ul>
+            <li>ספר מקורי (תל אביב : דביר, 1990)</li>
+          </ul>
+          <p><font>תרגומים לשפות זרות:</font></p>
+          <ul>
+            <li>His book / translated by Someone (London : Publisher, 1995)</li>
+          </ul>
+        </span>
+      HTML
+    end
+
+    it 'keeps them as original works, since the person did not translate them' do
+      expect(lex_person.works.select(&:work_type_translated?)).to be_empty
+      expect(lex_person.works.select(&:work_type_original?).size).to eq(2)
+    end
+  end
+
   context 'when works list includes a festschrift section' do
     let(:html) do
       <<~HTML

--- a/spec/system/lexicon/verification_link_delete_spec.rb
+++ b/spec/system/lexicon/verification_link_delete_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Deleting a link from the verification page', :js, type: :system do
+  before do
+    skip 'WebDriver not available or misconfigured' unless webdriver_available?
+    login_as_lexicon_editor
+  end
+
+  let(:entry) { create(:lex_entry, :person, status: :draft) }
+  let(:person) { entry.lex_item }
+  let!(:link) { create(:lex_link, item: person, url: 'https://example.com/doomed') }
+  let!(:other_link) { create(:lex_link, item: person, url: 'https://example.com/keeper') }
+
+  def delete_button_for(target)
+    within("#link-#{target.id}") do
+      find('a.delete-link')
+    end
+  end
+
+  it 'asks for confirmation and keeps the link when the confirmation is dismissed' do
+    visit lexicon_verification_path(entry)
+
+    dismiss_confirm(I18n.t('lexicon.verification.migrated.delete_link_confirm')) do
+      delete_button_for(link).click
+    end
+
+    expect(page).to have_css("#link-#{link.id}")
+    expect(person.links.reload).to include(link)
+  end
+
+  it 'deletes the link and reloads the page when the confirmation is accepted' do
+    visit lexicon_verification_path(entry)
+
+    accept_confirm(I18n.t('lexicon.verification.migrated.delete_link_confirm')) do
+      delete_button_for(link).click
+    end
+
+    expect(page).to have_no_css("#link-#{link.id}", wait: 8)
+    expect(page).to have_css("#link-#{other_link.id}")
+    expect(person.links.reload).to contain_exactly(other_link)
+  end
+end

--- a/spec/system/lexicon/verification_works_header_spec.rb
+++ b/spec/system/lexicon/verification_works_header_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# The verified/total tally used to sit at the far end of the works section header,
+# next to the proposed-matches button, which read as if it belonged to that button.
+RSpec.describe 'Works section header layout', :js, type: :system do
+  let(:person) { create(:lex_person) }
+  let(:entry) { create(:lex_entry, :person, status: :draft, lex_item: person) }
+  let!(:work) { create(:lex_person_work, person: person, title: 'A Work', seqno: 1) }
+
+  before do
+    skip 'WebDriver not available or misconfigured' unless webdriver_available?
+    login_as_lexicon_editor
+    entry.start_verification!('test@example.com')
+    visit lexicon_verification_path(entry)
+  end
+
+  it 'renders the tally closer to the section title than to the proposed-matches button' do
+    expect(page).to have_css('#section-works .section-header .verification-badge', text: '0/1')
+
+    distances = page.evaluate_script(<<~JS)
+      (function() {
+        var header = document.querySelector('#section-works .section-header');
+        var gap = function(a, b) {
+          var ra = a.getBoundingClientRect(), rb = b.getBoundingClientRect();
+          return Math.max(rb.left - ra.right, ra.left - rb.right);
+        };
+        var title = header.querySelector('h5');
+        var badge = header.querySelector('.verification-badge');
+        var button = header.querySelector('button');
+        return { toTitle: gap(title, badge), toButton: gap(badge, button) };
+      })()
+    JS
+
+    expect(distances['toTitle']).to be < distances['toButton']
+    # "adequately spaced": not glued to the title either
+    expect(distances['toTitle']).to be >= 8
+  end
+end


### PR DESCRIPTION
Three fixes to the migration verification workbench.

## 1. Delete a LexLink from the verification pane

Links could only be edited there. Added a red **מחק קישור** button to each link
card (person and publication panes), guarded by a rails-ujs `data-confirm`.

`destroy.js` now branches: the entry-edit view still lazy-reloads `#links`, the
verification view reloads the page (there is no `#links` container there).

Deleting a link also removes it from the verification checklist
(`LexEntry#remove_link_from_checklist!`), so the section's verified/total tally
and the overall percentage stay truthful. If the deleted link was the last one,
the section keeps whatever verified state it had — a zero-link section can
legitimately be marked verified by hand (see 806f3945).

## 2. Works tally moved next to the section title

The `x/y בדוק` badge sat at the far end of the works header, beside the
proposed-matches button, which made it read as a property of that button. It now
sits immediately after the title, separated by a new `.section-title-group`
(1rem gap). Note the previous `.gap-2` class was a no-op: this app is on
Bootstrap 4, which has no `gap-*` utilities — hence explicit CSS.

## 3. Translations were not separated from original works

Reported for `/lex/verification/5181` (עמוס קינן). The pane *does* group works by
`work_type` under headings — but all 32 of that entry's works are stored as
`original`. Root cause: the source `00156.php` heads its translation list with
**תרגומים:** (plural), and `ExtractPersonWorks::WORK_TYPE_HEADERS` only listed
`תרגום:`, so the parser logged "Unrecognized works section header" and silently
fell back to `original`.

Added the plural/possessive variants (`תרגומים:`, `תרגומיו:`, `תרגומיה:`,
`ספרים בתרגומו:`, `ספרים בתרגומה:`). Deliberately **not** added:
`תרגומים לשפות זרות:` and friends — those list translations *of* the person's
works into other languages, which are correctly `original`.

⚠️ Entry 5181 (and any other already-migrated entry) will only show the split
after re-migration, or after editing `work_type` on the affected works by hand.

## Tests

New/updated:
- `spec/services/lexicon/extract_person_works_spec.rb` — `תרגומים:` and `תרגומיו:`
  classify as translated; `תרגומים לשפות זרות:` stays original
- `spec/models/lex_entry_spec.rb` — `#remove_link_from_checklist!` (removal,
  unknown id, auto-verify, empty-section state)
- `spec/requests/lexicon/links_spec.rb` — DELETE drops the checklist item and
  responds with `reloadPage()`
- `spec/requests/lexicon/verification_spec.rb` — badge grouped with the title;
  original/translated render under separate headings, cards under the right one
- `spec/system/lexicon/verification_link_delete_spec.rb` (new) — confirm accepted
  / dismissed
- `spec/system/lexicon/verification_works_header_spec.rb` (new) — tally is closer
  to the title than to the button, and adequately spaced

Ran: `spec/requests/lexicon`, `spec/services/lexicon`, `spec/models/lex_entry_spec.rb`,
`spec/system/lexicon` (161 examples, 0 failures).

Six failures in `spec/requests/lexicon/files_spec.rb` are pre-existing and
environmental — Elasticsearch marked indices read-only because the dev disk is at
96% (flood-stage watermark). Verified they fail identically on a clean tree.

The full suite (40+ min) was **not** run — needs your go-ahead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)