### PR TITLE
Lexicon: float biography images so text wraps around them

### DIFF
--- a/app/assets/stylesheets/lexicon.scss
+++ b/app/assets/stylesheets/lexicon.scss
@@ -2,6 +2,46 @@ ul.lex {
   list-style-type:disc;
 }
 
+/* Biography images (entry show page and the migration verification workbench).
+   Entries migrated from the old PHP lexicon carry the legacy HTML `align` and
+   `hspace` attributes as data-align/data-hspace. Without a float such an image
+   occupies a line of its own, leaving a tall empty band beside it; floating it
+   lets the biography text wrap around. Images with no data-align are the inline
+   source logos (NLI, Heksherim...) and are deliberately left in the text flow. */
+#lexicon-biography,
+.bio-content {
+  display: flow-root; /* contain the floats, so they can't spill into the next section */
+
+  img[data-align] {
+    max-width: 40%;
+    height: auto;
+    margin-bottom: 0.5em;
+  }
+
+  img[data-align='left'] {
+    float: left;
+    margin-right: 1em;
+  }
+
+  img[data-align='right'] {
+    float: right;
+    margin-left: 1em;
+  }
+}
+
+/* Too narrow to wrap text alongside an image: back to full-width, in-flow. */
+@media (max-width: 479px) {
+  #lexicon-biography,
+  .bio-content {
+    img[data-align] {
+      float: none;
+      max-width: 100%;
+      margin-right: 0;
+      margin-left: 0;
+    }
+  }
+}
+
 /* Editor-only badge marking entries not yet migrated from the old PHP lexicon */
 .lex-php-badge {
   display: inline-block;

--- a/app/assets/stylesheets/lexicon_backend.scss
+++ b/app/assets/stylesheets/lexicon_backend.scss
@@ -40,6 +40,7 @@ body.staging::before {
 // SASS imports for lexicon backend
 @import 'fonts';
 @import 'jquery-ui';
+@import 'lexicon'; // shared lexicon rules; the workbench needs the biography image floats
 @import 'verification';
 
 // We need this to make rails-autocomplete working in Bootstrap modals

--- a/app/views/authors/_generated_toc.html.haml
+++ b/app/views/authors/_generated_toc.html.haml
@@ -20,7 +20,8 @@
       .by-card-v02
         #lexicon-bio
         .by-card-content-v02
-          %p#lexicon-biography!= MarkdownToHtml.call(lex_person.bio)
+          -# a div, not a p: see lexicon/entries/_show_person
+          #lexicon-biography!= MarkdownToHtml.call(lex_person.bio)
       #lexicon-works
         = render layout: 'lexicon/block', locals: { title: LexPerson.human_attribute_name(:works) } do
           - LexPersonWork.work_types.each_key do |work_type|

--- a/app/views/lexicon/entries/_show_person.html.haml
+++ b/app/views/lexicon/entries/_show_person.html.haml
@@ -22,7 +22,10 @@
                 .metadata
                   = render partial: 'shared/intellectual_property',
                            locals: { intellectual_property: lex_person.intellectual_property }
-          %p#lexicon-biography!= MarkdownToHtml.call(bio_for_display(lex_person.bio, @lex_entry))
+          -#
+            a div, not a p: the bio is multi-paragraph HTML, and a <p> wrapper would be
+            auto-closed by the parser, leaving the paragraphs outside #lexicon-biography
+          #lexicon-biography!= MarkdownToHtml.call(bio_for_display(lex_person.bio, @lex_entry))
         #lexicon-works
           = render layout: 'lexicon/block', locals: { title: LexPerson.human_attribute_name(:works) } do
             - LexPersonWork.work_types.each_key do |work_type|

--- a/spec/system/lexicon/bio_image_float_spec.rb
+++ b/spec/system/lexicon/bio_image_float_spec.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# Images embedded in a migrated biography used to sit on a line of their own, leaving a tall
+# empty band of vertical space beside them. They must float so the biography text wraps around.
+RSpec.describe 'Biography image float', :js, type: :system do
+  # 1x1 transparent GIF, so the image loads deterministically; the width/height attributes
+  # (as in the migrated entries) give it a real box.
+  let(:pixel) { 'data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==' }
+
+  let(:paragraph) { (['ביוגרפיה של אדם כלשהו, טקסט ארוך דיו כדי לעטוף את התמונה.'] * 8).join(' ') }
+
+  let(:bio) do
+    <<~HTML
+      <img src="#{pixel}" data-align="left" data-hspace="10" width="200" height="200" />
+
+      <p>#{paragraph}</p>
+
+      <p>#{paragraph}</p>
+    HTML
+  end
+
+  let(:person) { create(:lex_person, bio: bio) }
+
+  # Distance from the top of the first paragraph to the bottom of the floated image: negative
+  # (paragraph starts above the image's bottom edge) means the text runs alongside the image.
+  def paragraph_top_minus_image_bottom(container_selector)
+    page.evaluate_script(<<~JS)
+      (function() {
+        var container = document.querySelector('#{container_selector}');
+        var img = container.querySelector('img[data-align]');
+        var para = container.querySelector('p');
+        return para.getBoundingClientRect().top - img.getBoundingClientRect().bottom;
+      })()
+    JS
+  end
+
+  before { skip 'WebDriver not available or misconfigured' unless webdriver_available? }
+
+  describe 'on the public entry page' do
+    let!(:entry) { create(:lex_entry, :person, title: 'Test Person', lex_item: person, status: :published) }
+
+    before { visit lexicon_entry_path(entry) }
+
+    it 'floats the image so the biography text wraps around it' do
+      expect(page).to have_css('#lexicon-biography img[data-align="left"]')
+
+      # the paragraphs must be *inside* the container the float rules are scoped to
+      expect(page).to have_css('#lexicon-biography p', count: 2)
+
+      float = page.evaluate_script(
+        "window.getComputedStyle(document.querySelector('#lexicon-biography img[data-align]')).float"
+      )
+      expect(float).to eq 'left'
+      expect(paragraph_top_minus_image_bottom('#lexicon-biography')).to be < 0
+    end
+  end
+
+  describe 'in the migration verification workbench' do
+    let!(:entry) { create(:lex_entry, :person, title: 'Test Person', lex_item: person, status: :draft) }
+
+    before do
+      login_as_lexicon_editor
+      entry.start_verification!('test@example.com')
+      visit lexicon_verification_path(entry)
+    end
+
+    it 'floats the image so the biography text wraps around it' do
+      expect(page).to have_css('#section-bio .bio-content img[data-align="left"]')
+
+      float = page.evaluate_script(
+        "window.getComputedStyle(document.querySelector('#section-bio .bio-content img[data-align]')).float"
+      )
+      expect(float).to eq 'left'
+      expect(paragraph_top_minus_image_bottom('#section-bio .bio-content')).to be < 0
+    end
+  end
+end

--- a/spec/system/lexicon/bio_image_float_spec.rb
+++ b/spec/system/lexicon/bio_image_float_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe 'Biography image float', :js, type: :system do
 
     it 'floats the image so the biography text wraps around it' do
       expect(page).to have_css('#section-bio .bio-content img[data-align="left"]')
-
+      expect(page).to have_css('#section-bio .bio-content p', count: 2)
       float = page.evaluate_script(
         "window.getComputedStyle(document.querySelector('#section-bio .bio-content img[data-align]')).float"
       )


### PR DESCRIPTION
## Problem

Images embedded in a migrated biography (entry show page and the migration verification workbench) were rendered inline, occupying a line of their own — leaving a tall empty band of vertical space beside a 200px-wide portrait.

## Change

- `lexicon.scss`: in `#lexicon-biography` / `.bio-content`, float `img[data-align]` per its value (migrated entries carry the old PHP lexicon's `align`/`hspace` attributes as `data-align`/`data-hspace`), with a margin on the text side. Images **without** `data-align` are the small inline source logos (NLI, Heksherim…) and are deliberately left in the flow. The container gets `display: flow-root` so a float can't spill into the next section, and below 480px the images unfloat to full width.
- `lexicon_backend.scss`: `@import 'lexicon'` so the verification workbench gets the same rules (it doesn't load `application.css`).
- `lexicon/entries/_show_person.html.haml`, `authors/_generated_toc.html.haml`: the biography wrapper was `%p#lexicon-biography` around multi-paragraph HTML. The HTML parser auto-closes that `<p>` at the first nested `<p>`, so the paragraphs ended up *outside* `#lexicon-biography` — any rule scoped to that id would have missed the images inside paragraphs (20 of the 36 aligned images in the dev DB). Changed to a `div`; the id and scrollspy target are unchanged.

## Testing

- New `spec/system/lexicon/bio_image_float_spec.rb` (js): asserts on both the public entry page and the workbench that the bio image computes `float: left` and that the first paragraph starts *above* the image's bottom edge (i.e. text runs alongside it); also asserts the paragraphs are inside `#lexicon-biography`. Both examples were verified to fail without this change.
- Ran `spec/system/lexicon/entries_navbar_spec.rb`, `spec/system/author_lex_citations_spec.rb`, `spec/system/lexicon/verification_workbench_spec.rb`, `spec/system/lexicon/verification_layout_spacing_spec.rb` — 55 examples, 0 failures.
- rubocop + haml-lint clean on the changed lines.
- The full suite was **not** run (40+ min); it needs a maintainer's go-ahead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)