### PR TITLE
Lexicon: use the main-site palette for the entry sidebar's BY-sourced panes

### DIFF
--- a/app/assets/stylesheets/lexicon.scss
+++ b/app/assets/stylesheets/lexicon.scss
@@ -126,3 +126,55 @@ ul.lex {
   background-color: #efbfb7;
   color: #5E1228;
 }
+
+/* A card inside a lexicon entry whose content comes from the main Ben-Yehuda
+   database (the latest-works and works-about-this-author panes on the entry
+   sidebar) rather than from the lexicon. Such cards keep the main site's
+   palette, so these rules undo the `.peach2-lexicon` overrides for them. The
+   values are the main-site defaults from BY_styles_General.css; the selectors
+   are deliberately one class more specific than the peach rules they
+   countermand. */
+.peach2-lexicon .by-card-v02.main-palette-card {
+  background-color: #d9cdd5;
+
+  /* authors/_aboutnesses renders its own card, nested inside this one */
+  .by-card-v02,
+  .left-side-card-v02 {
+    background-color: #d9cdd5;
+  }
+
+  .by-card-header-left-v02 {
+    border-bottom: solid 2px #CBB3C3;
+  }
+
+  #author-whats-new-bg {
+    background-image: image-url('bullhorn.svg');
+  }
+
+  .new-card-v02 {
+    background-color: #eeeced;
+  }
+
+  .new-card-right-v02 {
+    background-color: #2b0d22;
+  }
+
+  .new-card-type-v02 {
+    background-image: image-url('new_bg1.png');
+  }
+
+  a {
+    color: #660248;
+
+    &:hover {
+      color: #2b0d22;
+      background-color: #d9cdd5;
+    }
+  }
+
+  /* the latest-works headline is a plain span, not a link, so on the main site it
+     gets no hover highlight at all (the base rule is scoped to `a .new-headline-v02`) */
+  .new-headline-v02:hover {
+    background-color: transparent;
+  }
+}

--- a/app/views/lexicon/entries/_show_person.html.haml
+++ b/app/views/lexicon/entries/_show_person.html.haml
@@ -63,9 +63,11 @@
       -#  = render partial: 'lexicon/shared/images', locals: { entry: lex_person.entry }
       .col
         - if lex_person.authority&.published?
-          .by-card-v02.left-side-card-v02
+          -# main-palette-card: these two panes show content from the main BY database, so they keep
+             the main site's colors rather than the lexicon's peach palette (see lexicon.scss)
+          .by-card-v02.left-side-card-v02.main-palette-card
             #author-whats-new-bg
               .by-card-content-v02.card-with-bottom-links.author-whats-new-content
                 = render partial: 'shared/latest_works_by_author', locals: { author: lex_person.authority }
-          .by-card-v02.left-side-card-v02
+          .by-card-v02.left-side-card-v02.main-palette-card
             = render partial: 'authors/aboutnesses', locals: { author: lex_person.authority }


### PR DESCRIPTION
## Summary

On a public lexicon entry, the two left-sidebar panes — **latest works** and **works about this author** — list content drawn from the main Ben-Yehuda database, not from the lexicon. They should therefore carry the main site's color palette (as in `Authority#toc`) rather than the lexicon's peach/salmon one.

Both panes sit inside the `.peach2-lexicon` wrapper, whose rules in `BY_styles_General.css` repaint `.by-card-v02`, `.left-side-card-v02`, `.new-card-v02`, `.new-card-right-v02`, `.by-card-header-left-v02`, the bullhorn / `new_bg1` background images, and link colors and hover highlights.

## Changes

- `app/views/lexicon/entries/_show_person.html.haml`: mark the two sidebar cards with a new `main-palette-card` class.
- `app/assets/stylesheets/lexicon.scss`: for that subtree only, restore the main-site defaults taken from `BY_styles_General.css` (card `#d9cdd5`, inner card `#eeeced`, icon column `#2b0d22`, `bullhorn.svg`, `new_bg1.png`, links `#660248` / hover `#2b0d22` on `#d9cdd5`, header rule `#CBB3C3`). Selectors are deliberately one class more specific than the peach rules they countermand.

`authors/_aboutnesses` renders its own nested `.by-card-v02.left-side-card-v02`, so the rules cover descendant cards as well.

`BY_styles_General.css` is untouched, per the project's read-only convention for the `BY_*.css` files.

## Test plan

Verified with a temporary Capybara system spec that drove a published lexicon entry (published authority + an aboutness) and asserted `getComputedStyle` values: all three cards `rgb(217, 205, 213)`, inner `.new-card-v02` `rgb(238, 236, 237)`, `.new-card-right-v02` `rgb(43, 13, 34)`, background images resolving to `bullhorn`/`new_bg1` and not their `_peach` variants, and the header border `rgb(203, 179, 195)`. 3 examples, 0 failures. The spec was removed before commit at the author's request — no permanent spec is kept for this CSS-only change.

`haml-lint` on the changed view reports only pre-existing lints (lines 13, 42, 49, 55); none on the changed lines. The full RSpec suite was **not** run (40+ min; needs explicit approval).

Closes beads_by-31j

🤖 Generated with [Claude Code](https://claude.com/claude-code)