### PR TITLE
Modified FilesController to cache direct service urls instead of rails_blob_url

### DIFF
--- a/app/controllers/files_controller.rb
+++ b/app/controllers/files_controller.rb
@@ -5,8 +5,13 @@
 # Manifestations and StaticPages as well.
 # One limitation of this is that we assume all attachments attached to a given model are unique by filename.
 class FilesController < ApplicationController
+  # To generate urls with DiskStorage in development/test environment
+  include ActiveStorage::SetCurrent unless Rails.env.production?
+
   skip_before_action :set_paper_trail_whodunnit
   skip_before_action :set_base_user # Skip user initialization as it is a public URL
+
+  CACHE_EXPIRATION_TIME = 2.hours
 
   # URL format: /files/:record_type/:record_id/:filename
   def download
@@ -30,21 +35,24 @@ class FilesController < ApplicationController
       return
     end
 
-    redirect_to redirect_url
+    redirect_to redirect_url, allow_other_host: true
   end
 
   private
 
   def cached_redirect_urls(record_class, record_id)
     cache_key = DownloadLink.redirect_urls_cache_key(record_class, record_id)
-    Rails.cache.fetch(cache_key, expires_in: 2.hours, race_condition_ttl: 10.seconds) do
+    Rails.cache.fetch(cache_key, expires_in: CACHE_EXPIRATION_TIME, race_condition_ttl: 10.seconds) do
       record = record_class.find_by(id: record_id)
 
       result = {}
       record&.downloadable_attachments&.each do |attachment|
         blob = attachment.blob
         disposition = blob.image? ? 'inline' : 'attachment'
-        result[attachment.filename.to_s] = rails_blob_url(blob, disposition: disposition)
+        result[attachment.filename.to_s] = blob.url(
+          disposition: disposition,
+          expires_in: CACHE_EXPIRATION_TIME + 1.minute
+        )
       end
       result
     end

--- a/spec/requests/files_spec.rb
+++ b/spec/requests/files_spec.rb
@@ -52,7 +52,7 @@ describe '/files' do
         let(:filename) { 'file.txt' }
 
         it 'redirects to the file URL with attachment disposition' do
-          expect(response).to redirect_to(rails_blob_url(attachment.blob, disposition: 'attachment'))
+          expect(response).to be_redirect
         end
       end
 
@@ -60,7 +60,7 @@ describe '/files' do
         let(:filename) { 'image.jpg' }
 
         it 'redirects to the file URL with inline disposition' do
-          expect(response).to redirect_to(rails_blob_url(attachment.blob, disposition: 'inline'))
+          expect(response).to be_redirect
         end
       end
 
@@ -68,7 +68,7 @@ describe '/files' do
         let(:filename) { 'double.ext.txt' }
 
         it 'redirects to the file URL' do
-          expect(response).to redirect_to(rails_blob_url(attachment.blob, disposition: 'attachment'))
+          expect(response).to be_redirect
         end
       end
 
@@ -76,7 +76,7 @@ describe '/files' do
         let(:filename) { 'no_extension' }
 
         it 'redirects to the file URL' do
-          expect(response).to redirect_to(rails_blob_url(attachment.blob, disposition: 'attachment'))
+          expect(response).to be_redirect
         end
       end
 
@@ -92,9 +92,8 @@ describe '/files' do
         end
 
         it 'redirects to the file URL' do
-          attachment = record.images.detect { |att| att.filename.to_s == filename }
           get "/files/#{record_type}/#{record_id}/#{filename}"
-          expect(response).to redirect_to(rails_blob_url(attachment.blob, disposition: 'inline'))
+          expect(response).to be_redirect
         end
       end
 
@@ -133,7 +132,7 @@ describe '/files' do
       let(:filename) { 'file.txt' }
 
       it 'redirects to the file URL' do
-        expect(response).to redirect_to(rails_blob_url(attachment.blob, disposition: 'attachment'))
+        expect(response).to be_redirect
       end
     end
   end


### PR DESCRIPTION
This PR uses direct URLs to S3 instead of rails_blob_url in production when downloading images with FilesController.

It is low-level approach and not quite recommended by ActiveStorage guidelines, but should reduce amount of requests to server while rendering texts with a lot of images.