### PR TITLE
Show impressions_count to editors in Manifestation#read and Authority#toc

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1273,3 +1273,12 @@ p.by-genre-name-v02.headline-2-v02 {
     }
   }
 }
+
+// editor-only view counter shown next to the editor action links in the metadata area
+.impressions-count {
+  display: inline-block;
+  padding: 1px 6px;
+  border: 1px solid #ccc;
+  border-radius: 3px;
+  background-color: #fff;
+}

--- a/app/views/authors/toc.html.haml
+++ b/app/views/authors/toc.html.haml
@@ -68,6 +68,8 @@
                   != '&nbsp;&nbsp;&nbsp;'
                   %span.static-btn
                     %b= link_to t(:edit_metadata), authors_edit_path(id: @author.id)
+                  != '&nbsp;&nbsp;&nbsp;'
+                  %span.impressions-count #{number_with_delimiter(@author.impressions_count, delimiter: ',')} #{t(:impressions_count)}
             .select-all-with-buttons{style:'display:none;margin-right:100px;'}
               .number-of-selected-texts{style: 'display:none'}
                 = t(:number_of_selected_texts)

--- a/app/views/manifestation/_metadata.html.haml
+++ b/app/views/manifestation/_metadata.html.haml
@@ -16,6 +16,8 @@
       %span.static-btn#originating-task-btn
         %a.pointer.originating-task-btn{ data: { 'manifestation-id': @m.id } }= t(:find_originating_task)
       %span#originating-task-result
+    != "&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"
+    %span.impressions-count #{number_with_delimiter(@m.impressions_count, delimiter: ',')} #{t(:impressions_count)}
     %br
   .headline-2-v02
     - unless @m.authors.nil? # shouldn't happen, but eh

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1619,6 +1619,7 @@ en:
   image_filename: Image File Name
   images: Images
   import: Import
+  impressions_count: views
   in_anthology: 'In Anthology:'
   in_bookshelf: 'In Reading List:'
   in_collection: In collection %{coll}

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -1574,6 +1574,7 @@ he:
   latest_uploads_for: יצירות שנוספו באחרונה מאת %{author}
   temporary_worklist: רשימת יצירות (זמנית)
   improvements_soon: דף זה טרם עוצב. בקרוב נכניס בו שיפורים, אבל רצינו שבינתיים תוכלו לגשת ליצירות עצמן.
+  impressions_count: צפיות
   primary: יצירה עיקרית
   group_in_collections: קיבוץ לאוספים
   collection_item_type: סוג פריט

--- a/spec/system/editor_impressions_count_spec.rb
+++ b/spec/system/editor_impressions_count_spec.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Editor-only impressions count display', :js, type: :system do
+  before do
+    skip 'WebDriver not available or misconfigured' unless webdriver_available?
+  end
+
+  let(:regular_user) { create(:user) }
+  let(:editor) { create(:user, editor: true) }
+
+  def login_as(user)
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
+  end
+
+  describe 'Manifestation#read' do
+    # Viewing the page itself bumps impressions_count by one before the view renders
+    let!(:manifestation) { create(:manifestation, impressions_count: 1_234_567) }
+
+    it 'shows the view count with thousands separators to editors' do
+      login_as(editor)
+      visit manifestation_path(id: manifestation.id)
+
+      expect(page).to have_css('.impressions-count', text: '1,234,568', wait: 5)
+      expect(page).to have_css('.impressions-count', text: I18n.t(:impressions_count))
+    end
+
+    it 'does not show the view count to non-editors' do
+      login_as(regular_user)
+      visit manifestation_path(id: manifestation.id)
+
+      expect(page).to have_css('.headline-1-v02', wait: 5) # page rendered
+      expect(page).not_to have_css('.impressions-count')
+    end
+
+    it 'does not show the view count to anonymous visitors' do
+      visit manifestation_path(id: manifestation.id)
+
+      expect(page).to have_css('.headline-1-v02', wait: 5) # page rendered
+      expect(page).not_to have_css('.impressions-count')
+    end
+  end
+
+  describe 'Authority#toc' do
+    let!(:authority) { create(:authority, impressions_count: 7_654_321) }
+
+    it 'shows the view count with thousands separators to editors' do
+      login_as(editor)
+      visit authority_path(authority)
+
+      expect(page).to have_css('.impressions-count', text: '7,654,322', wait: 5)
+      expect(page).to have_css('.impressions-count', text: I18n.t(:impressions_count))
+    end
+
+    it 'does not show the view count to non-editors' do
+      login_as(regular_user)
+      visit authority_path(authority)
+
+      expect(page).to have_content(authority.name, wait: 5)
+      expect(page).not_to have_css('.impressions-count')
+    end
+
+    it 'does not show the view count to anonymous visitors' do
+      visit authority_path(authority)
+
+      expect(page).to have_content(authority.name, wait: 5)
+      expect(page).not_to have_css('.impressions-count')
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Displays the view counter (`impressions_count`) to editors in the metadata area of two views, right next to the existing editor-only action links:

- **Manifestation#read** — in `manifestation/_metadata`, after the edit/show/version-history links
- **Authority#toc** — in `authors/toc`, after the "edit metadata" link

The number is formatted with commas separating thousands and millions, followed by the label `צפיות` (I18n key `impressions_count`, added to both `he.yml` and `en.yml`). It is wrapped in a `.impressions-count` span styled with a thin grey border, small padding and a white background (added to `application.scss`, not the read-only `BY_*.css` files).

Visibility is gated on `current_user.editor?`, matching the surrounding editor-only blocks. Anonymous visitors and non-editor logged-in users see nothing.

## Notes

- `_metadata` is shared with `manifestation/print`, so editors will also see the counter on the print view. This is consistent with the existing editor action links, which already render there.
- The counter reflects the value after the current page view is tracked, since `track_view` increments the record before the view renders.

## Test plan

New system spec `spec/system/editor_impressions_count_spec.rb` (6 examples), covering both views for editors, non-editor logged-in users, and anonymous visitors, and asserting the comma formatting.

- `bundle exec rspec spec/system/editor_impressions_count_spec.rb` → 6 examples, 0 failures
- `bundle exec rspec` (full suite) → 2216 examples, 0 failures, 14 pending (all pre-existing)
- `bundle exec rspec spec/system` re-run after the SCSS change → 274 examples, 0 failures, 4 pending
- `haml-lint` and `rubocop` clean on the changed lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)