### PR TITLE
Staging: show running version indicator at bottom left

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -50,6 +50,22 @@ body.staging::before {
   //);
 }
 
+// Staging environment indicator: running version, always visible at bottom left
+.staging-version-indicator {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  z-index: 10000; // above the body.staging::before overlay
+  padding: 2px 6px;
+  background-color: #fff;
+  color: #000;
+  border: 1px solid #000;
+  font-size: 11px;
+  line-height: 1.3;
+  direction: ltr;
+  pointer-events: none;
+}
+
 /*body{font-size:14px;} /* default */
 /* temporary fix */
 .credits{

--- a/app/assets/stylesheets/lexicon_backend.scss
+++ b/app/assets/stylesheets/lexicon_backend.scss
@@ -21,6 +21,22 @@ body.staging::before {
   //);
 }
 
+// Staging environment indicator: running version, always visible at bottom left
+.staging-version-indicator {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  z-index: 10000; // above the body.staging::before overlay
+  padding: 2px 6px;
+  background-color: #fff;
+  color: #000;
+  border: 1px solid #000;
+  font-size: 11px;
+  line-height: 1.3;
+  direction: ltr;
+  pointer-events: none;
+}
+
 // SASS imports for lexicon backend
 @import 'fonts';
 @import 'jquery-ui';

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -7,6 +7,22 @@ module ApplicationHelper
     (ENV['cache_nonce'] || ENV['CACHE_NONCE']) == 'staging'
   end
 
+  # Best-effort timestamp of the running deployment, for the staging indicator.
+  # Capistrano names release directories YYYYMMDDHHMMSS (UTC) and writes a REVISION
+  # file into them; in development/test neither exists, hence the unknown fallback.
+  def deployment_version
+    dir = Rails.root.basename.to_s
+    revision_file = Rails.root.join('REVISION')
+    time =
+      if dir.match?(/\A\d{14}\z/)
+        Time.find_zone('UTC').strptime(dir, '%Y%m%d%H%M%S')
+      elsif revision_file.exist?
+        revision_file.mtime
+      end
+
+    time.nil? ? t(:version_unknown) : time.in_time_zone.strftime('%Y-%m-%d %H:%M')
+  end
+
   def u8(s)
     return s if s.nil?
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -7,20 +7,23 @@ module ApplicationHelper
     (ENV['cache_nonce'] || ENV['CACHE_NONCE']) == 'staging'
   end
 
-  # Best-effort timestamp of the running deployment, for the staging indicator.
-  # Capistrano names release directories YYYYMMDDHHMMSS (UTC) and writes a REVISION
-  # file into them; in development/test neither exists, hence the unknown fallback.
+  # Best-effort description of the running deployment, for the staging indicator:
+  # deployment timestamp plus the deployed git SHA, when available. Capistrano names
+  # release directories YYYYMMDDHHMMSS (UTC) and writes a REVISION file (holding the
+  # deployed SHA) into them; in development/test neither exists.
   def deployment_version
     dir = Rails.root.basename.to_s
     revision_file = Rails.root.join('REVISION')
+    revision = revision_file.exist? ? revision_file.read.strip : nil
     time =
       if dir.match?(/\A\d{14}\z/)
         Time.find_zone('UTC').strptime(dir, '%Y%m%d%H%M%S')
-      elsif revision_file.exist?
+      elsif revision.present?
         revision_file.mtime
       end
 
-    time.nil? ? t(:version_unknown) : time.in_time_zone.strftime('%Y-%m-%d %H:%M')
+    label = time.nil? ? t(:version_unknown) : time.in_time_zone.strftime('%Y-%m-%d %H:%M')
+    revision.blank? ? label : "#{label} (#{revision[0, 8]})"
   end
 
   def u8(s)

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -295,5 +295,6 @@
   });
 </script>
 
+<%= render 'shared/staging_version_indicator' %>
 </body>
 </html>

--- a/app/views/layouts/backend.html.haml
+++ b/app/views/layouts/backend.html.haml
@@ -48,6 +48,7 @@
         %p
     #generalDlg.modal{"aria-hidden" => "true", role: "dialog"}
       "&gt;
+    = render 'shared/staging_version_indicator'
 :javascript
   $(document).ready(function() {
     var header = $("header");

--- a/app/views/layouts/lexicon_backend.html.haml
+++ b/app/views/layouts/lexicon_backend.html.haml
@@ -43,3 +43,4 @@
                 %span{ aria: { hidden: true } } &times;
             .modal-body#generalDlgBody
     %footer.container-fluid
+    = render 'shared/staging_version_indicator'

--- a/app/views/shared/_staging_version_indicator.html.haml
+++ b/app/views/shared/_staging_version_indicator.html.haml
@@ -1,0 +1,3 @@
+-# Version indicator, shown on the staging server only (see ApplicationHelper#staging?)
+- if staging?
+  .staging-version-indicator= t(:staging_version, version: deployment_version)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2193,6 +2193,7 @@ en:
   spanish: Spanish
   split: Split
   split_works: Split Works
+  staging_version: 'version: %{version}'
   start: Start
   start_date: Start Date
   start_page: Start Page
@@ -2382,6 +2383,7 @@ en:
   values: Values
   version: Version
   versions: Versions
+  version_unknown: unknown
   via: Via
   viaf: VIAF
   viaf_link: VIAF Link

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -1329,6 +1329,8 @@ he:
   responsibility_statement: שורת אחריות
   editors: בעריכת
   default_page_title: פרויקט בן־יהודה
+  staging_version: 'גרסה: %{version}'
+  version_unknown: לא ידועה
   font_size: גודל גופן
   path: נתיב
   'yes': כן

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
+require 'tmpdir'
 
 RSpec.describe ApplicationHelper, type: :helper do
   describe '#staging?' do
@@ -34,6 +35,32 @@ RSpec.describe ApplicationHelper, type: :helper do
       ENV['CACHE_NONCE'] = 'production'
       ENV['cache_nonce'] = nil
       expect(helper.staging?).to be false
+    end
+  end
+
+  describe '#deployment_version' do
+    it 'derives the timestamp from a Capistrano release directory name' do
+      allow(Rails).to receive(:root).and_return(Pathname.new('/home/bybe/releases/20260731131500'))
+      expected = Time.find_zone('UTC').local(2026, 7, 31, 13, 15).in_time_zone.strftime('%Y-%m-%d %H:%M')
+      expect(helper.deployment_version).to eq expected
+    end
+
+    it 'falls back to the mtime of the REVISION file' do
+      Dir.mktmpdir do |dir|
+        revision = File.join(dir, 'REVISION')
+        File.write(revision, "deadbeef\n")
+        mtime = Time.zone.local(2026, 6, 1, 9, 30)
+        File.utime(mtime.to_time, mtime.to_time, revision)
+        allow(Rails).to receive(:root).and_return(Pathname.new(dir))
+        expect(helper.deployment_version).to eq mtime.strftime('%Y-%m-%d %H:%M')
+      end
+    end
+
+    it 'reports an unknown version when there is nothing to derive it from' do
+      Dir.mktmpdir do |dir|
+        allow(Rails).to receive(:root).and_return(Pathname.new(dir))
+        expect(helper.deployment_version).to eq I18n.t(:version_unknown)
+      end
     end
   end
 

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -45,14 +45,25 @@ RSpec.describe ApplicationHelper, type: :helper do
       expect(helper.deployment_version).to eq expected
     end
 
+    it 'appends the short git SHA from the REVISION file' do
+      Dir.mktmpdir do |dir|
+        release = File.join(dir, '20260731131500')
+        Dir.mkdir(release)
+        File.write(File.join(release, 'REVISION'), "deadbeefcafe\n")
+        allow(Rails).to receive(:root).and_return(Pathname.new(release))
+        expected = Time.find_zone('UTC').local(2026, 7, 31, 13, 15).in_time_zone.strftime('%Y-%m-%d %H:%M')
+        expect(helper.deployment_version).to eq "#{expected} (deadbeef)"
+      end
+    end
+
     it 'falls back to the mtime of the REVISION file' do
       Dir.mktmpdir do |dir|
         revision = File.join(dir, 'REVISION')
-        File.write(revision, "deadbeef\n")
+        File.write(revision, "deadbeefcafe\n")
         mtime = Time.zone.local(2026, 6, 1, 9, 30)
         File.utime(mtime.to_time, mtime.to_time, revision)
         allow(Rails).to receive(:root).and_return(Pathname.new(dir))
-        expect(helper.deployment_version).to eq mtime.strftime('%Y-%m-%d %H:%M')
+        expect(helper.deployment_version).to eq "#{mtime.strftime('%Y-%m-%d %H:%M')} (deadbeef)"
       end
     end
 

--- a/spec/requests/staging_version_indicator_spec.rb
+++ b/spec/requests/staging_version_indicator_spec.rb
@@ -8,9 +8,13 @@ RSpec.describe 'Staging version indicator', type: :request do
   around do |example|
     original_upper = ENV.fetch('CACHE_NONCE', nil)
     original_lower = ENV.fetch('cache_nonce', nil)
-    example.run
-    ENV['CACHE_NONCE'] = original_upper
-    ENV['cache_nonce'] = original_lower
+
+    begin
+      example.run
+    ensure
+      ENV['CACHE_NONCE'] = original_upper
+      ENV['cache_nonce'] = original_lower
+    end
   end
 
   it 'shows the version indicator when running on staging' do

--- a/spec/requests/staging_version_indicator_spec.rb
+++ b/spec/requests/staging_version_indicator_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Staging version indicator', type: :request do
+  let!(:static_page) { create(:static_page) }
+
+  around do |example|
+    original_upper = ENV.fetch('CACHE_NONCE', nil)
+    original_lower = ENV.fetch('cache_nonce', nil)
+    example.run
+    ENV['CACHE_NONCE'] = original_upper
+    ENV['cache_nonce'] = original_lower
+  end
+
+  it 'shows the version indicator when running on staging' do
+    ENV['CACHE_NONCE'] = 'staging'
+    ENV['cache_nonce'] = nil
+    get static_pages_by_tag_path(static_page.tag)
+    expect(response).to have_http_status(:success)
+    expect(response.body).to include('staging-version-indicator')
+    # no REVISION file/release dir in the test checkout, so the version is reported as unknown
+    expect(response.body).to include(I18n.t(:staging_version, version: I18n.t(:version_unknown)))
+  end
+
+  it 'does not show the version indicator outside staging' do
+    ENV['CACHE_NONCE'] = nil
+    ENV['cache_nonce'] = nil
+    get static_pages_by_tag_path(static_page.tag)
+    expect(response).to have_http_status(:success)
+    expect(response.body).not_to include('staging-version-indicator')
+  end
+end


### PR DESCRIPTION
## Summary

On the staging server only, every page now shows a small fixed black-on-white box at the bottom left with the deployment timestamp, at a z-index above the `body.staging::before` overlay so it always stays visible.

- `ApplicationHelper#deployment_version` derives the timestamp from the Capistrano release directory name (`YYYYMMDDHHMMSS`, UTC), falls back to the mtime of the REVISION file Capistrano writes into each release, and reports an "unknown" label when neither exists (development/test).
- New partial `shared/_staging_version_indicator`, guarded by the existing `staging?` check, rendered from all three layouts (`application.html.erb`, `backend.html.haml`, `lexicon_backend.html.haml`).
- Styles added to `application.scss` and `lexicon_backend.scss` (the two stylesheets those layouts use).
- I18n keys `staging_version` / `version_unknown` in both `he.yml` and `en.yml`.

## Test plan

- `spec/helpers/application_helper_spec.rb` — new `#deployment_version` examples for all three derivation paths (release dir name, REVISION mtime, unknown).
- `spec/requests/staging_version_indicator_spec.rb` — new: indicator present when `CACHE_NONCE=staging`, absent otherwise.
- Ran: `bundle exec rspec spec/helpers/application_helper_spec.rb spec/requests/staging_version_indicator_spec.rb spec/requests/admin_spec.rb spec/requests/lexicon/entries_spec.rb` — all green (the latter two exercise the two HAML layouts I touched).
- Full suite **not** run (40+ min); needs a maintainer run.
- RuboCop/haml-lint clean on the changed lines.

Closes beads_by-3pu

🤖 Generated with [Claude Code](https://claude.com/claude-code)