### PR TITLE
Lexicon: stick the entry sections navbar below the actual header height

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1296,15 +1296,20 @@ p.by-genre-name-v02.headline-2-v02 {
 	overflow-y: auto;
 }
 
-/* Sticky navbar for lexicon entries */
+/* Sticky navbar for lexicon entries.
+ * --lexicon-sticky-top is measured from the fixed #header at runtime (see
+ * lexicon/entries/_navbar), because the header's height varies: the entry
+ * header adds a breadcrumbs/actions row that stays visible when scrolled, and
+ * editors get an extra "edit" button plus the dashboard link in the top bar.
+ * The literals below are only the pre-JS fallback. */
 .peach2-lexicon .side-menu-area {
 	position: sticky;
-  top: 80px;
+  top: var(--lexicon-sticky-top, 80px);
 	align-self: flex-start;
 }
 
 .peach2-lexicon .side-menu-area .book-nav-full {
-	max-height: calc(100vh - 100px);
+	max-height: calc(100vh - var(--lexicon-sticky-top, 80px) - 20px);
 	overflow-y: auto;
 }
 
@@ -1329,12 +1334,12 @@ p.by-genre-name-v02.headline-2-v02 {
 
   .peach2-lexicon .side-menu-area {
     position: sticky;
-    top: 60px;
+    top: var(--lexicon-sticky-top, 60px);
     align-self: flex-start;
   }
 
   .peach2-lexicon .side-menu-area .book-nav-full {
-    max-height: calc(100vh - 80px);
+    max-height: calc(100vh - var(--lexicon-sticky-top, 60px) - 20px);
     overflow-y: auto;
   }
 }

--- a/app/views/lexicon/entries/_navbar.html.haml
+++ b/app/views/lexicon/entries/_navbar.html.haml
@@ -57,7 +57,7 @@
     var pendingFrame = false;
 
     function stickyTop() {
-      return Math.round($('#header').outerHeight() || 0) + HEADER_GAP;
+      return Math.ceil($('#header').outerHeight() || 0) + HEADER_GAP;
     }
 
     function applyStickyTop() {

--- a/app/views/lexicon/entries/_navbar.html.haml
+++ b/app/views/lexicon/entries/_navbar.html.haml
@@ -47,6 +47,34 @@
 
 :javascript
   $(document).ready(function() {
+    // The site header is position:fixed, and its height is not constant: the lexicon
+    // entry header adds a breadcrumbs/actions row (which keeps its buttons visible
+    // when scrolled, and holds an extra "edit" button for editors), and the whole
+    // header shrinks once the layout adds .scrolled. So measure it instead of
+    // hardcoding an offset, and publish it for the sticky sidebar CSS to consume.
+    var HEADER_GAP = 8;
+    var lastStickyTop = null;
+    var pendingFrame = false;
+
+    function stickyTop() {
+      return Math.round($('#header').outerHeight() || 0) + HEADER_GAP;
+    }
+
+    function applyStickyTop() {
+      pendingFrame = false;
+      var top = stickyTop();
+      if (top === lastStickyTop) return;
+      lastStickyTop = top;
+      document.documentElement.style.setProperty('--lexicon-sticky-top', top + 'px');
+    }
+
+    applyStickyTop();
+    $(window).on('scroll resize', function() {
+      if (pendingFrame) return;
+      pendingFrame = true;
+      window.requestAnimationFrame(applyStickyTop);
+    });
+
     // Handle clicks on navbar items (scoped to #genre-nav to avoid affecting other navbars)
     $('#genre-nav .nav-item[data-scroll-target]').click(function(e) {
       var scrollTarget = $(this).data('scroll-target');
@@ -55,7 +83,7 @@
       $('#genre-nav .nav-link').removeClass('active').attr('aria-selected', 'false');
       $(this).find('.nav-link').addClass('active').attr('aria-selected', 'true');
       if (scrollTarget && $(scrollTarget).length > 0) {
-        var offset = $(scrollTarget).offset().top - 120;
+        var offset = $(scrollTarget).offset().top - stickyTop();
         $('html, body').animate({
           scrollTop: offset
         }, 500);

--- a/spec/system/lexicon/entry_navbar_sticky_offset_spec.rb
+++ b/spec/system/lexicon/entry_navbar_sticky_offset_spec.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# The sections navbar on a lexicon entry page sticks below the fixed site header. Its offset used
+# to be a hardcoded 80px, which ignored the entry's breadcrumbs/actions row (whose buttons stay
+# visible when scrolled) and the extra height an editor's header carries - so for editors the top
+# of the navbar ended up hidden behind the header.
+RSpec.describe 'Lexicon entry sticky navbar offset', :js, type: :system do
+  let(:paragraph) { (['פסקה של ביוגרפיה, ארוכה דיה כדי שאפשר יהיה לגלול את העמוד.'] * 12).join(' ') }
+  let(:bio) { Array.new(15) { "<p>#{paragraph}</p>" }.join("\n") }
+
+  let(:person) { create(:lex_person, bio: bio) }
+  let!(:entry) { create(:lex_entry, :person, title: 'Test Person', lex_item: person, status: :published) }
+
+  before { skip 'WebDriver not available or misconfigured' unless webdriver_available? }
+
+  # Vertical gap between the bottom of the fixed header and the top of the stuck navbar column.
+  # Negative means the navbar is (partly) hidden behind the header.
+  def navbar_top_minus_header_bottom
+    page.evaluate_script(<<~JS)
+      (function() {
+        var header = document.getElementById('header');
+        var nav = document.querySelector('.peach2-lexicon .side-menu-area');
+        return nav.getBoundingClientRect().top - header.getBoundingClientRect().bottom;
+      })()
+    JS
+  end
+
+  # Lets the browser settle after a scroll: the layout's own scroll handler toggles the header's
+  # .scrolled state, and the sticky offset is then recomputed in a requestAnimationFrame.
+  def await_two_animation_frames
+    page.evaluate_async_script(<<~JS)
+      var done = arguments[0];
+      requestAnimationFrame(function() { requestAnimationFrame(done); });
+    JS
+  end
+
+  shared_examples 'sticks just below the header' do
+    it 'keeps the navbar fully clear of the fixed header once stuck' do
+      visit lexicon_entry_path(entry)
+      expect(page).to have_css('#genrenav')
+
+      page.execute_script('window.scrollTo(0, 1200);')
+      expect(page).to have_css('body.scrolled') # set by the layout's scroll handler
+      await_two_animation_frames
+
+      gap = navbar_top_minus_header_bottom
+
+      # Fully below the header (>= 0), and actually stuck to it rather than scrolled off.
+      expect(gap).to be >= 0
+      expect(gap).to be <= 30
+    end
+  end
+
+  context 'when visiting as an anonymous visitor' do
+    it_behaves_like 'sticks just below the header'
+  end
+
+  context 'when visiting as a lexicon editor' do
+    before { login_as_lexicon_editor }
+
+    it 'shows the editor actions row inside the fixed header' do
+      visit lexicon_entry_path(entry)
+      expect(page).to have_css('#header #header-lexicon-entry .entry-top-actions', text: I18n.t(:edit))
+    end
+
+    it_behaves_like 'sticks just below the header'
+  end
+end


### PR DESCRIPTION
## Problem

On the public lexicon entry page the sections navbar (`#genrenav`) is sticky, but its offset was a hardcoded `top: 80px`. That ignores the entry's breadcrumbs/actions row, which is rendered *inside* the fixed `#header`, keeps its "back to list" / "edit" buttons visible after the header collapses on scroll, and is taller for editors (who also get the "back to dashboard" link in the top bar). Measured at 1400x900, the navbar's top sat ~49px behind the header once stuck.

## Change

- `app/assets/stylesheets/application.scss`: the sticky `top` (and the `book-nav-full` max-height) now read `var(--lexicon-sticky-top, …)`; the previous literals stay as pre-JS fallbacks.
- `app/views/lexicon/entries/_navbar.html.haml`: measure `#header` and publish the value as `--lexicon-sticky-top`, recomputed on scroll/resize inside a `requestAnimationFrame` (the header changes height when the layout toggles `.scrolled`).
- Same partial: the click-to-scroll offset used the same magic number (`- 120`) and now uses the same measurement, so a clicked section no longer lands under the header.

## Test plan

New regression spec `spec/system/lexicon/entry_navbar_sticky_offset_spec.rb` scrolls the entry page and asserts the navbar's top is at or below the header's bottom (and still stuck to it), both anonymously and as a lexicon editor. It fails on the current `lexicon` branch with `gap = -48.9` and passes with this change.

Ran:

```
bundle exec rspec spec/system/lexicon/entry_navbar_sticky_offset_spec.rb \
                  spec/system/lexicon/entries_navbar_spec.rb \
                  spec/system/lexicon/bio_image_float_spec.rb
# 14 examples, 0 failures
```

The full suite was **not** run (40+ min) — it needs your go-ahead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)