### PR TITLE
Lexicon: arbitrary text→link pairs for works and citations

### DIFF
--- a/app/controllers/concerns/text_links_concern.rb
+++ b/app/controllers/concerns/text_links_concern.rb
@@ -47,7 +47,10 @@ module TextLinksConcern
     end
 
     url = params[:url].to_s.strip
-    return nil if url.blank? || url.match?(/\Ajavascript:/i) || !url.match?(%r{\A(/|https?://|mailto:)}i)
+    # Same allowlist the ingestion path applies, rather than a denylist of script-bearing
+    # schemes: the url ends up in an href, so anything not known-inert is refused.
+    # (This subsumes the explicit javascript: check of the Copilot autofix it replaces.)
+    return nil unless url.match?(Lexicon::TextLinkExtraction::ALLOWED_URL_PATTERN)
 
     { 'text' => text, 'url' => url }
   end

--- a/app/controllers/concerns/text_links_concern.rb
+++ b/app/controllers/concerns/text_links_concern.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+# Shared add/remove handling for the text→link pairs stored in a JSON column
+# (LexPersonWork#title_links / #comment_links, LexCitation#text_links).
+# A pair is either { 'text' => ..., 'entry_id' => ... } or { 'text' => ..., 'url' => ... };
+# see LexiconHelper#apply_text_links for how they are rendered.
+module TextLinksConcern
+  extend ActiveSupport::Concern
+
+  private
+
+  def add_text_link_to(record, field)
+    pair = text_link_pair
+    return head :unprocessable_content if pair.nil?
+
+    links = Array(record.public_send(field))
+    # a given text can only be linked once, since it is substituted by first occurrence
+    record.update!(field => links + [pair]) if links.none? { |link| link['text'] == pair['text'] }
+
+    head :ok
+  end
+
+  def remove_text_link_from(record, field)
+    # Parse the :index param strictly: a non-numeric value ('abc'.to_i == 0) must not
+    # silently delete the first link.
+    index = Integer(params[:index], exception: false)
+    return head :unprocessable_content if index.nil?
+
+    links = Array(record.public_send(field))
+    links.delete_at(index) if index >= 0 && index < links.size
+    record.update!(field => links.presence)
+
+    head :ok
+  end
+
+  # Builds a link pair from the :text plus either the :entry_id or the :url param,
+  # returning nil when the input cannot form a usable pair.
+  def text_link_pair
+    text = params[:text].to_s.strip
+    return nil if text.blank?
+
+    entry_id = params[:entry_id].presence.to_i
+    if entry_id.positive?
+      return nil unless LexEntry.exists?(id: entry_id)
+
+      return { 'text' => text, 'entry_id' => entry_id }
+    end
+
+    url = params[:url].to_s.strip
+    return nil if url.blank? || url.match?(/\Ajavascript:/i)
+
+    { 'text' => text, 'url' => url }
+  end
+end

--- a/app/controllers/concerns/text_links_concern.rb
+++ b/app/controllers/concerns/text_links_concern.rb
@@ -47,7 +47,7 @@ module TextLinksConcern
     end
 
     url = params[:url].to_s.strip
-    return nil if url.blank? || url.match?(/\Ajavascript:/i)
+    return nil if url.blank? || url.match?(/\Ajavascript:/i) || !url.match?(%r{\A(/|https?://|mailto:)}i)
 
     { 'text' => text, 'url' => url }
   end

--- a/app/controllers/lexicon/citations_controller.rb
+++ b/app/controllers/lexicon/citations_controller.rb
@@ -5,12 +5,13 @@ module Lexicon
   class CitationsController < ApplicationController
     include LockLexEntryConcern
     include LinkCheckingConcern
+    include TextLinksConcern
 
     before_action do
       require_editor('edit_lexicon')
     end
 
-    before_action :set_citation, only: %i(edit update destroy reorder)
+    before_action :set_citation, only: %i(edit update destroy reorder text_links add_text_link remove_text_link)
     before_action :set_person, only: %i(new create index)
     before_action :try_to_lock_record
 
@@ -59,6 +60,16 @@ module Lexicon
 
     def destroy
       @citation.destroy!
+    end
+
+    def text_links; end
+
+    def add_text_link
+      add_text_link_to(@citation, :text_links)
+    end
+
+    def remove_text_link
+      remove_text_link_from(@citation, :text_links)
     end
 
     def reorder
@@ -114,7 +125,7 @@ module Lexicon
     # Only allow a list of trusted parameters through.
     def lex_citation_params
       params.expect(lex_citation: %i(title from_publication pages link backup_url manifestation_id subject
-                                     lex_person_work_id))
+                                     lex_person_work_id notes))
     end
   end
 end

--- a/app/controllers/lexicon/person_works_controller.rb
+++ b/app/controllers/lexicon/person_works_controller.rb
@@ -4,6 +4,7 @@ module Lexicon
   # Controller to work with Lexicon Person Works
   class PersonWorksController < ApplicationController
     include LockLexEntryConcern
+    include TextLinksConcern
 
     before_action do
       require_editor('edit_lexicon')
@@ -62,76 +63,24 @@ module Lexicon
       @person.entry&.remove_work_from_checklist!(work_id)
     end
 
-    def title_links
-      entry_ids = Array(@work.title_links).filter_map { |l| l['entry_id'] }
-      @title_link_entries = LexEntry.where(id: entry_ids).index_by(&:id)
-    end
-
-    def person_entry_for_title_link?(entry)
-      entry&.lex_file&.entrytype_person? || entry&.lex_item_type == 'LexPerson'
-    end
+    def title_links; end
 
     def add_title_link
-      text = params[:text].to_s.strip
-      entry_id = params[:entry_id].to_i
-      entry = LexEntry.find_by(id: entry_id)
-
-      if text.blank? || entry.nil? || !person_entry_for_title_link?(entry)
-        head :unprocessable_content
-        return
-      end
-
-      links = Array(@work.title_links)
-      unless links.any? { |l| l['text'] == text }
-        links << { 'text' => text, 'entry_id' => entry_id }
-        @work.update!(title_links: links)
-      end
-
-      head :ok
+      add_text_link_to(@work, :title_links)
     end
 
     def remove_title_link
-      index = link_index_param
-      return head :unprocessable_content if index.nil?
-
-      links = Array(@work.title_links)
-      links.delete_at(index) if index >= 0 && index < links.size
-      @work.update!(title_links: links.presence)
-      head :ok
+      remove_text_link_from(@work, :title_links)
     end
 
-    def comment_links
-      entry_ids = Array(@work.comment_links).filter_map { |l| l['entry_id'] }
-      @comment_link_entries = LexEntry.where(id: entry_ids).index_by(&:id)
-    end
+    def comment_links; end
 
     def add_comment_link
-      text = params[:text].to_s.strip
-      entry_id = params[:entry_id].to_i
-      entry = LexEntry.find_by(id: entry_id)
-
-      if text.blank? || entry.nil? || !person_entry_for_title_link?(entry)
-        head :unprocessable_content
-        return
-      end
-
-      links = Array(@work.comment_links)
-      unless links.any? { |l| l['text'] == text }
-        links << { 'text' => text, 'entry_id' => entry_id }
-        @work.update!(comment_links: links)
-      end
-
-      head :ok
+      add_text_link_to(@work, :comment_links)
     end
 
     def remove_comment_link
-      index = link_index_param
-      return head :unprocessable_content if index.nil?
-
-      links = Array(@work.comment_links)
-      links.delete_at(index) if index >= 0 && index < links.size
-      @work.update!(comment_links: links.presence)
-      head :ok
+      remove_text_link_from(@work, :comment_links)
     end
 
     def reorder
@@ -168,12 +117,6 @@ module Lexicon
     end
 
     private
-
-    # Parses the :index param as an integer, returning nil when it is missing or not a valid
-    # integer, so a non-numeric value (e.g. 'abc'.to_i == 0) can't silently delete the first link.
-    def link_index_param
-      Integer(params[:index], exception: false)
-    end
 
     def set_person
       @person = LexPerson.find(params[:person_id])

--- a/app/helpers/lexicon_helper.rb
+++ b/app/helpers/lexicon_helper.rb
@@ -87,8 +87,7 @@ module LexiconHelper
     html = ERB::Util.html_escape(text.to_s)
     return html.html_safe if links.empty?
 
-    # Preload all referenced entries in a single query to avoid an N+1 over the links
-    entries = LexEntry.where(id: links.filter_map { |link| link['entry_id'] }).index_by(&:id)
+    entries = text_link_entries(links)
     links.each do |link|
       link_text = link['text']
       next if link_text.blank?
@@ -103,8 +102,15 @@ module LexiconHelper
     html.html_safe
   end
 
+  # Loads the LexEntries referenced by a set of link pairs in one query, so that a list of pairs
+  # can be rendered without an N+1 over their entry_ids.
+  def text_link_entries(links)
+    LexEntry.where(id: Array(links).filter_map { |link| link['entry_id'] }).index_by(&:id)
+  end
+
   # Builds the anchor for a single link pair, or nil when it points nowhere (blank url, or an
-  # entry_id whose LexEntry has since been deleted).
+  # entry_id whose LexEntry has since been deleted). Callers rendering several pairs should build
+  # `entries` once with text_link_entries and pass it in.
   def text_link_anchor(link, entries = nil)
     if link['entry_id'].present?
       entry = entries ? entries[link['entry_id']] : LexEntry.find_by(id: link['entry_id'])

--- a/app/helpers/lexicon_helper.rb
+++ b/app/helpers/lexicon_helper.rb
@@ -6,14 +6,17 @@ module LexiconHelper
     author_bit = lex_citation.authors.sort_by(&:display_name)
                              .map { |author| render_citation_author(author) }.join(', ')
 
+    links = lex_citation.text_links
     title_bit = if lex_citation.link.blank?
-                  lex_citation.title
+                  # text_links are not applied when the whole title is already a link (no nested anchors)
+                  apply_text_links(lex_citation.title, links)
                 else
                   link_to(lex_citation.title, lex_citation.link, target: '_blank', rel: 'noopener noreferrer')
                 end
+    publication_bit = apply_text_links(lex_citation.from_publication, links)
 
     raw "#{author_bit}, #{title_bit}, " \
-        "<u>#{lex_citation.from_publication}</u>#{', עמ\' ' + lex_citation.pages if lex_citation.pages.present?}"
+        "<u>#{publication_bit}</u>#{', עמ\' ' + lex_citation.pages if lex_citation.pages.present?}"
   end
 
   def render_citation_author(author)
@@ -45,16 +48,7 @@ module LexiconHelper
       entry = work.lex_publication.entry
       link_to(entry.title, lexicon_entry_path(entry))
     elsif work.title_links.is_a?(Array) && work.title_links.present?
-      html = ERB::Util.html_escape(work.title)
-      work.title_links.each do |tl|
-        entry = LexEntry.find_by(id: tl['entry_id'])
-        next unless entry
-
-        escaped_text = ERB::Util.html_escape(tl['text'])
-        # Block form of sub avoids interpreting & or \1 in the replacement string
-        html = html.sub(escaped_text) { link_to(tl['text'], lexicon_entry_path(entry)) }
-      end
-      html.html_safe
+      apply_text_links(work.title, work.title_links)
     else
       work.title
     end
@@ -77,25 +71,47 @@ module LexiconHelper
     raw result
   end
 
-  # Renders a work comment, hyperlinking any names listed in comment_links to their LexEntry.
-  # comment_links mirror title_links ([{ 'text' => ..., 'entry_id' => ... }]). Returns an
-  # HTML-safe String with the comment text escaped and matched names replaced by links.
+  # Renders a work comment, hyperlinking any text listed in comment_links.
   def render_person_work_comment(comment, comment_links)
-    links = Array(comment_links)
-    html = ERB::Util.html_escape(comment)
+    apply_text_links(comment, comment_links)
+  end
+
+  # Hyperlinks occurrences of each link pair's text within the given plain text.
+  # A link pair is either { 'text' => ..., 'entry_id' => ... } (a lexicon entry) or
+  # { 'text' => ..., 'url' => ... } (an arbitrary URL). Pairs whose text does not occur in
+  # the given text are simply ignored, which is what lets one set of pairs be applied to
+  # several fields of the same record (e.g. a citation's title and from_publication).
+  # Returns an HTML-safe String with the text escaped and matched occurrences replaced by links.
+  def apply_text_links(text, links)
+    links = Array(links)
+    html = ERB::Util.html_escape(text.to_s)
     return html.html_safe if links.empty?
 
     # Preload all referenced entries in a single query to avoid an N+1 over the links
-    entries = LexEntry.where(id: links.filter_map { |cl| cl['entry_id'] }).index_by(&:id)
-    links.each do |cl|
-      entry = entries[cl['entry_id']]
-      next unless entry
+    entries = LexEntry.where(id: links.filter_map { |link| link['entry_id'] }).index_by(&:id)
+    links.each do |link|
+      link_text = link['text']
+      next if link_text.blank?
 
-      escaped_text = ERB::Util.html_escape(cl['text'])
+      anchor = text_link_anchor(link, entries)
+      next if anchor.nil?
+
+      escaped_text = ERB::Util.html_escape(link_text)
       # Block form of sub avoids interpreting & or \1 in the replacement string
-      html = html.sub(escaped_text) { link_to(cl['text'], lexicon_entry_path(entry)) }
+      html = html.sub(escaped_text) { anchor }
     end
     html.html_safe
+  end
+
+  # Builds the anchor for a single link pair, or nil when it points nowhere (blank url, or an
+  # entry_id whose LexEntry has since been deleted).
+  def text_link_anchor(link, entries = nil)
+    if link['entry_id'].present?
+      entry = entries ? entries[link['entry_id']] : LexEntry.find_by(id: link['entry_id'])
+      entry && link_to(link['text'], lexicon_entry_path(entry))
+    elsif link['url'].present?
+      link_to(link['text'], link['url'], target: '_blank', rel: 'noopener noreferrer')
+    end
   end
 
   def format_publication_details(work)

--- a/app/models/lex_citation.rb
+++ b/app/models/lex_citation.rb
@@ -38,6 +38,13 @@ class LexCitation < ApplicationRecord
     return person_work&.title || subject
   end
 
+  # The displayed prose that text_links pairs are matched against (see
+  # LexiconHelper#apply_text_links). Used to tell an editor when a pair's text
+  # no longer occurs anywhere in the citation.
+  def linkable_text
+    [title, from_publication, notes].compact_blank.join(' ')
+  end
+
   # Returns true if the citation link was checked and is inaccessible: either it
   # returned a 4xx/5xx status, or the host was unreachable (nil status after a
   # check). link_checked_at distinguishes "checked and dead" from "never checked".

--- a/app/services/lexicon/parse_citations.rb
+++ b/app/services/lexicon/parse_citations.rb
@@ -3,6 +3,8 @@
 module Lexicon
   # This service accepts HTML content reprsenting citations list for a Lexicon Entry and parses it using Deep Seek API
   class ParseCitations < ApplicationService
+    include TextLinkExtraction
+
     SYSTEM_PROMPT = <<PROMPT
   User will send you a set of bibliography records in html form, most of them are in Hebrew, but English and other
   languages are possible. Each record represents single work (e.g. book, or article) about a person, or one of this
@@ -33,8 +35,11 @@ module Lexicon
     journal where article was published, etc). You should include there additional information helping to identify
     publication, like year and number of issue for journal article, volume number for multivolume collection, etc.
   - pages - string representing page, or pages interval, e.g. "7", "5-12"
-  - link - (optional) URL of the article or work, from an inline link in the citation text (title or other
-    anchor). Do NOT use the `data-file-link` attribute value for this field.
+  - link - (optional) URL of the work itself, from an inline link on its title (or on other text naming the
+    work itself). Do NOT use a link that belongs to the publication the work appeared in -- a link on the
+    name of the book, collection or journal reported in `from_publication` is NOT the work's link, and when
+    it is the only inline link present `link` must be null. Such links are recovered separately, so nothing
+    is lost by leaving them out. Do NOT use the `data-file-link` attribute value for this field either.
   - backup_url - (optional) if the `<li>` element has a `data-file-link` attribute, set this field to that URL.
     Otherwise leave it null.
   - notes - (optional) some additional notes, not fitting into other fields (like 'First published at...')
@@ -63,8 +68,8 @@ PROMPT
 
     def call(html)
       Rails.logger.info('Parsing citations HTML with LLM API started.')
-      @asterisk_backups = []
-      html = preprocess_asterisk_links(html)
+      @source_items = []
+      html = preprocess_source_items(html)
       chat = RubyLLM.chat(model: 'gpt-4.1-mini')
       chat.with_instructions(SYSTEM_PROMPT).with_params(response_format: { type: :json_object })
 
@@ -104,6 +109,9 @@ PROMPT
       # The LLM is unreliable at copying data-file-link into backup_url, so we
       # recover it deterministically from the asterisk links we captured.
       recover_backup_urls(result)
+      # The LLM only reports one link per citation, so inline links sitting in other parts of the
+      # record (typically the publication the citation appeared in) are recovered separately.
+      assign_text_links(result)
 
       Rails.logger.info('Parsing citations complete.')
       result
@@ -131,31 +139,36 @@ PROMPT
       text&.gsub(/[\u201C\u201D\u05F4]/, 34.chr)&.gsub(/[\u2018\u2019]/, 39.chr)
     end
 
-    def preprocess_asterisk_links(html)
+    # Records every citation <li> of the source -- its text, its inline anchors, and the backup
+    # file its asterisk link points at -- so that data the LLM drops or misfiles can be recovered
+    # deterministically and joined back to the parsed citation. Asterisk anchors are moved into a
+    # data-file-link attribute and removed, since the LLM otherwise mistakes them for the
+    # citation's own link.
+    def preprocess_source_items(html)
       doc = Nokogiri::HTML::DocumentFragment.parse(html)
       modified = false
       doc.css('li').each do |li|
         anchors = own_anchors(li)
         asterisk_links = anchors.select { |a| a.text =~ /\A[[:space:]]*\*[[:space:]]*\z/ }
-        next if asterisk_links.empty?
+        inline_anchors = anchors - asterisk_links
+        backup_href = asterisk_links.map { |a| a['href'] }.find(&:present?)
+        li['data-file-link'] = backup_href if backup_href.present?
 
-        modified = true
-        href = asterisk_links.map { |a| a['href'] }.find(&:present?)
-
-        # Record the asterisk backup before removing the anchors, so we can
-        # re-attach it to the parsed citation deterministically afterwards.
-        # Inline (non-asterisk) hrefs are the citation's own links and serve as
-        # the strongest join key back to the LLM-parsed citation.
-        if href.present?
-          li['data-file-link'] = href
-          inline_hrefs = (anchors - asterisk_links).filter_map { |a| a['href'].presence }
-          @asterisk_backups << {
-            backup_href: href,
+        if backup_href.present? || inline_anchors.present?
+          # Inline (non-asterisk) hrefs are the citation's own links and serve as
+          # the strongest join key back to the LLM-parsed citation.
+          inline_hrefs = inline_anchors.filter_map { |a| a['href'].presence }
+          @source_items << {
+            backup_href: backup_href,
+            anchors: inline_anchors.map { |a| { text: a.text.squish, href: a['href'] } },
             inline_hrefs: inline_hrefs.reject { |h| h.end_with?('.php') || h.start_with?('#') },
             text: own_text(li)
           }
         end
 
+        next if asterisk_links.empty?
+
+        modified = true
         asterisk_links.each(&:remove)
       end
       modified ? doc.to_html : html
@@ -183,23 +196,73 @@ PROMPT
     # once, preferring an exact match on the citation's inline link and falling
     # back to a title/text containment match.
     def recover_backup_urls(citations)
-      return if @asterisk_backups.blank?
-
       assigned = Set.new
-      @asterisk_backups.each do |backup|
-        citation = match_by_link(citations, backup, assigned) ||
-                   match_by_text(citations, backup, assigned)
+      @source_items.each do |item|
+        next if item[:backup_href].blank?
+
+        citation = match_source_item(citations, item, assigned)
         next if citation.nil?
 
-        citation.backup_url = backup[:backup_href]
+        citation.backup_url = item[:backup_href]
         assigned << citation.object_id
       end
     end
 
-    def match_by_link(citations, backup, assigned)
-      return nil if backup[:inline_hrefs].empty?
+    # Restores the inline links of each source <li> that the LLM did not report, as text→link
+    # pairs on the citation it came from. Links already stored in a column of their own (the
+    # citation's link or backup file) or as one of its authors are skipped.
+    def assign_text_links(citations)
+      # Mirrors the guard ParsePersonWork uses for title_links/comment_links: skip quietly on an
+      # environment whose lex_citations table has not been migrated yet, rather than failing the
+      # whole ingestion.
+      return unless LexCitation.new.respond_to?(:text_links=)
 
-      hrefs = backup[:inline_hrefs].map { |h| normalize_url(h) }
+      assigned = Set.new
+      @source_items.each do |item|
+        next if item[:anchors].empty?
+
+        citation = match_source_item(citations, item, assigned)
+        next if citation.nil?
+
+        assigned << citation.object_id
+        links = item[:anchors].filter_map { |anchor| text_link_for(citation, anchor) }
+        citation.text_links = links.uniq { |link| link['text'] }.presence
+      end
+    end
+
+    def text_link_for(citation, anchor)
+      text = anchor[:text]
+      href = anchor[:href]
+      return nil if text.blank? || href.blank?
+      return nil if already_captured?(citation, text, href)
+
+      build_text_link(text, href)
+    end
+
+    # True when the anchor is already preserved elsewhere on the citation: as its own link, as its
+    # backup file, or as one of its authors (who carry their own entry/link).
+    def already_captured?(citation, text, href)
+      return true if [citation.link, citation.backup_url].compact_blank
+                                                         .any? { |url| normalize_url(url) == normalize_url(href) }
+
+      citation.authors.any? do |author|
+        (author.link.present? && normalize_url(author.link) == normalize_url(href)) ||
+          (author.entry.present? && author.entry.id == href_entry_id(href)) ||
+          (author.display_name.present? && normalize_text(author.display_name) == normalize_text(text))
+      end
+    end
+
+    # Finds the citation a source <li> was parsed into: preferring an exact match on the
+    # citation's inline link, and falling back to a title/text containment match. Each citation is
+    # matched at most once per pass.
+    def match_source_item(citations, item, assigned)
+      match_by_link(citations, item, assigned) || match_by_text(citations, item, assigned)
+    end
+
+    def match_by_link(citations, item, assigned)
+      return nil if item[:inline_hrefs].empty?
+
+      hrefs = item[:inline_hrefs].map { |h| normalize_url(h) }
       citations.find do |c|
         c.link.present? && assigned.exclude?(c.object_id) && hrefs.include?(normalize_url(c.link))
       end
@@ -208,12 +271,12 @@ PROMPT
     # Fallback: pick the not-yet-assigned citation whose (sufficiently long)
     # title appears within the source <li> text. Longest title wins to avoid
     # matching a short, generic title contained in several entries.
-    def match_by_text(citations, backup, assigned)
+    def match_by_text(citations, item, assigned)
       candidates = citations.select do |c|
         next false if assigned.include?(c.object_id)
 
         title = normalize_text(c.title)
-        title.length >= 8 && backup[:text].include?(title)
+        title.length >= 8 && item[:text].include?(title)
       end
       candidates.max_by { |c| normalize_text(c.title).length }
     end

--- a/app/services/lexicon/parse_person_work.rb
+++ b/app/services/lexicon/parse_person_work.rb
@@ -4,6 +4,7 @@ module Lexicon
   # Service to parse works of Lexicon Person
   class ParsePersonWork < ApplicationService
     include Rails.application.routes.url_helpers
+    include TextLinkExtraction
 
     # rubocop:disable Style/WordArray
     ROLE_STRINGS = {
@@ -128,8 +129,11 @@ module Lexicon
       return LexLinkedPerson.new(name: name, link_type: link_type, person_entry: find_person_entry(name, element))
     end
 
-    # Scans the HTML element for <a> tags whose text appears in the title portion (not in comment brackets)
-    # and that link to person LexEntries. Returns an array of {text:, entry_id:} hashes.
+    # Scans the HTML element for <a> tags whose text appears in the title portion (not in comment
+    # brackets). Returns an array of {text:, entry_id:} / {text:, url:} hashes. Any target is
+    # accepted -- a lexicon entry of any type (a person, but also a publication or bibliography
+    # entry), or an arbitrary URL -- since the title is stored as plain text and the anchor would
+    # otherwise be lost.
     def extract_title_links(element, title_text)
       links = []
       # Comments in angle brackets are stripped from the line before the title is extracted,
@@ -138,20 +142,16 @@ module Lexicon
       comment_hrefs = Set.new(element.css('font[size="2"] a').pluck('href'))
 
       element.css('a').each do |anchor|
-        href = anchor['href']
-        next unless href&.start_with?(lexicon_entries_path + '/')
         # skip anchors that belong to comment sections
-        next if comment_hrefs.include?(href)
+        next if comment_hrefs.include?(anchor['href'])
 
         link_text = anchor.text.squish
         # Only include if the link text actually appears in the title (not in publication details)
-        next unless title_text.include?(link_text)
+        next unless link_text.present? && title_text.include?(link_text)
+        next if links.any? { |link| link['text'] == link_text }
 
-        entry_id = href.delete_prefix(lexicon_entries_path + '/').to_i
-        entry = LexEntry.find_by(id: entry_id)
-        next unless entry&.lex_file&.entrytype_person?
-
-        links << { 'text' => link_text, 'entry_id' => entry_id }
+        link = build_text_link(link_text, anchor['href'])
+        links << link if link
       end
 
       links.presence
@@ -159,26 +159,19 @@ module Lexicon
 
     # Scans the comment-section <a> tags (inside <font size="2"> wrappers, the same convention
     # extract_title_links relies on to tell comment anchors apart from title anchors) whose text
-    # appears within the given plain comment and that link to person LexEntries. Returns an array
-    # of {text:, entry_id:} hashes so the link can be reconstructed when rendering the
-    # (otherwise plain-text) comment.
+    # appears within the given plain comment. Returns an array of {text:, entry_id:} /
+    # {text:, url:} hashes so the link can be reconstructed when rendering the (otherwise
+    # plain-text) comment.
     def extract_comment_links(comment, element)
       links = []
       element.css('font[size="2"] a').each do |anchor|
-        href = anchor['href']
-        next unless href&.start_with?(lexicon_entries_path + '/')
-
         link_text = anchor.text.squish
-        next if link_text.blank?
         # Only include anchors whose text actually appears in this comment
-        next unless comment.include?(link_text)
-        next if links.any? { |l| l['text'] == link_text }
+        next unless link_text.present? && comment.include?(link_text)
+        next if links.any? { |link| link['text'] == link_text }
 
-        entry_id = href.delete_prefix(lexicon_entries_path + '/').to_i
-        entry = LexEntry.find_by(id: entry_id)
-        next unless entry&.lex_file&.entrytype_person?
-
-        links << { 'text' => link_text, 'entry_id' => entry_id }
+        link = build_text_link(link_text, anchor['href'])
+        links << link if link
       end
       links
     end

--- a/app/services/lexicon/text_link_extraction.rb
+++ b/app/services/lexicon/text_link_extraction.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+module Lexicon
+  # Shared helpers for turning an <a> tag of a legacy lexicon page into a text→link pair
+  # (see LexiconHelper#apply_text_links), used when the surrounding text is stored as plain
+  # text and the anchor would otherwise be lost.
+  module TextLinkExtraction
+    # Builds a { 'text' =>, 'entry_id' | 'url' => } pair, or nil when the anchor cannot be used
+    # (blank text, blank/local-anchor href, or a link to a LexEntry that no longer exists).
+    def build_text_link(text, href)
+      target = text_link_target(href)
+      return nil if text.blank? || target.nil?
+
+      target.merge('text' => text)
+    end
+
+    # Lexicon links have already been rewritten to /lex/entries/:id by Lexicon::ProcessLinks,
+    # so an href pointing there is stored as an entry reference; everything else is stored as a
+    # plain URL. Hrefs that are still relative at this point are legacy paths ProcessLinks could
+    # not resolve (e.g. an un-migrated NNNNN.php page): they are meaningless outside the old site,
+    # and would be resolved against the entry's own path if stored, so they are dropped.
+    def text_link_target(href)
+      return nil if href.blank? || href.start_with?('#')
+
+      entry_id = href_entry_id(href)
+      return { 'entry_id' => entry_id } if entry_id.present? && LexEntry.exists?(id: entry_id)
+      return nil if entry_id.present?
+
+      href.match?(%r{\A(/|https?://|mailto:)}i) ? { 'url' => href } : nil
+    end
+
+    # The LexEntry id an href points at, or nil when it does not point at a lexicon entry.
+    def href_entry_id(href)
+      entries_path = Rails.application.routes.url_helpers.lexicon_entries_path
+      match = href.to_s.match(%r{\A#{Regexp.escape(entries_path)}/(?<entry_id>\d+)})
+      match && match[:entry_id].to_i
+    end
+  end
+end

--- a/app/services/lexicon/text_link_extraction.rb
+++ b/app/services/lexicon/text_link_extraction.rb
@@ -5,6 +5,11 @@ module Lexicon
   # (see LexiconHelper#apply_text_links), used when the surrounding text is stored as plain
   # text and the anchor would otherwise be lost.
   module TextLinkExtraction
+    # A link pair's url is rendered straight into an href, so only schemes that cannot execute
+    # script are accepted: an absolute http(s) URL, a mailto:, or a path on this site. Anything
+    # else (javascript:, data:, vbscript:, ...) is refused rather than sanitized.
+    ALLOWED_URL_PATTERN = %r{\A(/|https?://|mailto:)}i
+
     # Builds a { 'text' =>, 'entry_id' | 'url' => } pair, or nil when the anchor cannot be used
     # (blank text, blank/local-anchor href, or a link to a LexEntry that no longer exists).
     def build_text_link(text, href)
@@ -26,7 +31,7 @@ module Lexicon
       return { 'entry_id' => entry_id } if entry_id.present? && LexEntry.exists?(id: entry_id)
       return nil if entry_id.present?
 
-      href.match?(%r{\A(/|https?://|mailto:)}i) ? { 'url' => href } : nil
+      href.match?(ALLOWED_URL_PATTERN) ? { 'url' => href } : nil
     end
 
     # The LexEntry id an href points at, or nil when it does not point at a lexicon entry.

--- a/app/views/lexicon/citations/_form.html.haml
+++ b/app/views/lexicon/citations/_form.html.haml
@@ -29,8 +29,42 @@
     %span.text-secondary= t('.save_before_adding_authors')
 
 - unless @citation.new_record?
+  %hr
+  %h4= t('lexicon.citations.text_links.section_heading')
+  .border.rounded.p-2#text-links-list
+
   :javascript
     function reloadAuthors() {
       $('#authors-list').load(`/lex/citations/#{@citation.id}/authors`);
     }
     reloadAuthors();
+
+    function reloadCitationTextLinks() {
+      $('#text-links-list').load('#{text_links_lexicon_citation_path(@citation)}');
+    }
+    reloadCitationTextLinks();
+
+    function addCitationTextLink(citationId) {
+      var text = $('#text_link_text').val();
+      var entryId = $('#text_link_entry_id').val();
+      var url = $('#text_link_url').val();
+      if (!text || (!entryId && !url)) { return; }
+      $.ajax({
+        url: '/lex/citations/' + citationId + '/add_text_link',
+        method: 'POST',
+        headers: { 'X-CSRF-Token': $('meta[name="csrf-token"]').attr('content') },
+        data: { text: text, entry_id: entryId, url: url },
+        success: reloadCitationTextLinks
+      });
+    }
+
+    function removeCitationTextLink(citationId, index) {
+      if (!confirm('#{j(t(:are_you_sure))}')) { return; }
+      $.ajax({
+        url: '/lex/citations/' + citationId + '/remove_text_link',
+        method: 'DELETE',
+        headers: { 'X-CSRF-Token': $('meta[name="csrf-token"]').attr('content') },
+        data: { index: index },
+        success: reloadCitationTextLinks
+      });
+    }

--- a/app/views/lexicon/citations/text_links.html.haml
+++ b/app/views/lexicon/citations/text_links.html.haml
@@ -1,0 +1,10 @@
+= render 'lexicon/shared/text_links_editor',
+         links: @citation.text_links,
+         record_id: @citation.id,
+         prefix: 'text_link',
+         list_class: 'text-links-list',
+         text_label: t('lexicon.citations.text_links.text_label'),
+         add_label: t('lexicon.citations.text_links.add_link'),
+         add_fn: 'addCitationTextLink',
+         remove_fn: 'removeCitationTextLink',
+         source_text: @citation.linkable_text

--- a/app/views/lexicon/person_works/_form.html.haml
+++ b/app/views/lexicon/person_works/_form.html.haml
@@ -70,12 +70,13 @@
     function addTitleLink(workId) {
       var text = $('#title_link_text').val();
       var entryId = $('#title_link_entry_id').val();
-      if (!text || !entryId) { return; }
+      var url = $('#title_link_url').val();
+      if (!text || (!entryId && !url)) { return; }
       $.ajax({
         url: '/lex/works/' + workId + '/add_title_link',
         method: 'POST',
         headers: { 'X-CSRF-Token': $('meta[name="csrf-token"]').attr('content') },
-        data: { text: text, entry_id: entryId },
+        data: { text: text, entry_id: entryId, url: url },
         success: reloadTitleLinks
       });
     }
@@ -94,12 +95,13 @@
     function addCommentLink(workId) {
       var text = $('#comment_link_text').val();
       var entryId = $('#comment_link_entry_id').val();
-      if (!text || !entryId) { return; }
+      var url = $('#comment_link_url').val();
+      if (!text || (!entryId && !url)) { return; }
       $.ajax({
         url: '/lex/works/' + workId + '/add_comment_link',
         method: 'POST',
         headers: { 'X-CSRF-Token': $('meta[name="csrf-token"]').attr('content') },
-        data: { text: text, entry_id: entryId },
+        data: { text: text, entry_id: entryId, url: url },
         success: reloadCommentLinks
       });
     }

--- a/app/views/lexicon/person_works/comment_links.html.haml
+++ b/app/views/lexicon/person_works/comment_links.html.haml
@@ -1,38 +1,10 @@
--# haml-lint:disable LineLength
-%ul.comment-links-list.list-unstyled.mb-2
-  - Array(@work.comment_links).each_with_index do |link, idx|
-    - entry = @comment_link_entries[link['entry_id']]
-    %li.d-flex.align-items-center.gap-2.mb-1
-      %span.badge.bg-light.text-dark.border= link['text']
-      %span →
-      - if entry
-        = link_to entry.title, lexicon_entry_path(entry), target: '_blank', rel: 'noopener'
-      - else
-        %span.text-muted= t('lexicon.person_works.comment_links.entry_not_found')
-      %button.btn.btn-sm.btn-outline-danger{ onclick: "removeCommentLink(#{@work.id}, #{idx})" }
-        = t(:delete)
-
-%hr.my-2
-%strong= t('lexicon.person_works.comment_links.add_link')
-.row.g-2.align-items-end.mt-1#add-comment-link-form
-  .col-sm-5
-    = label_tag :comment_link_text, t('lexicon.person_works.comment_links.text_in_comment'), class: 'form-label form-label-sm'
-    = text_field_tag :comment_link_text, nil, class: 'form-control form-control-sm', id: 'comment_link_text', placeholder: t('lexicon.person_works.comment_links.text_placeholder')
-  .col-sm-5
-    = label_tag :comment_link_entry_autocomplete, t('lexicon.person_works.comment_links.target'), class: 'form-label form-label-sm'
-    = hidden_field_tag :comment_link_entry_id, nil, id: 'comment_link_entry_id'
-    = autocomplete_field_tag :comment_link_entry_autocomplete,
-                             nil,
-                             autocomplete_lexicon_entries_path(entry_type: :person),
-                             id_element: '#comment_link_entry_id',
-                             class: 'form-control form-control-sm',
-                             placeholder: t('lexicon.person_works.comment_links.person_placeholder')
-  .col-sm-2
-    %button.btn.btn-sm.btn-primary.w-100{ onclick: "addCommentLink(#{@work.id})" }
-      = t(:add)
-
-:javascript
-  $.ui.autocomplete.prototype._resizeMenu = function () {
-    const ul = this.menu.element;
-    ul.outerWidth(this.element.outerWidth());
-  };
+= render 'lexicon/shared/text_links_editor',
+         links: @work.comment_links,
+         record_id: @work.id,
+         prefix: 'comment_link',
+         list_class: 'comment-links-list',
+         text_label: t('lexicon.person_works.comment_links.text_label'),
+         add_label: t('lexicon.person_works.comment_links.add_link'),
+         add_fn: 'addCommentLink',
+         remove_fn: 'removeCommentLink',
+         source_text: @work.comment

--- a/app/views/lexicon/person_works/title_links.html.haml
+++ b/app/views/lexicon/person_works/title_links.html.haml
@@ -1,38 +1,10 @@
--# haml-lint:disable LineLength
-%ul.title-links-list.list-unstyled.mb-2
-  - Array(@work.title_links).each_with_index do |link, idx|
-    - entry = @title_link_entries[link['entry_id']]
-    %li.d-flex.align-items-center.gap-2.mb-1
-      %span.badge.bg-light.text-dark.border= link['text']
-      %span →
-      - if entry
-        = link_to entry.title, lexicon_entry_path(entry), target: '_blank', rel: 'noopener'
-      - else
-        %span.text-muted= t('lexicon.person_works.title_links.entry_not_found')
-      %button.btn.btn-sm.btn-outline-danger{ onclick: "removeTitleLink(#{@work.id}, #{idx})" }
-        = t(:delete)
-
-%hr.my-2
-%strong= t('lexicon.person_works.title_links.add_link')
-.row.g-2.align-items-end.mt-1#add-title-link-form
-  .col-sm-5
-    = label_tag :title_link_text, t('lexicon.person_works.title_links.text_in_title'), class: 'form-label form-label-sm'
-    = text_field_tag :title_link_text, nil, class: 'form-control form-control-sm', id: 'title_link_text', placeholder: t('lexicon.person_works.title_links.text_placeholder')
-  .col-sm-5
-    = label_tag :title_link_entry_autocomplete, t('lexicon.person_works.title_links.target'), class: 'form-label form-label-sm'
-    = hidden_field_tag :title_link_entry_id, nil, id: 'title_link_entry_id'
-    = autocomplete_field_tag :title_link_entry_autocomplete,
-                             nil,
-                             autocomplete_lexicon_entries_path(entry_type: :person),
-                             id_element: '#title_link_entry_id',
-                             class: 'form-control form-control-sm',
-                             placeholder: t('lexicon.person_works.title_links.person_placeholder')
-  .col-sm-2
-    %button.btn.btn-sm.btn-primary.w-100{ onclick: "addTitleLink(#{@work.id})" }
-      = t(:add)
-
-:javascript
-  $.ui.autocomplete.prototype._resizeMenu = function () {
-    const ul = this.menu.element;
-    ul.outerWidth(this.element.outerWidth());
-  };
+= render 'lexicon/shared/text_links_editor',
+         links: @work.title_links,
+         record_id: @work.id,
+         prefix: 'title_link',
+         list_class: 'title-links-list',
+         text_label: t('lexicon.person_works.title_links.text_label'),
+         add_label: t('lexicon.person_works.title_links.add_link'),
+         add_fn: 'addTitleLink',
+         remove_fn: 'removeTitleLink',
+         source_text: @work.title

--- a/app/views/lexicon/shared/_text_links_editor.html.haml
+++ b/app/views/lexicon/shared/_text_links_editor.html.haml
@@ -1,0 +1,65 @@
+-#
+  haml-lint:disable LineLength
+  Editor for a list of text→link pairs (see LexiconHelper#apply_text_links).
+  Shared by LexPersonWork title_links / comment_links and LexCitation text_links.
+  Locals:
+    links       - array of { 'text' =>, 'entry_id' | 'url' => } hashes
+    record_id   - id of the record owning the links, passed to the JS callbacks
+    prefix      - id prefix for the add-form fields, e.g. 'title_link'
+    list_class  - css class of the <ul> listing the existing pairs
+    text_label  - label of the "text" field, e.g. "Text in title"
+    add_label   - heading of the add-link form
+    add_fn      - name of the JS function adding a link
+    remove_fn   - name of the JS function removing a link
+    source_text - (optional) the text the links are applied to, used to warn about pairs that do not match it
+%ul.list-unstyled.mb-2{ class: list_class }
+  - Array(links).each_with_index do |link, idx|
+    %li.d-flex.align-items-center.gap-2.mb-1
+      %span.badge.bg-light.text-dark.border= link['text']
+      %span →
+      - anchor = text_link_anchor(link)
+      - if anchor
+        = anchor
+      - else
+        %span.text-muted= t('lexicon.text_links.entry_not_found')
+      - if defined?(source_text) && source_text.present? && link['text'].present? && source_text.exclude?(link['text'])
+        %span.text-warning.small.text-not-found= t('lexicon.text_links.text_not_found')
+      %button.btn.btn-sm.btn-outline-danger{ onclick: "#{remove_fn}(#{record_id}, #{idx})" }
+        = t(:delete)
+
+%hr.my-2
+%strong= add_label
+.row.g-2.align-items-end.mt-1{ id: "add-#{prefix.dasherize}-form" }
+  .col-sm-6
+    = label_tag "#{prefix}_text", text_label, class: 'form-label form-label-sm'
+    = text_field_tag "#{prefix}_text", nil, class: 'form-control form-control-sm', id: "#{prefix}_text", placeholder: t('lexicon.text_links.text_placeholder')
+  .col-sm-6
+    = label_tag "#{prefix}_entry_autocomplete", t('lexicon.text_links.target_entry'), class: 'form-label form-label-sm'
+    = hidden_field_tag "#{prefix}_entry_id", nil, id: "#{prefix}_entry_id"
+    = autocomplete_field_tag "#{prefix}_entry_autocomplete",
+                             nil,
+                             autocomplete_lexicon_entries_path,
+                             id_element: "##{prefix}_entry_id",
+                             class: 'form-control form-control-sm',
+                             placeholder: t('lexicon.text_links.entry_placeholder')
+  .col-sm-10
+    = label_tag "#{prefix}_url", t('lexicon.text_links.target_url'), class: 'form-label form-label-sm'
+    = text_field_tag "#{prefix}_url", nil, class: 'form-control form-control-sm', id: "#{prefix}_url", placeholder: t('lexicon.text_links.url_placeholder')
+  .col-sm-2
+    %button.btn.btn-sm.btn-primary.w-100{ onclick: "#{add_fn}(#{record_id})" }
+      = t(:add)
+  .col-12
+    %small.text-muted= t('lexicon.text_links.target_hint')
+
+:javascript
+  $.ui.autocomplete.prototype._resizeMenu = function () {
+    const ul = this.menu.element;
+    ul.outerWidth(this.element.outerWidth());
+  };
+  // Picking an entry and typing a URL are mutually exclusive targets: clear the other one.
+  $('##{prefix}_url').on('input', function() {
+    if ($(this).val()) { $('##{prefix}_entry_id').val(''); $('##{prefix}_entry_autocomplete').val(''); }
+  });
+  $('##{prefix}_entry_autocomplete').on('railsAutocomplete.select', function() {
+    $('##{prefix}_url').val('');
+  });

--- a/app/views/lexicon/shared/_text_links_editor.html.haml
+++ b/app/views/lexicon/shared/_text_links_editor.html.haml
@@ -12,12 +12,13 @@
     add_fn      - name of the JS function adding a link
     remove_fn   - name of the JS function removing a link
     source_text - (optional) the text the links are applied to, used to warn about pairs that do not match it
+- link_entries = text_link_entries(links)
 %ul.list-unstyled.mb-2{ class: list_class }
   - Array(links).each_with_index do |link, idx|
     %li.d-flex.align-items-center.gap-2.mb-1
       %span.badge.bg-light.text-dark.border= link['text']
       %span →
-      - anchor = text_link_anchor(link)
+      - anchor = text_link_anchor(link, link_entries)
       - if anchor
         = anchor
       - else

--- a/app/views/lexicon/verification/_person_sections.html.haml
+++ b/app/views/lexicon/verification/_person_sections.html.haml
@@ -216,7 +216,7 @@
             .citation-card{ id: "citation-#{citation.id}", class: citation_card_css(citation, checklist) }
               .citation-content{dir: text_dir(citation.title.to_s)}
                 - if citation.title.present?
-                  %strong= citation.title
+                  %strong!= apply_text_links(citation.title, citation.text_links)
                 - if citation.authors.any?
                   %br
                   %span.text-muted
@@ -226,7 +226,7 @@
                   %br
                   %span.text-muted
                     = t('lexicon.verification.sections.citation_from_publication')
-                    = citation.from_publication
+                    != apply_text_links(citation.from_publication, citation.text_links)
                 - if citation.pages.present?
                   %br
                   %span.text-muted
@@ -234,7 +234,7 @@
                     = citation.pages
                 - if citation.notes.present?
                   %br
-                  %span.text-muted= citation.notes
+                  %span.text-muted!= apply_text_links(citation.notes, citation.text_links)
                 - if citation.link.present?
                   %br
                   - if citation.link_broken?

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3277,19 +3277,11 @@ en:
       title_links:
         section_heading: Title Links
         add_link: Add Title Link
-        text_in_title: Text in title
-        text_placeholder: Text that becomes a link
-        target: Target URL
-        person_placeholder: Search person entry...
-        entry_not_found: Entry not found
+        text_label: Text in title
       comment_links:
         section_heading: Comment Links
         add_link: Add Comment Link
-        text_in_comment: Text in comment
-        text_placeholder: Text that becomes a link
-        target: Target URL
-        person_placeholder: Search person entry...
-        entry_not_found: Entry not found
+        text_label: Text in comment
     citations:
       index:
         add_citation: Add Citation
@@ -3298,9 +3290,22 @@ en:
         no_subject: General
       edit:
         title: Edit Citation
+      text_links:
+        section_heading: Text Links
+        add_link: Add Text Link
+        text_label: Text in citation
     links:
       edit:
         title: Edit Link
+    text_links:
+      text_placeholder: Text that becomes a link
+      target_entry: Lexicon entry
+      target_url: Target URL
+      entry_placeholder: Search lexicon entry...
+      url_placeholder: "https://example.com/page.html"
+      target_hint: Fill in exactly one target – a lexicon entry or a URL.
+      entry_not_found: Entry not found
+      text_not_found: Text does not occur here
   lex_issues:
     index:
       title: Lex Issues

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -2528,19 +2528,11 @@ he:
       title_links:
         section_heading: קישורים בכותרת
         add_link: הוספת קישור בכותרת
-        text_in_title: טקסט בכותרת
-        text_placeholder: טקסט שיהפוך לקישור
-        target: כתובת היעד (URL)
-        person_placeholder: חפש ערך אדם...
-        entry_not_found: ערך לא נמצא
+        text_label: טקסט בכותרת
       comment_links:
         section_heading: קישורים בהערה
         add_link: הוספת קישור בהערה
-        text_in_comment: טקסט בהערה
-        text_placeholder: טקסט שיהפוך לקישור
-        target: כתובת היעד (URL)
-        person_placeholder: חפש ערך אדם...
-        entry_not_found: ערך לא נמצא
+        text_label: טקסט בהערה
     citations:
       index:
         add_citation: הוספת מראה מקום
@@ -2549,9 +2541,22 @@ he:
         no_subject: כללי
       edit:
         title: עריכת מראה מקום
+      text_links:
+        section_heading: קישורים בטקסט
+        add_link: הוספת קישור בטקסט
+        text_label: טקסט במראה המקום
     links:
       edit:
         title: עריכת קישור
+    text_links:
+      text_placeholder: טקסט שיהפוך לקישור
+      target_entry: ערך במילון
+      target_url: כתובת יעד (URL)
+      entry_placeholder: חיפוש ערך במילון...
+      url_placeholder: "https://example.com/page.html"
+      target_hint: יש למלא יעד אחד בלבד – ערך במילון או כתובת URL.
+      entry_not_found: ערך לא נמצא
+      text_not_found: הטקסט אינו מופיע כאן
   lex_issues:
     index:
       title: גיליונות

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -68,6 +68,11 @@ Bybeconv::Application.routes.draw do
       resources :citations, shallow: true, except: %i(show) do
         post :reorder, on: :member
         resources :authors, controller: 'citation_authors', only: %i(index create)
+        member do
+          get :text_links
+          post :add_text_link
+          delete :remove_text_link
+        end
       end
       resources :works, controller: 'person_works', shallow: true, except: %i(show) do
         post :reorder, on: :member

--- a/db/migrate/20260802000001_add_text_links_to_lex_citations.rb
+++ b/db/migrate/20260802000001_add_text_links_to_lex_citations.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddTextLinksToLexCitations < ActiveRecord::Migration[8.1]
+  def change
+    add_column :lex_citations, :text_links, :json
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_15_091952) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_02_000001) do
   create_table "aboutnesses", id: :integer, charset: "utf8mb4", collation: "utf8mb4_bin", force: :cascade do |t|
     t.integer "aboutable_id"
     t.string "aboutable_type"
@@ -661,6 +661,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_15_091952) do
     t.string "pages"
     t.integer "seqno", null: false
     t.string "subject"
+    t.json "text_links"
     t.string "title"
     t.datetime "updated_at", precision: nil, null: false
     t.index ["lex_person_id"], name: "index_lex_citations_on_lex_person_id"

--- a/spec/helpers/lexicon_helper_spec.rb
+++ b/spec/helpers/lexicon_helper_spec.rb
@@ -212,6 +212,67 @@ RSpec.describe LexiconHelper, type: :helper do
     end
   end
 
+  describe '#apply_text_links' do
+    let!(:target_entry) { create(:lex_entry, :publication, title: 'שדות ומזוודות') }
+
+    it 'links text to a lexicon entry of any type' do
+      result = helper.apply_text_links('בספרו: שדות ומזוודות : תזות',
+                                       [{ 'text' => 'שדות ומזוודות', 'entry_id' => target_entry.id }])
+      expect(result).to include(lexicon_entry_path(target_entry))
+      expect(result).to include('בספרו:')
+    end
+
+    it 'links text to an arbitrary URL, opening it in a new tab' do
+      result = helper.apply_text_links('תרגם שמעון בוזגלו', [{ 'text' => 'שמעון בוזגלו',
+                                                               'url' => 'http://example.com/x' }])
+      expect(result).to include('href="http://example.com/x"')
+      expect(result).to include('target="_blank"')
+      expect(result).to include('rel="noopener noreferrer"')
+    end
+
+    it 'leaves text alone when the pair does not occur in it' do
+      result = helper.apply_text_links('a text', [{ 'text' => 'absent', 'url' => 'http://example.com' }])
+      expect(result).to eq('a text')
+    end
+
+    it 'ignores a pair with a blank target' do
+      result = helper.apply_text_links('some text', [{ 'text' => 'some', 'url' => '' }])
+      expect(result).to eq('some text')
+    end
+
+    it 'escapes the text it is given' do
+      expect(helper.apply_text_links('a < b & c', nil)).to eq('a &lt; b &amp; c')
+    end
+  end
+
+  describe '#render_citation with text_links' do
+    let(:person) { create(:lex_person) }
+    let!(:target_entry) { create(:lex_entry, :publication, title: 'שדות ומזוודות') }
+    let(:citation) do
+      create(:lex_citation,
+             person: person,
+             title: 'כל העסק מתפרק בכלל',
+             from_publication: 'בספרו: שדות ומזוודות : תזות על הדרמה העברית',
+             link: nil,
+             authors_count: 0,
+             text_links: [{ 'text' => 'שדות ומזוודות', 'entry_id' => target_entry.id }])
+    end
+
+    it 'hyperlinks the matched text inside from_publication' do
+      expect(helper.render_citation(citation)).to include(lexicon_entry_path(target_entry))
+    end
+
+    context 'when the citation has its own link' do
+      before { citation.update!(link: 'http://example.com/article') }
+
+      it 'still links the whole title and does not nest anchors in it' do
+        result = helper.render_citation(citation)
+        expect(result).to include('href="http://example.com/article"')
+        expect(result.scan('<a ').size).to eq(2) # the title link and the from_publication link
+      end
+    end
+  end
+
   describe 'attachment/citation association' do
     let(:person) { create(:lex_person) }
     let(:entry) { create(:lex_entry, lex_item: person) }

--- a/spec/requests/lexicon/citations_spec.rb
+++ b/spec/requests/lexicon/citations_spec.rb
@@ -118,6 +118,15 @@ describe '/lexicon/citations' do
       end
     end
 
+    context 'when editing notes' do
+      let(:citation_params) { { notes: 'ראיון עם הסופרת לרגל צאת ספרה' } }
+
+      it 'persists the notes' do
+        expect(call).to eq(200)
+        expect(citation.reload.notes).to eq('ראיון עם הסופרת לרגל צאת ספרה')
+      end
+    end
+
     context 'when invalid params' do
       let(:citation_params) { attributes_for(:lex_citation, title: '') }
 
@@ -251,6 +260,77 @@ describe '/lexicon/citations' do
     it 'removes record' do
       expect { call }.to change { person.citations.count }.by(-1)
       expect(call).to eq(200)
+    end
+  end
+
+  describe 'GET /lex/citations/:id/text_links' do
+    it 'returns 200' do
+      expect(get("/lex/citations/#{citation.id}/text_links", xhr: true)).to eq(200)
+    end
+  end
+
+  describe 'POST /lex/citations/:id/add_text_link' do
+    subject(:call) do
+      post "/lex/citations/#{citation.id}/add_text_link",
+           params: { text: 'שדות ומזוודות', entry_id: target_entry.id },
+           xhr: true
+    end
+
+    let!(:target_entry) { create(:lex_file, :publication, title: 'שדות ומזוודות').lex_entry }
+
+    it 'adds the text link and returns 200' do
+      expect(call).to eq(200)
+      expect(citation.reload.text_links).to eq([{ 'text' => 'שדות ומזוודות', 'entry_id' => target_entry.id }])
+    end
+
+    it 'does not duplicate an existing link with the same text' do
+      citation.update!(text_links: [{ 'text' => 'שדות ומזוודות', 'entry_id' => target_entry.id }])
+      expect { call }.not_to(change { citation.reload.text_links.size })
+    end
+
+    context 'when a url is given instead of an entry' do
+      subject(:call) do
+        post "/lex/citations/#{citation.id}/add_text_link",
+             params: { text: 'שדות ומזוודות', url: 'http://example.com/page' },
+             xhr: true
+      end
+
+      it 'adds a url link pair' do
+        expect(call).to eq(200)
+        expect(citation.reload.text_links).to eq([{ 'text' => 'שדות ומזוודות', 'url' => 'http://example.com/page' }])
+      end
+    end
+
+    context 'when text is blank' do
+      subject(:call) do
+        post "/lex/citations/#{citation.id}/add_text_link",
+             params: { text: '', entry_id: target_entry.id },
+             xhr: true
+      end
+
+      it 'returns 422' do
+        expect(call).to eq(422)
+      end
+    end
+  end
+
+  describe 'DELETE /lex/citations/:id/remove_text_link' do
+    subject(:call) { delete "/lex/citations/#{citation.id}/remove_text_link", params: { index: 0 }, xhr: true }
+
+    before do
+      citation.update!(text_links: [{ 'text' => 'שדות ומזוודות', 'entry_id' => 1 },
+                                    { 'text' => 'לספר את הקיבוץ', 'url' => 'http://example.com' }])
+    end
+
+    it 'removes the link at the given index and returns 200' do
+      expect(call).to eq(200)
+      expect(citation.reload.text_links).to eq([{ 'text' => 'לספר את הקיבוץ', 'url' => 'http://example.com' }])
+    end
+
+    it 'returns 422 and removes nothing when the index is not an integer' do
+      delete "/lex/citations/#{citation.id}/remove_text_link", params: { index: 'abc' }, xhr: true
+      expect(response).to have_http_status(:unprocessable_content)
+      expect(citation.reload.text_links.size).to eq(2)
     end
   end
 

--- a/spec/requests/lexicon/person_works_spec.rb
+++ b/spec/requests/lexicon/person_works_spec.rb
@@ -312,8 +312,46 @@ describe '/lexicon/person_works' do
 
       let!(:publication_entry) { create(:lex_file, :publication, title: 'ספר כלשהו').lex_entry }
 
+      it 'accepts it: a title may link to a lexicon entry of any type' do
+        expect(call).to eq(200)
+        expect(work.reload.title_links).to eq([{ 'text' => 'ספר כלשהו', 'entry_id' => publication_entry.id }])
+      end
+    end
+
+    context 'when a url is given instead of an entry' do
+      subject(:call) do
+        post "/lex/works/#{work.id}/add_title_link",
+             params: { text: 'אפרת דנון', url: 'http://example.com/page' },
+             xhr: true
+      end
+
+      it 'adds a url link pair' do
+        expect(call).to eq(200)
+        expect(work.reload.title_links).to eq([{ 'text' => 'אפרת דנון', 'url' => 'http://example.com/page' }])
+      end
+    end
+
+    context 'when neither an entry nor a url is given' do
+      subject(:call) do
+        post "/lex/works/#{work.id}/add_title_link", params: { text: 'אפרת דנון' }, xhr: true
+      end
+
       it 'returns 422' do
         expect(call).to eq(422)
+        expect(work.reload.title_links).to be_nil
+      end
+    end
+
+    context 'when the url is a javascript: pseudo-url' do
+      subject(:call) do
+        post "/lex/works/#{work.id}/add_title_link",
+             params: { text: 'אפרת דנון', url: 'javascript:alert(1)' },
+             xhr: true
+      end
+
+      it 'returns 422' do
+        expect(call).to eq(422)
+        expect(work.reload.title_links).to be_nil
       end
     end
   end
@@ -399,8 +437,22 @@ describe '/lexicon/person_works' do
 
       let!(:publication_entry) { create(:lex_file, :publication, title: 'ספר כלשהו').lex_entry }
 
-      it 'returns 422' do
-        expect(call).to eq(422)
+      it 'accepts it: a comment may link to a lexicon entry of any type' do
+        expect(call).to eq(200)
+        expect(work.reload.comment_links).to eq([{ 'text' => 'ספר כלשהו', 'entry_id' => publication_entry.id }])
+      end
+    end
+
+    context 'when a url is given instead of an entry' do
+      subject(:call) do
+        post "/lex/works/#{work.id}/add_comment_link",
+             params: { text: 'יגאל שוורץ', url: 'http://example.com/page' },
+             xhr: true
+      end
+
+      it 'adds a url link pair' do
+        expect(call).to eq(200)
+        expect(work.reload.comment_links).to eq([{ 'text' => 'יגאל שוורץ', 'url' => 'http://example.com/page' }])
       end
     end
   end

--- a/spec/requests/lexicon/person_works_spec.rb
+++ b/spec/requests/lexicon/person_works_spec.rb
@@ -342,16 +342,31 @@ describe '/lexicon/person_works' do
       end
     end
 
-    context 'when the url is a javascript: pseudo-url' do
+    # The url is rendered straight into an href, so only known-inert schemes are accepted.
+    ['javascript:alert(1)', 'data:text/html;base64,PHNjcmlwdD5hbGVydCgxKTwvc2NyaXB0Pg==',
+     'vbscript:msgbox(1)', 'JaVaScRiPt:alert(1)', 'ftp://example.com/x'].each do |bad_url|
+      context "when the url is #{bad_url.truncate(30)}" do
+        subject(:call) do
+          post "/lex/works/#{work.id}/add_title_link", params: { text: 'אפרת דנון', url: bad_url }, xhr: true
+        end
+
+        it 'returns 422 and stores nothing' do
+          expect(call).to eq(422)
+          expect(work.reload.title_links).to be_nil
+        end
+      end
+    end
+
+    context 'when the url is a path on this site' do
       subject(:call) do
         post "/lex/works/#{work.id}/add_title_link",
-             params: { text: 'אפרת דנון', url: 'javascript:alert(1)' },
+             params: { text: 'אפרת דנון', url: '/files/lex/5181/00156200.pdf' },
              xhr: true
       end
 
-      it 'returns 422' do
-        expect(call).to eq(422)
-        expect(work.reload.title_links).to be_nil
+      it 'accepts it' do
+        expect(call).to eq(200)
+        expect(work.reload.title_links).to eq([{ 'text' => 'אפרת דנון', 'url' => '/files/lex/5181/00156200.pdf' }])
       end
     end
   end

--- a/spec/services/lexicon/parse_citations_spec.rb
+++ b/spec/services/lexicon/parse_citations_spec.rb
@@ -357,6 +357,66 @@ describe Lexicon::ParseCitations do
     end
   end
 
+  # The LLM reports at most one link per citation, so a link sitting elsewhere in the record
+  # (typically on the publication the citation appeared in) used to be dropped entirely.
+  context 'when a citation carries an inline link the LLM did not report' do
+    def stub_llm(works)
+      chat_double = instance_double(RubyLLM::Chat)
+      allow(RubyLLM).to receive(:chat).and_return(chat_double)
+      allow(chat_double).to receive_messages(with_instructions: chat_double, with_params: chat_double)
+      allow(chat_double).to receive(:ask).and_return(
+        instance_double(RubyLLM::Message, content: { result: [{ subject: nil, works: works }] }.to_json)
+      )
+    end
+
+    let!(:publication_entry) { create(:lex_file, :publication, title: 'שדות ומזוודות').lex_entry }
+    let!(:author_entry) { create(:lex_file, :person, title: 'אברהם עוז').lex_entry }
+
+    let(:html) do
+      <<~HTML
+        <ul>
+          <li><b><a href="/lex/entries/#{author_entry.id}">עוז, אברהם.</a></b> כל העסק מתפרק בכלל :
+            הרומן האבוד של עמוס קינן והתיאטרון. בספרו:
+            <b><a href="/lex/entries/#{publication_entry.id}">שדות ומזוודות</a></b> : תזות על הדרמה
+            (תל־אביב : רסלינג, 2014), עמ' 173–185.</li>
+        </ul>
+      HTML
+    end
+
+    let(:works) do
+      [
+        { title: 'כל העסק מתפרק בכלל : הרומן האבוד של עמוס קינן והתיאטרון',
+          authors: [{ name: 'עוז, אברהם', link: "/lex/entries/#{author_entry.id}" }],
+          from_publication: 'בספרו: שדות ומזוודות : תזות על הדרמה (תל־אביב : רסלינג, 2014)',
+          pages: '173–185', link: nil, backup_url: nil, notes: nil }
+      ]
+    end
+
+    it 'stores it as a text link on the citation it came from' do
+      stub_llm(works)
+
+      result = described_class.call(html)
+
+      expect(result.first.text_links).to eq([{ 'text' => 'שדות ומזוודות', 'entry_id' => publication_entry.id }])
+    end
+
+    it 'does not duplicate an author link as a text link' do
+      stub_llm(works)
+
+      result = described_class.call(html)
+
+      expect(result.first.text_links.pluck('text')).not_to include('עוז, אברהם.')
+    end
+
+    it 'does not duplicate the citation own link as a text link' do
+      stub_llm([works.first.merge(link: "/lex/entries/#{publication_entry.id}")])
+
+      result = described_class.call(html)
+
+      expect(result.first.text_links).to be_nil
+    end
+  end
+
   context 'when the LLM returns citations with blank titles' do
     let(:html) { '<ul><li>some html</li></ul>' }
 

--- a/spec/services/lexicon/parse_person_work_spec.rb
+++ b/spec/services/lexicon/parse_person_work_spec.rb
@@ -249,4 +249,51 @@ describe Lexicon::ParsePersonWork do
       expect(result.title_links).to be_nil
     end
   end
+
+  context 'when the title links to a non-person LexEntry' do
+    let!(:publication_entry) { create(:lex_file, :publication, title: 'כתמי אור').lex_entry }
+    let(:line) do
+      "<a href=\"/lex/entries/#{publication_entry.id}\">כתמי אור</a> : חמישים שנות ביקורת " \
+        '(תל אביב : הקיבוץ המאוחד, 2010)'
+    end
+
+    it 'stores the title link to that entry' do
+      expect(result.title_links).to eq([{ 'text' => 'כתמי אור', 'entry_id' => publication_entry.id }])
+    end
+  end
+
+  context 'when the title links to an external URL' do
+    let(:line) { '<a href="http://example.com/node/111">מדיאה</a> (תל אביב : שוקן, 2010)' }
+
+    it 'stores the title link as a url pair' do
+      expect(result.title_links).to eq([{ 'text' => 'מדיאה', 'url' => 'http://example.com/node/111' }])
+    end
+  end
+
+  context 'when a plain comment links to an external URL' do
+    let(:line) do
+      'מעיל קטון (אור יהודה : זמורה-ביתן, 2008) <font size="2">&lt;כולל אחרית דבר מאת ' \
+        '<a href="http://example.com/afterword">דני קרמן</a>&gt;</font>'
+    end
+
+    it 'stores the comment link as a url pair' do
+      expect(result.comment_links).to eq([{ 'text' => 'דני קרמן', 'url' => 'http://example.com/afterword' }])
+    end
+  end
+
+  context 'when a link points at an unmigrated legacy page' do
+    let(:line) { '<a href="01122001.php">שדות ומזוודות</a> (תל אביב : רסלינג, 2014)' }
+
+    it 'drops the link rather than storing an unresolvable relative url' do
+      expect(result.title_links).to be_nil
+    end
+  end
+
+  context 'when a link points at a LexEntry that no longer exists' do
+    let(:line) { '<a href="/lex/entries/999999">שדות ומזוודות</a> (תל אביב : רסלינג, 2014)' }
+
+    it 'drops the link' do
+      expect(result.title_links).to be_nil
+    end
+  end
 end

--- a/spec/system/lexicon/citation_text_links_spec.rb
+++ b/spec/system/lexicon/citation_text_links_spec.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'LexCitation text links in the verification workbench', :js, type: :system do
+  before do
+    skip 'WebDriver not available or misconfigured' unless webdriver_available?
+    login_as_lexicon_editor
+  end
+
+  let!(:target_entry) { create(:lex_file, :publication, title: 'שדות ומזוודות').lex_entry }
+
+  let!(:person) { create(:lex_person, birthdate: '1927', gender: :male) }
+
+  let!(:entry) { create(:lex_entry, title: 'עמוס קינן', lex_item: person, status: :draft) }
+
+  let!(:lex_file) do
+    file_path = Rails.root.join('tmp/test_citation_text_links.php')
+    File.write(file_path, '<html><body><h1>עמוס קינן</h1></body></html>')
+    create(:lex_file,
+           lex_entry: entry,
+           fname: 'test_citation_text_links.php',
+           full_path: file_path.to_s,
+           status: :ingested,
+           entrytype: :person)
+  end
+
+  let!(:citation) do
+    create(:lex_citation,
+           person: person,
+           authors_count: 0,
+           title: 'כל העסק מתפרק בכלל',
+           from_publication: 'בספרו: שדות ומזוודות : תזות על הדרמה העברית',
+           link: nil,
+           text_links: [{ 'text' => 'שדות ומזוודות', 'entry_id' => target_entry.id }])
+  end
+
+  after { FileUtils.rm_f(Rails.root.join('tmp/test_citation_text_links.php')) }
+
+  it 'renders the text link inside the citation publication line' do
+    visit "/lex/verification/#{entry.id}"
+
+    within "#citation-#{citation.id}" do
+      expect(page).to have_link('שדות ומזוודות', href: "/lex/entries/#{target_entry.id}")
+    end
+  end
+
+  it 'shows the existing text link in the citation edit modal' do
+    visit "/lex/verification/#{entry.id}"
+
+    within "#citation-#{citation.id}" do
+      click_button I18n.t('lexicon.verification.migrated.edit')
+    end
+
+    expect(page).to have_css('#generalDlg.show', wait: 5)
+
+    within '#generalDlg' do
+      expect(page).to have_css('#text-links-list .badge', text: 'שדות ומזוודות', wait: 5)
+    end
+  end
+
+  it 'adds a link to an arbitrary URL from the citation edit modal' do
+    visit "/lex/verification/#{entry.id}"
+
+    within "#citation-#{citation.id}" do
+      click_button I18n.t('lexicon.verification.migrated.edit')
+    end
+
+    expect(page).to have_css('#generalDlg.show', wait: 5)
+
+    within '#generalDlg' do
+      expect(page).to have_css('#text-links-list .badge', text: 'שדות ומזוודות', wait: 5)
+      fill_in 'text_link_text', with: 'תזות על הדרמה העברית'
+      fill_in 'text_link_url', with: 'http://example.com/theses'
+      click_button I18n.t(:add)
+
+      expect(page).to have_css('#text-links-list .badge', text: 'תזות על הדרמה העברית', wait: 5)
+    end
+
+    expect(citation.reload.text_links).to include({ 'text' => 'תזות על הדרמה העברית',
+                                                    'url' => 'http://example.com/theses' })
+  end
+end


### PR DESCRIPTION
## What

Two related pieces of the lexicon migration verification work:

1. **Editors can link arbitrary words to arbitrary URLs** in a `LexPersonWork` or a `LexCitation`, the way the works' editing views already allowed linking words to *person* entries.
2. **Ingestion preserves inline links it used to discard**, storing them as text/link pairs in that same mechanism.

## Storage

A link pair is `{ text, entry_id }` (a lexicon entry, any type) or `{ text, url }` (anything else).

- `LexCitation` gains a `text_links` JSON column. One set per citation, applied to whichever displayed part contains the text — title, `from_publication`, or `notes`.
- `LexPersonWork` keeps its existing `title_links` / `comment_links` columns and shape; they simply gain `url` targets.

## Rendering

`LexiconHelper#apply_text_links` is now the single implementation behind the works' title/comment rendering, `render_citation`, and the verification cards. URL targets open in a new tab; entry targets stay internal. A citation's title is hyperlinked from `text_links` only when the citation has no `link` of its own, so anchors never nest.

## Editing UI

One shared partial (`lexicon/shared/_text_links_editor`) replaces the two near-identical work partials and serves the new citation section. Its add-form offers an entry autocomplete **or** a URL field, mutually exclusive. `TextLinksConcern` replaces the four duplicated add/remove actions in `PersonWorksController` and backs the new `text_links` / `add_text_link` / `remove_text_link` routes on citations; `javascript:` URLs are rejected.

The person-only restriction on link targets is lifted — it was the direct cause of the dropped links below. A pair whose text no longer occurs in the record is flagged in the list, which matters because the LLM sometimes garbles the surrounding text.

## Detection

**Works** (`ParsePersonWork`): every anchor not pointing at a *person* entry was discarded, losing links to publication and bibliography entries — e.g. on `00156.php`, `01122001.php` (a `text` entry) and `99995017.php` (a `bib` entry) — plus all external URLs. Any resolvable target is now kept; only relative legacy paths that `ProcessLinks` could not resolve are dropped, since storing them would produce links resolved against the entry's own path.

**Citations** (`ParseCitations`): the LLM reports at most one link per citation, so an anchor elsewhere in the record was lost outright or misfiled as the citation's own `link`. Each source `<li>`'s inline anchors are now recorded and joined back to the citation the LLM produced, reusing the link/title matching that already recovered `backup_url`. Anchors already held as the citation's `link`, `backup_url`, or one of its authors are skipped. The prompt also now states that a link on the publication named in `from_publication` is not the work's link, so it stops landing on the title.

Verified against real data — for the `כל העסק מתפרק בכלל` citation of entry 5181 the recovery yields `[{"entry_id"=>6458, "text"=>"שדות ומזוודות"}]`, correctly excluding the author anchor. A 60-file sample also recovers publication links (`כתמי אור`) and external URLs (`shimonbouzaglo.co.il`) that were previously discarded.

No backfill: this applies to future ingests only, by design.

## Drive-by

`notes` is now permitted in `lex_citation_params`. The citation form has rendered a `notes` field all along, but the param was never permitted, so edits silently vanished.

## Test plan

New coverage:
- `spec/helpers/lexicon_helper_spec.rb` — `apply_text_links` with entry/url targets, non-matching and blank-target pairs, escaping; `render_citation` linking inside `from_publication` without nesting anchors in a linked title.
- `spec/services/lexicon/parse_person_work_spec.rb` — non-person entry targets, external URLs in title and comment, unresolvable `.php` and dangling entry ids dropped.
- `spec/services/lexicon/parse_citations_spec.rb` — an unreported inline link becomes a text link; author anchors and the citation's own link are not duplicated.
- `spec/requests/lexicon/citations_spec.rb` — the three new endpoints, plus `notes` persistence.
- `spec/requests/lexicon/person_works_spec.rb` — url pairs, missing target, `javascript:` rejection; the two "entry is not a person → 422" cases now assert the intended 200.
- `spec/system/lexicon/citation_text_links_spec.rb` (`js: true`) — the pair renders on the verification page, appears in the edit modal, and a URL pair can be added through the UI.

Runs: `spec/services/lexicon` (180), `spec/requests/lexicon`, `spec/helpers`, `spec/models/lex_citation_spec.rb`, and the lexicon/citation system specs — all green except 6 pre-existing failures in `spec/requests/lexicon/files_spec.rb`, which are an Elasticsearch flood-stage read-only block from local disk pressure and fail identically on a clean tree. The full suite was not run locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)