### PR TITLE
Fix donation popup being clipped behind the sticky header

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -213,6 +213,15 @@ header {overflow-x: hidden;} /* prevent horizontal scrollbar (caused by Slick's 
 .modal-backdrop { z-index: 2500 !important; }
 // Popovers (e.g. footnotes) must appear above the sticky header (z-index: 2000)
 .popover { z-index: 2100 !important; }
+// The IsraelGives donation modal (third-party IGmodal.css) ships z-index 1050/1040,
+// which puts it *below* our sticky header, clipping the top of the popup.
+.ig-modal {
+  z-index: 3000 !important;
+  // IGModal.js never sets the .ig-modal-open body class its CSS relies on for
+  // scrolling, so without this a popup taller than the viewport is unreachable.
+  overflow-y: auto !important;
+}
+.ig-modal-backdrop { z-index: 2500 !important; }
 .by-dropdown-content-v02 p {
   padding: 6px 15px;
   margin: 0;

--- a/spec/system/donation_popup_stacking_spec.rb
+++ b/spec/system/donation_popup_stacking_spec.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# The donation popup on /page/donate is an iframe modal injected by IsraelGives'
+# third-party IGModal.js. Their stylesheet gives it z-index 1050 (backdrop 1040),
+# which sits *below* our sticky #header (z-index 2000), so the top of the popup —
+# including its close button — used to be hidden behind the header.
+#
+# We deliberately do not load the third-party script in tests (external network,
+# flaky). Instead we reproduce the markup igModal.prototype.igAddHtml builds and
+# the upstream IGmodal.css declarations the stacking depends on, then assert our
+# override in application.scss wins.
+RSpec.describe 'IsraelGives donation popup stacking', :js, type: :system do
+  before do
+    skip 'WebDriver not available or misconfigured' unless webdriver_available?
+  end
+
+  # Verbatim subset of https://www.israelgives.org/Content/IGModal/IGmodal.css
+  let(:upstream_ig_css) do
+    <<~CSS
+      .ig-modal { position: fixed; top: 0; right: 0; bottom: 0; left: 0;
+                  z-index: 1050; display: none; overflow: hidden; outline: 0; }
+      .ig-modal.ig-show { display: block !important; }
+      .ig-modal-backdrop { position: fixed; top: 0; right: 0; bottom: 0; left: 0;
+                           z-index: 1040; background-color: #000; }
+      .ig-modal-backdrop.ig-show { opacity: .5; display: block !important; }
+    CSS
+  end
+
+  let!(:donate_page) do
+    create(
+      :static_page,
+      tag: 'donate-popup-stacking',
+      title: 'תמיכה כספית בפרויקט בן־יהודה',
+      body: '<div class="btn linky ig_open_modal">לחצ/י לתרומה | Donate Now</div>'
+    )
+  end
+
+  # Mirrors what IGModal.js appends to <body> when the donate button is clicked.
+  def open_ig_modal
+    page.execute_script(<<~JS, upstream_ig_css)
+      var style = document.createElement('style');
+      style.textContent = arguments[0];
+      document.head.appendChild(style);
+
+      var backdrop = document.createElement('div');
+      backdrop.id = 'igBbackdrop';
+      backdrop.className = 'ig-modal-backdrop ig-show';
+      document.body.appendChild(backdrop);
+
+      var modal = document.createElement('div');
+      modal.id = 'igModal';
+      modal.className = 'ig-modal ig-fade ig-show';
+      modal.setAttribute('role', 'dialog');
+      document.body.appendChild(modal);
+    JS
+  end
+
+  # id of whatever is painted topmost at the centre of the sticky header
+  def topmost_element_id_over_header
+    page.evaluate_script(<<~JS)
+      (function () {
+        var rect = document.getElementById('header').getBoundingClientRect();
+        var el = document.elementFromPoint(rect.left + rect.width / 2,
+                                           rect.top + rect.height / 2);
+        return el ? el.id : null;
+      })();
+    JS
+  end
+
+  it 'paints the popup above the sticky header instead of behind it' do
+    visit static_pages_by_tag_path(donate_page.tag)
+    expect(page).to have_css('.ig_open_modal', wait: 5)
+
+    open_ig_modal
+
+    expect(page).to have_css('#igModal.ig-show', visible: true, wait: 5)
+    expect(topmost_element_id_over_header).to eq('igModal')
+  end
+
+  it 'keeps a popup taller than the viewport scrollable rather than clipping it' do
+    visit static_pages_by_tag_path(donate_page.tag)
+    expect(page).to have_css('.ig_open_modal', wait: 5)
+
+    open_ig_modal
+
+    # IGModal.js never adds the .ig-modal-open body class its CSS keys scrolling
+    # off, so without our override .ig-modal stays overflow: hidden.
+    overflow_y = page.evaluate_script(
+      "window.getComputedStyle(document.getElementById('igModal')).overflowY"
+    )
+    expect(overflow_y).to eq('auto')
+  end
+end

--- a/spec/system/donation_popup_stacking_spec.rb
+++ b/spec/system/donation_popup_stacking_spec.rb
@@ -61,7 +61,9 @@ RSpec.describe 'IsraelGives donation popup stacking', :js, type: :system do
   def topmost_element_id_over_header
     page.evaluate_script(<<~JS)
       (function () {
-        var rect = document.getElementById('header').getBoundingClientRect();
+        var header = document.getElementById('header');
+        if (!header) { return null; }
+        var rect = header.getBoundingClientRect();
         var el = document.elementFromPoint(rect.left + rect.width / 2,
                                            rect.top + rect.height / 2);
         return el ? el.id : null;


### PR DESCRIPTION
## Problem

The donation popup on `/page/donate` is rendered partially behind the sticky site header — its title bar, the tax-deductibility note, and the close (×) button are all invisible.

The popup is an iframe modal injected by IsraelGives' third-party `IGModal.js` (loaded via a `<script>` tag inside the donate static page body). Their stylesheet ships:

```css
.ig-modal          { z-index: 1050; }
.ig-modal-backdrop { z-index: 1040; }
```

Our `#header` is `position: fixed; z-index: 2000` (`application.scss:206`), so the header simply paints over the top of the popup. The backdrop doesn't darken the header area either, for the same reason.

## Fix

Override both z-indexes above the header, exactly mirroring what we already do a few lines up for Bootstrap's `.modal` / `.modal-backdrop` (3000 / 2500). We can't change israelgives.org's CSS, so overriding their class names is the only hook available.

Also included: `overflow-y: auto` on `.ig-modal`. Their CSS keys modal scrolling off a `.ig-modal-open` body class that `IGModal.js` never actually adds, leaving the modal permanently `overflow: hidden` — so on a short viewport the bottom of a tall popup (e.g. the expanded credit-card step) is unreachable. Same family of bug, one line.

## Test plan

New system spec `spec/system/donation_popup_stacking_spec.rb`. It deliberately does **not** load the third-party script (external network → flaky); instead it reproduces the markup `igModal.prototype.igAddHtml` builds plus the verbatim upstream `IGmodal.css` declarations the stacking depends on, then asserts:

1. `document.elementFromPoint()` over the centre of the sticky header returns the modal, not the header.
2. `.ig-modal` computes to `overflow-y: auto`.

Both examples fail on master (`got: "header"` / `got: "hidden"`) and pass with the fix.

Additionally verified end-to-end against the **live** IsraelGives widget in a real browser against the dev server: modal `z-index` resolves to 3000, `overflow-y` to `auto`, and the topmost element over the header becomes `igPaymentIFrame`. Screenshot check confirms the title bar and × button are now visible.

Note: the full suite was not run for this change at the maintainer's direction.

Closes by-t02

🤖 Generated with [Claude Code](https://claude.com/claude-code)