### PR TITLE
Lexicon: don't present the migration date as a manual update

### DIFF
--- a/app/views/lexicon/entries/show.html.haml
+++ b/app/views/lexicon/entries/show.html.haml
@@ -4,9 +4,11 @@
     = render partial: 'show_person', locals: { lex_person: lex_item }
   - elsif lex_item.is_a?(LexPublication)
     = render partial: 'show_publication', locals: { lex_publication: lex_item }
-  .lexicon-last-updated
-    - date_str = @lex_entry.date_of_manual_update.presence || l(@lex_entry.last_content_update.to_date)
-    = t('lexicon.entries.show.last_updated', date: date_str)
+  -# only the date ingested from the legacy PHP file counts as a manual update
+    (the migration itself does not), so show nothing when it is absent
+  - if @lex_entry.date_of_manual_update.present?
+    .lexicon-last-updated
+      = t('lexicon.entries.show.last_updated', date: @lex_entry.date_of_manual_update)
 
 -# found mistake popup
 = render partial: 'shared/proof'

--- a/spec/requests/lexicon/entries_spec.rb
+++ b/spec/requests/lexicon/entries_spec.rb
@@ -144,6 +144,27 @@ describe '/lexicon/entries' do
 
       it { is_expected.to eq(200) }
     end
+
+    describe 'last updated line' do
+      context 'when the legacy PHP file carried a manual update date' do
+        let(:entry) { create(:lex_entry, :person, status: :published, date_of_manual_update: '12 ביולי 2023') }
+
+        it 'shows the ingested date' do
+          expect(call).to eq(200)
+          expect(response.body).to include('lexicon-last-updated')
+          expect(response.body).to include('12 ביולי 2023')
+        end
+      end
+
+      context 'when the legacy PHP file carried no manual update date' do
+        let(:entry) { create(:lex_entry, :person, status: :published, date_of_manual_update: nil) }
+
+        it 'omits the line rather than presenting the migration date as a manual update' do
+          expect(call).to eq(200)
+          expect(response.body).not_to include('lexicon-last-updated')
+        end
+      end
+    end
   end
 
   describe 'DELETE /destroy' do


### PR DESCRIPTION
## What

The lexicon entry page rendered:

```haml
- date_str = @lex_entry.date_of_manual_update.presence || l(@lex_entry.last_content_update.to_date)
= t('lexicon.entries.show.last_updated', date: date_str)
```

`last_content_update` is `max(updated_at, lex_item.updated_at, citations/works/links updated_at)`. For a freshly migrated entry that is the **migration timestamp**, so the public page claimed "עודכן לאחרונה ב: \<migration date\>" for entries nobody had manually touched.

The migration is not a manual update. When the legacy PHP file carried no `עודכן לאחרונה` date, the line is now omitted entirely.

## What did NOT need changing

Ingestion was already correct. `Lexicon::IngestBase#extract_date_of_manual_update` scrapes the date out of the PHP footer and returns `nil` when it isn't there; nothing in the codebase ever stamps the field with the migration time. The only other writers are the editor-facing verification form and the people/publications `entry_attributes` permit lists — genuine manual edits.

## Note for reviewers

`LexEntry#last_content_update` now has no caller outside its own model spec. Its documented side effect (silently syncing `updated_at` so list views eventually reflect the real last change) was previously triggered only by this view, and only for entries *without* a manual-update date. I left the method alone rather than deleting it or relocating the sync — say the word if you'd prefer either.

## Test plan

- Added two request specs in `spec/requests/lexicon/entries_spec.rb` covering both branches.
- Verified the regression test **fails** against the old view (`expected ... not to include "lexicon-last-updated"`) and passes with the fix.
- `bundle exec rspec spec/requests/lexicon/entries_spec.rb` — 16 examples, 0 failures
- `bundle exec rspec spec/models/lex_entry_spec.rb spec/services/lexicon/ingest_person_spec.rb` — 66 examples, 0 failures
- haml-lint and rubocop clean on the changed files (the 3 remaining rubocop `RSpec/NamedSubject` offenses are pre-existing, in the index tests).
- Full suite NOT run (40+ min; needs your approval).

Closes beads_by-pga

🤖 Generated with [Claude Code](https://claude.com/claude-code)