### PR TITLE
Lexicon: report broken-link corrections to Monday

### DIFF
--- a/app/assets/javascripts/verification.js
+++ b/app/assets/javascripts/verification.js
@@ -30,6 +30,14 @@ function initVerification() {
         showToast(linkCheckToastMessage, linkCheckToastType);
     }
 
+    // Show a failure toast when a broken-link correction could not be reported to Monday.
+    // Always an error, so only the message is carried across the reload.
+    const mondayToastMessage = sessionStorage.getItem('monday-report-toast-message');
+    if (mondayToastMessage) {
+        sessionStorage.removeItem('monday-report-toast-message');
+        showToast(mondayToastMessage, 'error');
+    }
+
     // Remove legacy key left by older code versions (no-op if already absent).
     sessionStorage.removeItem('source_scroll_top');
 

--- a/app/controllers/concerns/link_checking_concern.rb
+++ b/app/controllers/concerns/link_checking_concern.rb
@@ -3,6 +3,7 @@
 # Shared synchronous external-link (re-)checking for Lexicon controllers that let editors
 # edit a URL (LexLink and LexCitation). On a URL change the controller re-checks the link
 # and stores the fresh HTTP status on the record, exposing a toast for the JS response.
+# Also reports corrections of previously-broken links to Monday (see #report_broken_link_fix).
 #
 # Records differ in their column names, so the caller passes them in:
 #   - LexLink:     status_column: :http_status,      checked_at_column: :checked_at
@@ -29,6 +30,28 @@ module LinkCheckingConcern
     # verification view, and the toast must survive into the reloaded request.
     flash[:link_check_toast_type] = @link_toast_type
     flash[:link_check_toast_message] = @link_toast_message
+  end
+
+  # Files a Monday report when an editor replaces a link that link-checking had flagged as
+  # broken, so the correction can be tracked alongside the other verification reports.
+  # Limited to entries still in the migration verification workflow: routine link maintenance
+  # on published entries is not part of migration verification and is not reported.
+  # A failed report never blocks the save; it only raises a toast (see the update.js.erb views).
+  def report_broken_link_fix(record, entry, old_link)
+    return unless entry&.needs_verification?
+
+    result = Lexicon::MondayReport.call(
+      entry: entry,
+      report_type: :fixed_broken_link,
+      current_url: lexicon_verification_url(entry),
+      record: record,
+      old_link: old_link
+    )
+    return if result[:success]
+
+    Rails.logger.error("#{self.class.name}: Monday broken-link report failed: #{result[:error]}")
+    @monday_report_failed = true
+    @monday_toast_message = t('lexicon.verification.monday.report_error')
   end
 
   def link_toast_for(status)

--- a/app/controllers/lexicon/citations_controller.rb
+++ b/app/controllers/lexicon/citations_controller.rb
@@ -38,6 +38,9 @@ module Lexicon
 
     def update
       old_subject_title = @citation.subject_title
+      # Captured before assign_attributes: link_broken? must be evaluated against the stored link
+      link_was_broken = @citation.link_broken?
+      old_link = @citation.link
       @citation.assign_attributes(lex_citation_params)
       new_subject_title = @citation.subject_title
 
@@ -51,6 +54,7 @@ module Lexicon
         if @citation.saved_change_to_link?
           check_link_synchronously(@citation, @citation.link,
                                    status_column: :link_http_status, checked_at_column: :link_checked_at)
+          report_broken_link_fix(@citation, @person.entry, old_link) if link_was_broken
         end
         return
       end

--- a/app/controllers/lexicon/links_controller.rb
+++ b/app/controllers/lexicon/links_controller.rb
@@ -34,11 +34,16 @@ module Lexicon
     def edit; end
 
     def update
+      # Captured before the update: broken? must be evaluated against the stored URL
+      link_was_broken = @link.broken?
+      old_url = @link.url
+
       if @link.update(lex_link_params)
         # Re-check the link only when its URL actually changed, so a previously-broken
         # link (e.g. HTTP 403) is re-evaluated instead of keeping its stale status.
         if @link.saved_change_to_url?
           check_link_synchronously(@link, @link.url, status_column: :http_status, checked_at_column: :checked_at)
+          report_broken_link_fix(@link, @item.entry, old_url) if link_was_broken
         end
         return
       end

--- a/app/models/lex_entry.rb
+++ b/app/models/lex_entry.rb
@@ -37,8 +37,11 @@ class LexEntry < ApplicationRecord
 
   validates :title, :sort_title, :status, presence: true
 
+  # Statuses in which an entry is still part of the migration verification workflow
+  VERIFICATION_STATUSES = %i(draft verifying error escalated).freeze
+
   # Scopes for verification queue
-  scope :needs_verification, -> { where(status: %i(draft verifying error escalated)) }
+  scope :needs_verification, -> { where(status: VERIFICATION_STATUSES) }
   scope :in_verification, -> { where(status: :verifying) }
 
   # Main entries are shown in /lex; secondary entries (main: false) are only
@@ -57,6 +60,12 @@ class LexEntry < ApplicationRecord
     elsif lex_item.is_a?(LexPublication) || lex_file&.entrytype_text?
       :publication
     end
+  end
+
+  # Instance-level counterpart of the needs_verification scope: is this entry still
+  # going through migration verification (as opposed to published/deprecated)?
+  def needs_verification?
+    VERIFICATION_STATUSES.include?(status.to_sym)
   end
 
   # returns link to page representing this entry in old lexicon system

--- a/app/services/lexicon/monday_report.rb
+++ b/app/services/lexicon/monday_report.rb
@@ -13,16 +13,24 @@ module Lexicon
     end
 
     # @param entry [LexEntry]
-    # @param report_type [Symbol] :general or :missing_work
+    # @param report_type [Symbol] :general, :missing_work or :fixed_broken_link
     # @param current_url [String] full URL of the verification page
     # @param description [String, nil] free-text (only for :general reports)
     # @param publication [Publication, nil] the publication missing from the lexicon (only for :missing_work)
-    def initialize(entry:, report_type:, current_url:, description: nil, publication: nil)
+    # @param record [LexCitation, LexLink, nil] the record whose broken link was replaced
+    #   (only for :fixed_broken_link)
+    # @param old_link [String, nil] the broken URL that was replaced (only for :fixed_broken_link)
+    # rubocop:disable Metrics/ParameterLists -- keyword args, each optional and specific to a report_type
+    def initialize(entry:, report_type:, current_url:, description: nil, publication: nil, record: nil,
+                   old_link: nil)
+      # rubocop:enable Metrics/ParameterLists
       @entry = entry
       @report_type = report_type
       @current_url = current_url
       @description = description
       @publication = publication
+      @record = record
+      @old_link = old_link
     end
 
     def call
@@ -50,7 +58,11 @@ module Lexicon
         'text_mm2tn5yc' => @entry.title,
         'link_mm2t7e9n' => { 'url' => @current_url, 'text' => I18n.t('lexicon.verification.monday.link_text') }
       }
-      long_text = @report_type == :missing_work ? publication_details : @description
+      long_text = case @report_type
+                  when :missing_work then publication_details
+                  when :fixed_broken_link then fixed_broken_link_details
+                  else @description
+                  end
       values['long_text_mm2tzz8q'] = long_text if long_text.present?
       values
     end
@@ -64,9 +76,40 @@ module Lexicon
              year: @publication.pub_year.presence || I18n.t('unknown'))
     end
 
+    # Old and new values of a link that an editor replaced after it was flagged as broken.
+    # A cleared link is reported explicitly rather than as an empty value.
+    def fixed_broken_link_details
+      return nil if @record.nil?
+
+      removed = I18n.t('lexicon.verification.monday.link_removed')
+      I18n.t('lexicon.verification.monday.fixed_broken_link_details',
+             old_link: @old_link.presence || removed,
+             new_link: current_link.presence || removed)
+    end
+
+    # LexCitation and LexLink store the URL under different column names.
+    def current_link
+      @record.is_a?(LexLink) ? @record.url : @record.link
+    end
+
+    # Identifies the corrected record in the report title: a citation by its title,
+    # a link by its description (falling back to the URL itself when unlabelled).
+    def fixed_broken_link_subject
+      if @record.is_a?(LexLink)
+        I18n.t('lexicon.verification.monday.fixed_broken_link_subject.link',
+               title: @record.description.presence || @record.url)
+      else
+        I18n.t('lexicon.verification.monday.fixed_broken_link_subject.citation', title: @record.title)
+      end
+    end
+
     def item_name_column
-      if @report_type == :missing_work
+      case @report_type
+      when :missing_work
         I18n.t('lexicon.verification.monday.missing_work_name', title: @publication&.title || @entry.title)
+      when :fixed_broken_link
+        I18n.t('lexicon.verification.monday.fixed_broken_link_name',
+               subject: @record.nil? ? @entry.title : fixed_broken_link_subject)
       else
         I18n.t('lexicon.verification.monday.general_name')
       end

--- a/app/views/lexicon/citations/update.js.erb
+++ b/app/views/lexicon/citations/update.js.erb
@@ -4,12 +4,18 @@ if ($('#citations').length) {
   <% if @link_check_performed %>
   showToast(<%= @link_toast_message.to_json %>, '<%= @link_toast_type %>');
   <% end %>
+  <% if @monday_report_failed %>
+  showToast(<%= @monday_toast_message.to_json %>, 'error');
+  <% end %>
 } else {
   // Verification view: store toast data in sessionStorage so it survives the page reload.
   // flash.now (set by the controller) only lives for the current JS response, not the reload.
 <% if @link_check_performed %>
   sessionStorage.setItem('link-check-toast-type', <%= @link_toast_type.to_json %>);
   sessionStorage.setItem('link-check-toast-message', <%= @link_toast_message.to_json %>);
+<% end %>
+<% if @monday_report_failed %>
+  sessionStorage.setItem('monday-report-toast-message', <%= @monday_toast_message.to_json %>);
 <% end %>
   // Reload is triggered by the openModal onSuccess callback; setTimeout is a safety fallback.
   setTimeout(function() { reloadPage(); }, 300);

--- a/app/views/lexicon/links/update.js.erb
+++ b/app/views/lexicon/links/update.js.erb
@@ -4,12 +4,18 @@ if ($('#links').length) {
   <% if @link_check_performed %>
   showToast(<%= @link_toast_message.to_json %>, '<%= @link_toast_type %>');
   <% end %>
+  <% if @monday_report_failed %>
+  showToast(<%= @monday_toast_message.to_json %>, 'error');
+  <% end %>
 } else {
   // Verification view: store toast data in sessionStorage so it survives the page reload.
   // flash (set by the controller) is also embedded into the reloaded page as a fallback if sessionStorage isn't available.
 <% if @link_check_performed %>
   sessionStorage.setItem('link-check-toast-type', <%= @link_toast_type.to_json %>);
   sessionStorage.setItem('link-check-toast-message', <%= @link_toast_message.to_json %>);
+<% end %>
+<% if @monday_report_failed %>
+  sessionStorage.setItem('monday-report-toast-message', <%= @monday_toast_message.to_json %>);
 <% end %>
   // Reload is triggered by the edit-button onSuccess callback; setTimeout is a safety fallback.
   setTimeout(function() { reloadPage(); }, 300);

--- a/config/locales/lexicon.en.yml
+++ b/config/locales/lexicon.en.yml
@@ -369,3 +369,9 @@ en:
         missing_work_name: "The work %{title} is known in the bibliography but does not appear in the lexicon entry."
         missing_work_details: "Publisher: %{publisher}. Year: %{year}."
         missing_work_reported: "Already reported"
+        fixed_broken_link_name: "A broken link was replaced in %{subject}."
+        fixed_broken_link_subject:
+          citation: "the citation %{title}"
+          link: "the link %{title}"
+        fixed_broken_link_details: "Previous link: %{old_link}. New link: %{new_link}."
+        link_removed: "(no link)"

--- a/config/locales/lexicon.he.yml
+++ b/config/locales/lexicon.he.yml
@@ -370,3 +370,9 @@ he:
         missing_work_name: "החיבור %{title} ידוע בביבליוגרפיה אך לא מופיע בערך הלקסיקון."
         missing_work_details: "מו״ל: %{publisher}. שנת הוצאה: %{year}."
         missing_work_reported: "דווח בעבר"
+        fixed_broken_link_name: "קישור שבור הוחלף ב%{subject}."
+        fixed_broken_link_subject:
+          citation: "מראה המקום %{title}"
+          link: "קישור %{title}"
+        fixed_broken_link_details: "הקישור הקודם: %{old_link}. הקישור החדש: %{new_link}."
+        link_removed: "(ללא קישור)"

--- a/spec/models/lex_entry_spec.rb
+++ b/spec/models/lex_entry_spec.rb
@@ -386,6 +386,20 @@ RSpec.describe LexEntry, type: :model do
     end
   end
 
+  describe '#needs_verification?' do
+    it 'is true for the same statuses matched by the needs_verification scope' do
+      LexEntry::VERIFICATION_STATUSES.each do |status|
+        expect(create(:lex_entry, status: status).needs_verification?).to be(true)
+      end
+    end
+
+    it 'is false once the entry has left the verification workflow' do
+      %i(published deprecated verified).each do |status|
+        expect(create(:lex_entry, status: status).needs_verification?).to be(false)
+      end
+    end
+  end
+
   describe '#redo_migration_eligible?' do
     it 'is true for draft, verifying, and escalated entries that have a lex_file' do
       %i(draft verifying escalated).each do |status|

--- a/spec/requests/lexicon/citations_spec.rb
+++ b/spec/requests/lexicon/citations_spec.rb
@@ -195,6 +195,115 @@ describe '/lexicon/citations' do
       end
     end
 
+    context 'when a broken link is replaced' do
+      let(:checker) { instance_double(Lexicon::CheckExternalLinks, check_url: 200) }
+      let(:entry) { create(:lex_entry, :person, status: :verifying) }
+      let(:person) { entry.lex_item }
+      let(:old_link) { 'https://dead.example.com/page' }
+      let(:citation) do
+        create(:lex_citation, person: person, title: 'על מוישה זוכמיר', link: old_link,
+                              link_http_status: 404, link_checked_at: 1.day.ago)
+      end
+      let(:citation_params) { { link: 'https://alive.example.com/page' } }
+
+      before do
+        allow(Lexicon::CheckExternalLinks).to receive(:new).and_return(checker)
+        allow(Lexicon::MondayReport).to receive(:call).and_return({ success: true })
+      end
+
+      it 'reports the citation, the old link and the new link to Monday' do
+        call
+
+        expect(Lexicon::MondayReport).to have_received(:call).with(
+          hash_including(entry: entry, report_type: :fixed_broken_link, record: citation, old_link: old_link)
+        )
+      end
+
+      it 'reports the link that was stored before the edit, not the new one' do
+        call
+
+        expect(Lexicon::MondayReport).to have_received(:call) do |args|
+          expect(args[:old_link]).to eq(old_link)
+          expect(args[:record].link).to eq('https://alive.example.com/page')
+        end
+      end
+
+      it 'still saves the citation and raises no toast when the report succeeds' do
+        expect(call).to eq(200)
+        expect(citation.reload.link).to eq('https://alive.example.com/page')
+        expect(response.body).not_to include('monday-report-toast-message')
+      end
+
+      context 'when the replacement link is also broken' do
+        let(:checker) { instance_double(Lexicon::CheckExternalLinks, check_url: 404) }
+
+        it 'still reports the change' do
+          call
+
+          expect(Lexicon::MondayReport).to have_received(:call).with(
+            hash_including(report_type: :fixed_broken_link)
+          )
+        end
+      end
+
+      context 'when the broken link is cleared rather than replaced' do
+        let(:citation_params) { { link: '' } }
+
+        it 'reports the removal' do
+          call
+
+          expect(Lexicon::MondayReport).to have_received(:call).with(
+            hash_including(report_type: :fixed_broken_link, old_link: old_link)
+          )
+        end
+      end
+
+      context 'when the entry is no longer in verification' do
+        let(:entry) { create(:lex_entry, :person, status: :published) }
+
+        it 'does not report' do
+          call
+
+          expect(Lexicon::MondayReport).not_to have_received(:call)
+        end
+      end
+
+      context 'when the previous link was never flagged as broken' do
+        let(:citation) do
+          create(:lex_citation, person: person, link: old_link, link_http_status: 200, link_checked_at: 1.day.ago)
+        end
+
+        it 'does not report' do
+          call
+
+          expect(Lexicon::MondayReport).not_to have_received(:call)
+        end
+      end
+
+      context 'when the link is not changed' do
+        let(:citation_params) { { title: 'New Title', link: old_link } }
+
+        it 'does not report' do
+          call
+
+          expect(Lexicon::MondayReport).not_to have_received(:call)
+        end
+      end
+
+      context 'when the Monday report fails' do
+        before do
+          allow(Lexicon::MondayReport).to receive(:call).and_return({ success: false, error: 'Invalid token' })
+        end
+
+        it 'saves the citation anyway and raises a failure toast' do
+          expect(call).to eq(200)
+          expect(citation.reload.link).to eq('https://alive.example.com/page')
+          expect(response.body).to include('monday-report-toast-message')
+          expect(response.body).to include(I18n.t('lexicon.verification.monday.report_error'))
+        end
+      end
+    end
+
     context 'when link is cleared' do
       let(:citation) { create(:lex_citation, person: person, link: 'https://old.example.com/', link_http_status: 404) }
       let(:citation_params) { { link: '' } }

--- a/spec/requests/lexicon/links_spec.rb
+++ b/spec/requests/lexicon/links_spec.rb
@@ -92,6 +92,9 @@ describe '/lexicon/links' do
 
       before do
         allow(Lexicon::CheckExternalLinks).to receive(:new).and_return(checker)
+        # The link starts out broken, so correcting it now files a Monday report.
+        # Stubbed so these examples never reach the real board (see the dedicated context below).
+        allow(Lexicon::MondayReport).to receive(:call).and_return({ success: true })
         link.update_columns(http_status: 403, checked_at: 1.day.ago)
       end
 
@@ -131,6 +134,98 @@ describe '/lexicon/links' do
           expect(link.http_status).to be_nil
           expect(link.checked_at).to be_present
           expect(link).to be_broken
+        end
+      end
+    end
+
+    context 'when a broken URL is replaced' do
+      let(:checker) { instance_double(Lexicon::CheckExternalLinks, check_url: 200) }
+      let(:entry) { create(:lex_entry, :person, status: :verifying) }
+      let(:old_url) { 'https://dead.example.com/page' }
+      let(:link) { create(:lex_link, item: person, description: 'אתר הזיכרון', url: old_url) }
+      let(:link_params) { { url: 'https://alive.example.com/page' } }
+
+      before do
+        allow(Lexicon::CheckExternalLinks).to receive(:new).and_return(checker)
+        allow(Lexicon::MondayReport).to receive(:call).and_return({ success: true })
+        link.update_columns(http_status: 404, checked_at: 1.day.ago)
+      end
+
+      it 'reports the link, the old URL and the new URL to Monday' do
+        call
+
+        expect(Lexicon::MondayReport).to have_received(:call).with(
+          hash_including(entry: entry, report_type: :fixed_broken_link, record: link, old_link: old_url)
+        )
+      end
+
+      it 'reports the URL that was stored before the edit, not the new one' do
+        call
+
+        expect(Lexicon::MondayReport).to have_received(:call) do |args|
+          expect(args[:old_link]).to eq(old_url)
+          expect(args[:record].url).to eq('https://alive.example.com/page')
+        end
+      end
+
+      it 'still saves the link and raises no toast when the report succeeds' do
+        expect(call).to eq(200)
+        expect(link.reload.url).to eq('https://alive.example.com/page')
+        expect(response.body).not_to include('monday-report-toast-message')
+      end
+
+      context 'when the replacement URL is also broken' do
+        let(:checker) { instance_double(Lexicon::CheckExternalLinks, check_url: 404) }
+
+        it 'still reports the change' do
+          call
+
+          expect(Lexicon::MondayReport).to have_received(:call).with(
+            hash_including(report_type: :fixed_broken_link)
+          )
+        end
+      end
+
+      context 'when the entry is no longer in verification' do
+        let(:entry) { create(:lex_entry, :person, status: :published) }
+
+        it 'does not report' do
+          call
+
+          expect(Lexicon::MondayReport).not_to have_received(:call)
+        end
+      end
+
+      context 'when the previous URL was never flagged as broken' do
+        before { link.update_columns(http_status: 200, checked_at: 1.day.ago) }
+
+        it 'does not report' do
+          call
+
+          expect(Lexicon::MondayReport).not_to have_received(:call)
+        end
+      end
+
+      context 'when the URL is unchanged' do
+        let(:link_params) { { description: 'Updated description', url: old_url } }
+
+        it 'does not report' do
+          call
+
+          expect(Lexicon::MondayReport).not_to have_received(:call)
+        end
+      end
+
+      context 'when the Monday report fails' do
+        before do
+          allow(Lexicon::MondayReport).to receive(:call).and_return({ success: false, error: 'Invalid token' })
+        end
+
+        it 'saves the link anyway and raises a failure toast' do
+          expect(call).to eq(200)
+          expect(link.reload.url).to eq('https://alive.example.com/page')
+          expect(response.body).to include('monday-report-toast-message')
+          expect(response.body).to include(I18n.t('lexicon.verification.monday.report_error'))
         end
       end
     end

--- a/spec/services/lexicon/monday_report_spec.rb
+++ b/spec/services/lexicon/monday_report_spec.rb
@@ -174,6 +174,101 @@ RSpec.describe Lexicon::MondayReport do
       end
     end
 
+    context 'with a fixed_broken_link report' do
+      let(:person) { entry.lex_item }
+      let(:old_link) { 'https://dead.example.com/page' }
+      let(:new_link) { 'https://alive.example.com/page' }
+
+      def report(record)
+        described_class.call(
+          entry: entry, report_type: :fixed_broken_link, current_url: current_url,
+          record: record, old_link: old_link
+        )
+      end
+
+      shared_examples 'a broken-link correction report' do
+        it 'returns success when Monday API succeeds' do
+          stub_monday_success
+
+          expect(report(record)[:success]).to be true
+        end
+
+        it 'names the corrected record in the item name' do
+          captured_body = nil
+          stub_monday_success { |req| captured_body = req.body }
+
+          report(record)
+
+          expect(JSON.parse(captured_body)['query']).to include(expected_name)
+        end
+
+        it 'includes the old and new link values in the long_text column' do
+          captured_body = nil
+          stub_monday_success { |req| captured_body = req.body }
+
+          report(record)
+
+          query = JSON.parse(captured_body)['query']
+          expect(query).to include('long_text_mm2tzz8q')
+          expect(query).to include(old_link).and include(new_link)
+        end
+
+        it 'links back to the verification page' do
+          captured_body = nil
+          stub_monday_success { |req| captured_body = req.body }
+
+          report(record)
+
+          expect(JSON.parse(captured_body)['query']).to include(current_url)
+        end
+      end
+
+      context 'when the corrected record is a citation' do
+        let(:record) { create(:lex_citation, person: person, title: 'על מוישה זוכמיר', link: new_link) }
+        let(:expected_name) do
+          I18n.t('lexicon.verification.monday.fixed_broken_link_name',
+                 subject: I18n.t('lexicon.verification.monday.fixed_broken_link_subject.citation',
+                                 title: 'על מוישה זוכמיר'))
+        end
+
+        it_behaves_like 'a broken-link correction report'
+
+        it 'reports a cleared link with the link_removed label rather than an empty value' do
+          record.update!(link: nil)
+          captured_body = nil
+          stub_monday_success { |req| captured_body = req.body }
+          expected = I18n.t('lexicon.verification.monday.fixed_broken_link_details',
+                            old_link: old_link, new_link: I18n.t('lexicon.verification.monday.link_removed'))
+
+          report(record)
+
+          expect(JSON.parse(captured_body)['query']).to include(expected)
+        end
+      end
+
+      context 'when the corrected record is a link' do
+        let(:record) { create(:lex_link, item: person, description: 'אתר הזיכרון', url: new_link) }
+        let(:expected_name) do
+          I18n.t('lexicon.verification.monday.fixed_broken_link_name',
+                 subject: I18n.t('lexicon.verification.monday.fixed_broken_link_subject.link',
+                                 title: 'אתר הזיכרון'))
+        end
+
+        it_behaves_like 'a broken-link correction report'
+
+        it 'falls back to the URL when the link has no description' do
+          record.update!(description: nil)
+          captured_body = nil
+          stub_monday_success { |req| captured_body = req.body }
+          expected = I18n.t('lexicon.verification.monday.fixed_broken_link_subject.link', title: new_link)
+
+          report(record)
+
+          expect(JSON.parse(captured_body)['query']).to include(expected)
+        end
+      end
+    end
+
     context 'when Monday API returns an error response' do
       before { stub_monday_error('Invalid auth token') }
 


### PR DESCRIPTION
## What

When a verification editor replaces a link that link-checking had flagged as broken, file a report on the same Monday board used by the other verification reports (general notes, missing works). The report carries the record's title, the **old (replaced)** value and the **new** value, and links back to the verification page.

Covers both `LexCitation` links and `LexLink` URLs.

## Behavior decisions

- **Trigger**: any change away from a link that was broken — including a replacement that turns out to also be broken, and including a citation whose link is cleared (reported as a removal, using an explicit label rather than an empty value). `LexLink` validates URL presence, so it has no cleared case.
- **Scope**: only entries still in the migration verification workflow (`draft`/`verifying`/`error`/`escalated`). Routine link maintenance on published entries is not part of migration verification and files nothing.
- **Failure**: the report is filed after a successful save and never blocks it. A failed post is logged and shown to the editor as its own toast, on a separate channel so it does not clobber the existing link-check toast ("now accessible" / "still broken").

"Broken" is the existing `LexCitation#link_broken?` / `LexLink#broken?` definition, unchanged: checked, and either 4xx/5xx or an unreachable host. Broken state is captured *before* the attributes are assigned, since it must be evaluated against the stored link rather than the incoming one.

## Changes

- `app/controllers/concerns/link_checking_concern.rb` — new `#report_broken_link_fix`, alongside the existing shared re-check logic that already spans both record types. Each controller is 2 lines.
- `app/services/lexicon/monday_report.rb` — new `:fixed_broken_link` report type taking `record:` (either type) and `old_link:`.
- `app/models/lex_entry.rb` — `VERIFICATION_STATUSES` extracted from the existing `needs_verification` scope, plus an instance-level `#needs_verification?` so scope and predicate cannot drift.
- `app/views/lexicon/{citations,links}/update.js.erb`, `app/assets/javascripts/verification.js` — the separate failure-toast channel, surviving the verification view's page reload via sessionStorage.
- `config/locales/lexicon.{he,en}.yml` — `fixed_broken_link_name` takes a `%{subject}` supplied by `fixed_broken_link_subject.citation` / `.link`, so the report says which kind of record was corrected.

## Test plan

New coverage, for both citations and links: reports on replacement, on a still-broken replacement, and on clearing (citations); does *not* report for published entries, never-broken links, or unchanged links; the save survives a failed report and raises the toast; the reported old value is the pre-edit one. Service specs assert the item name, the old/new values in the long-text column, the link back to the verification page, and the description→URL fallback for unlabelled links.

Ran `spec/requests/lexicon/`, `spec/services/lexicon/`, `spec/models/lex_entry_spec.rb`, `spec/models/lex_citation_spec.rb` — 542 examples, 0 failures — plus `spec/system/lexicon/verification_link_check_spec.rb` and `spec/system/lexicon/verification_citation_link_check_spec.rb` (12 examples). RuboCop clean on all changed files. **The full suite was not run** (40+ min).

## Note for the reviewer

There is no global WebMock guard in this suite, and the existing `links_spec` "when the URL is changed" context already sets up a genuinely broken link. Those examples would have started invoking the real reporter — harmless where `MONDAY_*` is unset, but on a machine with those env vars exported, `rspec` would have posted real items to the board. `Lexicon::MondayReport` is now stubbed there. A suite-wide stub or WebMock guard may be worth adding separately.

Also worth knowing: where Monday env vars are unset (dev, staging), every broken-link fix will now show a red "report failed" toast. That is the intended reading of the failure behavior — an unconfigured production really is losing reports — but it will be noise in dev.

🤖 Generated with [Claude Code](https://claude.com/claude-code)