### PR TITLE
Lexicon: omit benyehuda.org self-links from migrated LexLinks

### DIFF
--- a/app/services/lexicon/associate_authority.rb
+++ b/app/services/lexicon/associate_authority.rb
@@ -12,7 +12,6 @@ module Lexicon
   #
   # Sets lex_person.authority and saves if an authority is found.
   class AssociateAuthority < ApplicationService
-    BENYEHUDA_HOST_PATTERN = %r{\Ahttps?://(?:www\.)?benyehuda\.org}i
     WIKIDATA_ENTITY_PATTERN = %r{wikidata\.org/(?:wiki|entity)/(Q\d+)}i
     WIKIDATA_API_BASE = 'https://www.wikidata.org'
     # P7507 = Project Ben-Yehuda author ID property on Wikidata
@@ -34,39 +33,11 @@ module Lexicon
 
     def find_by_benyehuda_link(html_doc)
       html_doc.css('a[href]').each do |link|
-        href = link['href'].to_s
-        next unless href.match?(BENYEHUDA_HOST_PATTERN)
-
-        begin
-          path = URI.parse(href).path
-        rescue URI::InvalidURIError
-          next
-        end
-
-        next if path.blank?
-
-        authority = authority_from_benyehuda_path(path)
+        authority = BenyehudaLinks.authority_for(link['href'])
         return authority if authority
       end
 
       nil
-    end
-
-    # Emulates what HtmlFileController#render_by_legacy_url does to resolve a path to an Authority.
-    def authority_from_benyehuda_path(path)
-      # Numeric ID: /author/1234 or /author/1234/
-      if (match = path.match(%r{\A/author/(\d+)/?\z}))
-        return Authority.find_by(id: match[1].to_i)
-      end
-
-      # Non-numeric slug: /shats or /shats/index
-      # Extract first non-numeric path segment and look up in HtmlDir.
-      # HtmlDir belongs_to :person (Person model), which has_one :authority.
-      segment = path.split('/').compact_blank.first
-      return nil if segment.blank?
-      return nil if segment.match?(/\A\d+\z/)
-
-      HtmlDir.find_by(path: segment)&.person&.authority
     end
 
     def find_by_wikidata(html_doc)

--- a/app/services/lexicon/benyehuda_links.rb
+++ b/app/services/lexicon/benyehuda_links.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+module Lexicon
+  # Resolves a link to benyehuda.org into the Authority it points at.
+  #
+  # Emulates what HtmlFileController#render_by_legacy_url does, supporting both forms:
+  # - numeric ID: https://benyehuda.org/author/1234
+  # - slug:       https://benyehuda.org/shats (looked up via HtmlDir)
+  module BenyehudaLinks
+    HOST_PATTERN = %r{\Ahttps?://(?:www\.)?benyehuda\.org}i
+
+    module_function
+
+    # Returns the Authority the given URL points at, or nil if the URL is not a
+    # benyehuda.org author link, or no matching Authority exists.
+    def authority_for(url)
+      url = url.to_s
+      return nil unless url.match?(HOST_PATTERN)
+
+      begin
+        path = URI.parse(url).path
+      rescue URI::InvalidURIError
+        return nil
+      end
+
+      return nil if path.blank?
+
+      authority_from_path(path)
+    end
+
+    def authority_from_path(path)
+      # Numeric ID: /author/1234 or /author/1234/
+      if (match = path.match(%r{\A/author/(\d+)/?\z}))
+        return Authority.find_by(id: match[1].to_i)
+      end
+
+      # Non-numeric slug: /shats or /shats/index
+      # Extract first non-numeric path segment and look up in HtmlDir.
+      # HtmlDir belongs_to :person (Person model), which has_one :authority.
+      segment = path.split('/').compact_blank.first
+      return nil if segment.blank?
+      return nil if segment.match?(/\A\d+\z/)
+
+      HtmlDir.find_by(path: segment)&.person&.authority
+    end
+  end
+end

--- a/app/services/lexicon/benyehuda_links.rb
+++ b/app/services/lexicon/benyehuda_links.rb
@@ -7,25 +7,28 @@ module Lexicon
   # - numeric ID: https://benyehuda.org/author/1234
   # - slug:       https://benyehuda.org/shats (looked up via HtmlDir)
   module BenyehudaLinks
-    HOST_PATTERN = %r{\Ahttps?://(?:www\.)?benyehuda\.org}i
+    HOSTS = ['benyehuda.org', 'www.benyehuda.org'].freeze
+    SCHEMES = %w(http https).freeze
 
     module_function
 
     # Returns the Authority the given URL points at, or nil if the URL is not a
     # benyehuda.org author link, or no matching Authority exists.
     def authority_for(url)
-      url = url.to_s
-      return nil unless url.match?(HOST_PATTERN)
-
       begin
-        path = URI.parse(url).path
+        uri = URI.parse(url.to_s)
       rescue URI::InvalidURIError
         return nil
       end
 
-      return nil if path.blank?
+      # Compare the parsed host rather than matching a prefix of the URL: a prefix match
+      # would also accept lookalike hosts such as benyehuda.org.il, or benyehuda.org
+      # appearing as userinfo (https://benyehuda.org@example.com/author/1).
+      return nil unless SCHEMES.include?(uri.scheme&.downcase)
+      return nil unless HOSTS.include?(uri.host&.downcase)
+      return nil if uri.path.blank?
 
-      authority_from_path(path)
+      authority_from_path(uri.path)
     end
 
     def authority_from_path(path)

--- a/app/services/lexicon/ingest_person.rb
+++ b/app/services/lexicon/ingest_person.rb
@@ -91,9 +91,6 @@ module Lexicon
         Lexicon::ExtractPersonWorks.call(next_elem, lex_person)
       end
 
-      buf = html_doc.to_html
-      parse_person_links(lex_person, buf[%r{a name="links".*?</ul}m])
-
       lex_person.gender = @female ? :female : :male
 
       # We need to save the person and its citations and works before linking citations to works
@@ -105,6 +102,13 @@ module Lexicon
       # has not been committed yet (lex_entry.lex_item= is set after create_lex_item returns), so
       # lex_person.entry would return nil inside AssociateAuthority.
       AssociateAuthority.call(lex_person, html_doc, entry_title: @lex_entry&.title) if lex_person.authority.nil?
+
+      # Links are parsed only after the authority is known, so that links pointing at this entry's
+      # own authority page on benyehuda.org can be skipped (see #redundant_authority_link?).
+      buf = html_doc.to_html
+      parse_person_links(lex_person, buf[%r{a name="links".*?</ul}m])
+      lex_person.save!
+
       link_citations_to_works(lex_person)
       attach_backup_files(lex_person)
       lex_person
@@ -158,13 +162,25 @@ module Lexicon
       end.map do |linkstring|
         next unless linkstring =~ %r{(.*?)<a .*?href="(.*?)".*?>(.*?)</a>(.*)}m
 
+        url = ::Regexp.last_match(2)
+        before, label, after = ::Regexp.last_match.values_at(1, 3, 4)
+
+        next if redundant_authority_link?(url, person)
+
         person.links.build(
-          url: ::Regexp.last_match(2),
-          description: "#{html2txt(img_to_text(::Regexp.last_match(1)))} " \
-                       "#{html2txt(img_to_text(::Regexp.last_match(3)))} " \
-                       "#{html2txt(img_to_text(::Regexp.last_match(4)))}"
+          url: url,
+          description: "#{html2txt(img_to_text(before))} " \
+                       "#{html2txt(img_to_text(label))} " \
+                       "#{html2txt(img_to_text(after))}"
         )
       end
+    end
+
+    # Links pointing at the entry's own Authority page on benyehuda.org are not migrated:
+    # the entry is already associated with that Authority, so the link is redundant. Links to
+    # other benyehuda.org authorities (or to non-author pages) are migrated as usual.
+    def redundant_authority_link?(url, person)
+      person.authority.present? && BenyehudaLinks.authority_for(url) == person.authority
     end
 
     def img_to_text(html)

--- a/spec/fixtures/files/lexicon/benyehuda_links.php
+++ b/spec/fixtures/files/lexicon/benyehuda_links.php
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>test person with benyehuda links</title>
+</head>
+<body dir="rtl">
+<table border="0" width="100%">
+  <tr>
+    <td><p align="center"><font size="5" color="#FF0000">ישראלי, ישראל</font><font size="4" color="#FF0000">(1970)</font></p></td>
+  </tr>
+</table>
+<p>פרטים ביוגרפיים.</p>
+<p><font size="4" color="#0000FF"><a name="Books">ספריו:</a></font></p>
+<ul>
+  <li>ספר לדוגמה (תל אביב : הוצאה לדוגמה, 1990)</li>
+</ul>
+<p><font size="4" color="#0000FF"><a name="Bib.">על המחבר ויצירתו:</a></font></p>
+<p>לא נמצאו מקורות.</p>
+<font size="4" color="#0000FF"><a name="links">קישורים:</a></font>
+<ul>
+  <li><i><a target="_blank" href="https://benyehuda.org/author/OWN_AUTHORITY_ID">כתביו</a></i> בפרויקט בן-יהודה</li>
+  <li><i><a target="_blank" href="https://www.benyehuda.org/author/OTHER_AUTHORITY_ID">כתבי חברו</a></i> בפרויקט בן-יהודה</li>
+  <li><i><a target="_blank" href="http://example.com/article">כתבה כלשהי</a></i> באתר כלשהו</li>
+</ul>
+</body>
+</html>

--- a/spec/services/lexicon/benyehuda_links_spec.rb
+++ b/spec/services/lexicon/benyehuda_links_spec.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Lexicon::BenyehudaLinks do
+  describe '.authority_for' do
+    subject(:authority) { described_class.authority_for(url) }
+
+    let(:expected_authority) { create(:authority) }
+
+    context 'when the URL is a benyehuda.org numeric author link' do
+      let(:url) { "https://benyehuda.org/author/#{expected_authority.id}" }
+
+      it { is_expected.to eq(expected_authority) }
+    end
+
+    context 'when the URL uses the www host and a trailing slash' do
+      let(:url) { "https://www.benyehuda.org/author/#{expected_authority.id}/" }
+
+      it { is_expected.to eq(expected_authority) }
+    end
+
+    context 'when the URL is a benyehuda.org slug matched by HtmlDir' do
+      let(:url) { 'https://benyehuda.org/shats/index' }
+
+      before { HtmlDir.create!(path: 'shats', person: expected_authority.person, author: 'Shats') }
+
+      it { is_expected.to eq(expected_authority) }
+    end
+
+    context 'when the numeric ID matches no Authority' do
+      let(:url) { 'https://benyehuda.org/author/999999' }
+
+      it { is_expected.to be_nil }
+    end
+
+    context 'when the slug matches no HtmlDir' do
+      let(:url) { 'https://benyehuda.org/nonexistent_slug' }
+
+      it { is_expected.to be_nil }
+    end
+
+    context 'when the host is not benyehuda.org' do
+      let(:url) { "https://example.com/author/#{expected_authority.id}" }
+
+      it { is_expected.to be_nil }
+    end
+
+    context 'when the URL has no path' do
+      let(:url) { 'https://benyehuda.org' }
+
+      it { is_expected.to be_nil }
+    end
+
+    context 'when the URL is unparseable' do
+      let(:url) { 'https://benyehuda.org/author/1 2' }
+
+      it { is_expected.to be_nil }
+    end
+
+    context 'when the URL is nil' do
+      let(:url) { nil }
+
+      it { is_expected.to be_nil }
+    end
+  end
+end

--- a/spec/services/lexicon/benyehuda_links_spec.rb
+++ b/spec/services/lexicon/benyehuda_links_spec.rb
@@ -46,6 +46,36 @@ describe Lexicon::BenyehudaLinks do
       it { is_expected.to be_nil }
     end
 
+    context 'when the host merely starts with benyehuda.org' do
+      let(:url) { "https://benyehuda.org.il/author/#{expected_authority.id}" }
+
+      it { is_expected.to be_nil }
+    end
+
+    context 'when the host is a lookalike subdomain of another domain' do
+      let(:url) { "https://benyehuda.org.example.com/author/#{expected_authority.id}" }
+
+      it { is_expected.to be_nil }
+    end
+
+    context 'when benyehuda.org appears as userinfo rather than the host' do
+      let(:url) { "https://benyehuda.org@example.com/author/#{expected_authority.id}" }
+
+      it { is_expected.to be_nil }
+    end
+
+    context 'when benyehuda.org appears only in the path of another host' do
+      let(:url) { "https://example.com/benyehuda.org/author/#{expected_authority.id}" }
+
+      it { is_expected.to be_nil }
+    end
+
+    context 'when the scheme is not http(s)' do
+      let(:url) { "ftp://benyehuda.org/author/#{expected_authority.id}" }
+
+      it { is_expected.to be_nil }
+    end
+
     context 'when the URL has no path' do
       let(:url) { 'https://benyehuda.org' }
 

--- a/spec/services/lexicon/ingest_person_spec.rb
+++ b/spec/services/lexicon/ingest_person_spec.rb
@@ -396,6 +396,59 @@ describe Lexicon::IngestPerson do
     end
   end
 
+  context 'when the links section contains links to benyehuda.org authority pages' do
+    let(:own_authority) { create(:authority) }
+    let(:other_authority) { create(:authority) }
+    let(:own_authority_id) { own_authority.id }
+    let(:other_authority_id) { other_authority.id }
+    let(:tmpdir) { Dir.mktmpdir }
+    let(:php_path) do
+      template = Rails.root.join('spec/fixtures/files/lexicon/benyehuda_links.php').read
+      path = File.join(tmpdir, 'benyehuda_links.php')
+      File.write(path, template.gsub('OWN_AUTHORITY_ID', own_authority_id.to_s)
+                               .gsub('OTHER_AUTHORITY_ID', other_authority_id.to_s))
+      path
+    end
+    let!(:file) do
+      create(
+        :lex_file,
+        {
+          entrytype: :person,
+          status: :classified,
+          title: 'ישראלי, ישראל',
+          fname: 'benyehuda_links.php',
+          full_path: php_path
+        }
+      )
+    end
+
+    after { FileUtils.remove_entry(tmpdir) }
+
+    it 'omits the link to the entry own authority but keeps other benyehuda.org and external links' do
+      expect { call }.to change(LexPerson, :count).by(1)
+
+      person = file.lex_entry.lex_item
+      expect(person.authority).to eq(own_authority)
+      expect(person.links.map(&:url)).to contain_exactly(
+        "https://www.benyehuda.org/author/#{other_authority.id}",
+        'http://example.com/article'
+      )
+    end
+
+    context 'when no authority could be associated with the entry' do
+      let(:own_authority_id) { 999_998 }
+      let(:other_authority_id) { 999_999 }
+
+      it 'keeps every link' do
+        call
+
+        person = file.lex_entry.lex_item
+        expect(person.authority).to be_nil
+        expect(person.links.count).to eq(3)
+      end
+    end
+  end
+
   context 'when the date of manual update is wrapped in square brackets' do
     let!(:file) do
       create(


### PR DESCRIPTION
## What & why

We already omit links to benyehuda.org from the migrated **biography** section
(`Lexicon::ExtractAuthority` removes the badge anchor from the document before the
bio is extracted). The same should hold for the **links** (`קישורים`) section: a
link there that points at the Authority associated with the LexEntry is redundant —
the entry is already associated with that authority — so it is no longer migrated
as a `LexLink`.

Links to *other* benyehuda.org authorities, and to non-author benyehuda.org pages,
are migrated exactly as before.

## Changes

- **New `Lexicon::BenyehudaLinks`** — the URL → `Authority` resolution that
  `AssociateAuthority` already performed (`/author/:id`, and slug lookup via
  `HtmlDir`, mirroring `HtmlFileController#render_by_legacy_url`) is extracted into
  a small module so the ingest filter and the authority association share one
  implementation instead of duplicating it. `AssociateAuthority#find_by_benyehuda_link`
  now delegates to it; its behaviour is unchanged.
- **`Lexicon::IngestPerson`** — `parse_person_links` now skips a link when
  `BenyehudaLinks.authority_for(url)` equals the person's authority. Because the
  authority is resolved by `AssociateAuthority` *after* the item is first saved, the
  links-section parsing was moved to run after that call, so the filter has an
  authority to compare against.

Note the ordering consequence: when the link that identified the authority *is* the
one in the links section, it is now the link that gets dropped — which is the intent.

## Test plan

New coverage:
- `spec/services/lexicon/ingest_person_spec.rb` — full ingest of a fixture whose links
  section holds (a) a link to the entry's own authority, (b) a link to a different
  authority, (c) a plain external link: only (a) is dropped. A second example covers
  the case where no authority could be associated, where every link is kept.
- `spec/services/lexicon/benyehuda_links_spec.rb` — numeric/`www`/trailing-slash/slug
  forms, plus the nil cases (foreign host, unknown ID, unknown slug, no path,
  unparseable URL, nil).

Verified the new ingest spec fails without the filter (the own-authority link is
migrated) and passes with it.

Specs run: `spec/services/`, `spec/models/`, `spec/jobs/` — 1225 examples, 0 failures,
1 pre-existing pending. RuboCop clean on all changed files. The **full suite was not
run** (it takes 40+ min and needs approval); the system/request/feature specs are
therefore unverified locally and left to CI.

Closes beads_by-3mf

🤖 Generated with [Claude Code](https://claude.com/claude-code)