### PR TITLE
Lexicon: stop libxml2 mangling entry titles from charset-less files

### DIFF
--- a/app/services/lexicon/extract_title.rb
+++ b/app/services/lexicon/extract_title.rb
@@ -8,7 +8,7 @@ module Lexicon
     LIFE_YEARS_PATTERN = /\s*\(\d{4}(?:[-–־]\d{4})?\)\s*\z/
 
     def call(fname)
-      html_doc = File.open(fname) { |f| Nokogiri::HTML(f) }
+      html_doc = HtmlUtils.parse_file(fname)
 
       title_table_node = html_doc.at_css('table#table5')
       if title_table_node.present?

--- a/app/services/lexicon/html_utils.rb
+++ b/app/services/lexicon/html_utils.rb
@@ -3,6 +3,21 @@
 module Lexicon
   # Utility methods for HTML processing to use them during PHP files parsing
   module HtmlUtils
+    # Encoding libxml2 falls back to when a document declares no charset at all.
+    # Legacy lexicon files are UTF-8, so that fallback silently mangles Hebrew into
+    # mojibake ('נ' -> '× ', 'ת' -> '×ª', ...) rather than failing loudly.
+    FALLBACK_ENCODING = 'ISO-8859-1'
+
+    # Parses a legacy lexicon PHP file, honouring the charset it declares (a handful of
+    # the oldest files are genuinely windows-1255) but defaulting to UTF-8 instead of
+    # libxml2's Latin-1 when no charset is declared.
+    def self.parse_file(path)
+      doc = File.open(path) { |f| Nokogiri::HTML(f) }
+      return doc unless doc.encoding.blank? || doc.encoding.casecmp?(FALLBACK_ENCODING)
+
+      Nokogiri::HTML(File.read(path, encoding: 'UTF-8'), nil, 'UTF-8')
+    end
+
     # Legacy lexicon PHP files uses font or p elements wrapping anchor with a name as a headers
     def header?(elem, section_name = nil)
       return false unless %w(p font).include?(elem.name)

--- a/app/services/lexicon/ingest_base.rb
+++ b/app/services/lexicon/ingest_base.rb
@@ -6,7 +6,7 @@ module Lexicon
     def call(lex_file)
       @lex_entry = lex_file.lex_entry
 
-      html_doc = File.open(lex_file.full_path) { |f| Nokogiri::HTML(f) }
+      html_doc = HtmlUtils.parse_file(lex_file.full_path)
       Lexicon::AttachImages.call(html_doc, @lex_entry)
       Lexicon::ProcessLinks.call(html_doc, @lex_entry)
 

--- a/lib/tasks/ingest_lexicon.rake
+++ b/lib/tasks/ingest_lexicon.rake
@@ -147,11 +147,14 @@ def process_legacy_lexicon_entry(fname)
     lf.update!(entrytype: entrytype, status: status)
     lex_entry = lf.lex_entry
     lex_entry.update!(main: is_main) if lex_entry.main != is_main
+    # Refresh the title whenever the source file changed. This must not be tied to the
+    # presence of a lex_item: entries still awaiting migration have no lex_item, and used
+    # to keep their originally ingested title forever.
+    lex_entry.update!(title: title) if lex_entry.title != title
     lex_item = lex_entry.lex_item
     # destroying item to be recreated during ingestion
     if lex_item.present?
       lex_entry.lex_item = nil
-      lex_entry.title = title
       lex_entry.status_raw!
       lex_item.destroy!
     end
@@ -166,6 +169,46 @@ def process_legacy_lexicon_entry(fname)
     @people << title
   end
   print entrytype[0]
+end
+
+# UTF-8 Hebrew decoded as ISO-8859-1 leaves U+00D7 (×) followed by a Latin-1 supplement or
+# C1 character. No genuine lexicon title looks like that.
+MOJIBAKE_TITLE_PATTERN = /\u00D7[\u0080-\u00FF]/
+
+desc 'repair Lexicon entry titles mangled by the ISO-8859-1 parsing fallback'
+task fix_lexicon_titles: :environment do
+  found = 0
+  fixed = 0
+  missing = []
+  still_mangled = []
+
+  Chewy.strategy(:atomic) do
+    # `LIKE` is only a cheap pre-filter here; the regex below decides.
+    LexEntry.includes(:lex_file).where('title LIKE ?', '%×%').find_each do |entry|
+      next unless entry.title.match?(MOJIBAKE_TITLE_PATTERN)
+
+      found += 1
+      path = entry.lex_file&.full_path
+      if path.blank? || !File.exist?(path)
+        missing << entry.id
+        next
+      end
+
+      title = Lexicon::ExtractTitle.call(path)
+      if title.blank? || title.match?(MOJIBAKE_TITLE_PATTERN)
+        still_mangled << entry.id
+        next
+      end
+
+      puts "#{entry.id}: #{entry.title.inspect} -> #{title}"
+      entry.update!(title: title)
+      fixed += 1
+    end
+  end
+
+  puts "#{found} mangled titles found; #{fixed} repaired"
+  puts "No readable source file for entry ids: #{missing.join(', ')}" if missing.any?
+  puts "Source file still yields a mangled title for entry ids: #{still_mangled.join(', ')}" if still_mangled.any?
 end
 
 task reset_lexicon_ingestion: :environment do

--- a/spec/fixtures/files/lexicon/no_charset_declaration.php
+++ b/spec/fixtures/files/lexicon/no_charset_declaration.php
@@ -1,0 +1,17 @@
+<html>
+
+<head>
+<link rel="stylesheet" href="lexicon2.css" type="text/css">
+<title>נורית זרחי</title>
+</head>
+<body dir="rtl">
+		<table border="0" width="100%" id="table5">
+		<tr>
+				<td><p align="center"><font size="5" color="#FF0000">נורית זרחי </font>
+				<font size="4" color="#FF0000">(1941)</font></td>
+				<td><p align="center" dir="ltr"><font size="5" color="#FF0000">Nurit Zarchi</font></td>
+			</tr>
+		</table>
+		<p class="margin" align="justify">נורית זרחי היא משוררת וסופרת ישראלית.
+</body>
+</html>

--- a/spec/fixtures/files/lexicon/windows_1255_declared.php
+++ b/spec/fixtures/files/lexicon/windows_1255_declared.php
@@ -1,0 +1,18 @@
+<html>
+
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=windows-1255">
+<link rel="stylesheet" href="lexicon2.css" type="text/css">
+<title>נורית זרחי</title>
+</head>
+<body dir="rtl">
+		<table border="0" width="100%" id="table5">
+		<tr>
+				<td><p align="center"><font size="5" color="#FF0000">נורית זרחי </font>
+				<font size="4" color="#FF0000">(1941)</font></td>
+				<td><p align="center" dir="ltr"><font size="5" color="#FF0000">Nurit Zarchi</font></td>
+			</tr>
+		</table>
+		<p class="margin" align="justify">נורית זרחי היא משוררת וסופרת ישראלית.
+</body>
+</html>

--- a/spec/lib/tasks/ingest_lexicon_rake_spec.rb
+++ b/spec/lib/tasks/ingest_lexicon_rake_spec.rb
@@ -44,4 +44,53 @@ RSpec.describe 'ingest_lexicon rake task' do # rubocop:disable RSpec/DescribeCla
 
     expect(entry_for('02645001.php').main).to be false
   end
+
+  it 'refreshes the title of a not-yet-migrated entry whose source file changed' do
+    stage('00020.php')
+    task.invoke(work_dir)
+    entry = entry_for('00020.php')
+    original_title = entry.title
+    entry.update!(title: 'כותרת ישנה')
+    FileUtils.touch(File.join(work_dir, '00020.php'), mtime: 1.hour.from_now.to_time)
+
+    task.reenable
+    task.invoke(work_dir)
+
+    expect(entry.reload.title).to eq(original_title)
+  end
+
+  describe 'fix_lexicon_titles' do
+    let(:fix_task) { Rake::Task['fix_lexicon_titles'] }
+    let(:source_file) { fixtures_dir.join('00020.php') }
+    let(:correct_title) { Lexicon::ExtractTitle.call(source_file) }
+
+    before { fix_task.reenable }
+
+    # Reproduces what libxml2's ISO-8859-1 fallback used to make of UTF-8 Hebrew
+    def mangle(str)
+      str.b.force_encoding('ISO-8859-1').encode('UTF-8')
+    end
+
+    def raw_entry_with_title(title)
+      lex_file = create(:lex_file, :person, entry_status: :raw, fname: '00020.php',
+                                            full_path: source_file.to_s)
+      lex_file.lex_entry.tap { |entry| entry.update!(title: title) }
+    end
+
+    it 're-extracts a mangled title from the source file' do
+      entry = raw_entry_with_title(mangle(correct_title))
+
+      fix_task.invoke
+
+      expect(entry.reload.title).to eq(correct_title)
+    end
+
+    it 'leaves a well-formed title alone even when it differs from the source file' do
+      entry = raw_entry_with_title('כותרת שתוקנה ביד')
+
+      fix_task.invoke
+
+      expect(entry.reload.title).to eq('כותרת שתוקנה ביד')
+    end
+  end
 end

--- a/spec/services/lexicon/extract_title_spec.rb
+++ b/spec/services/lexicon/extract_title_spec.rb
@@ -17,6 +17,14 @@ describe Lexicon::ExtractTitle do
     end
   end
 
+  context 'when file declares no charset' do
+    let(:file) { Rails.root.join('spec/fixtures/files/lexicon/no_charset_declaration.php') }
+
+    # Regression: libxml2 falls back to ISO-8859-1 for documents that declare no charset,
+    # which used to store byte-per-character mojibake in lex_entries.title.
+    it { is_expected.to eq('נורית זרחי') }
+  end
+
   context 'when publication file is provided' do
     let(:file) { Rails.root.join('spec/fixtures/files/lexicon/02645001.php') }
 

--- a/spec/services/lexicon/html_utils_spec.rb
+++ b/spec/services/lexicon/html_utils_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Lexicon::HtmlUtils do
+  describe '.parse_file' do
+    subject(:doc) { described_class.parse_file(file) }
+
+    let(:fixtures_dir) { Rails.root.join('spec/fixtures/files/lexicon') }
+
+    # The Hebrew entry title, as it appears in the first cell of the header table
+    def title_text
+      doc.at_css('table#table5 td p[align="center"]').text.squish
+    end
+
+    context 'when the file declares charset=UTF-8' do
+      let(:file) { fixtures_dir.join('00024.php') }
+
+      it 'reads Hebrew correctly' do
+        expect(title_text).to start_with('שמואל בס')
+      end
+    end
+
+    context 'when the file declares no charset at all' do
+      let(:file) { fixtures_dir.join('no_charset_declaration.php') }
+
+      it 'defaults to UTF-8 instead of libxml2 ISO-8859-1 fallback' do
+        expect(title_text).to start_with('נורית זרחי')
+      end
+    end
+
+    context 'when the file declares windows-1255 and really is windows-1255' do
+      let(:file) { fixtures_dir.join('windows_1255_declared.php') }
+
+      it 'honours the declared encoding rather than forcing UTF-8' do
+        expect(title_text).to start_with('נורית זרחי')
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Problem

Filtering the public lexicon list (`/lex`) by `a` in production returns entries whose titles are mojibake (the Hebrew renders as a run of `×` followed by invisible C1 control characters).

`Lexicon::ExtractTitle` and `Lexicon::IngestBase` parsed legacy PHP files with a bare `Nokogiri::HTML(io)`, letting libxml2 sniff the charset. **When a file declares no charset, libxml2 falls back to ISO-8859-1** and decodes the UTF-8 Hebrew byte-per-character. The mangled string is written to `lex_entries.title`, so the damage is in the data, not the view.

Reproduced locally with identical content differing only in the meta tag:

```
no_meta:   doc_encoding="ISO-8859-1"  title="× ××¨××ª"
meta_utf8: doc_encoding="UTF-8"       title="נורית"
```

The en-dash rendering in the reported output (`1902<mojibake>1977`, i.e. `E2 80 93` with `0x80`/`0x93` lost as unassigned C1 controls) confirms ISO-8859-1 specifically rather than CP1252 or a CP1255 mixup.

Note `ingest_person.rb:27` already read with an explicit `encoding: 'UTF-8'`; the two Nokogiri call sites were the inconsistent ones.

### Why this was invisible on dev

The mojibake for Hebrew ת (`D7 AA`) contains U+00AA. Whether `LIKE '%a%'` matches it is purely a collation question:

| collation | matches `%a%` |
|---|---|
| `utf8mb4_bin` (schema.rb, dev) | 0 |
| `utf8mb4_general_ci` | 0 |
| `utf8mb4_unicode_ci` | 1 |
| `utf8mb4_0900_ai_ci` | 1 |

Since production *did* return those rows, prod's `lex_entries.title` collation appears to have drifted off `utf8mb4_bin`. **Not addressed by this PR** — worth confirming separately with `SHOW FULL COLUMNS FROM lex_entries WHERE Field = 'title';`, since it means filtering behaves differently on dev and prod generally.

## Changes

- **`HtmlUtils.parse_file`** — honours a declared charset (a few of the oldest files are genuinely windows-1255) but re-parses as UTF-8 when libxml2 fell back to Latin-1. `ExtractTitle` and `IngestBase` both use it.
- **`ingest_lexicon` rake task** — refreshes `lex_entry.title` independently of `lex_item` presence. Previously the title was only reassigned inside `if lex_item.present?`, so entries still awaiting migration (which have no `lex_item`) kept their originally ingested title forever, even after their source file changed. Without this, re-ingesting would not repair anything.
- **`fix_lexicon_titles` rake task** — re-extracts titles from source files for the repair run. It only touches titles that still look like Latin-1 mojibake, so editorially-corrected titles are left alone, and it reports entries it could not repair.

Un-mangling the stored strings was rejected: `ExtractTitle`'s `.squish` turns the NBSP that encodes Hebrew נ (`D7 A0`) into a plain space, so the round trip loses that letter. Re-extraction from source is the only clean path.

## Verification

- Ran `Lexicon::ExtractTitle` over all 4,950 files in the real lexicon corpus before and after: 0 mojibake titles both ways (the current corpus declares UTF-8 almost everywhere — the corrupt prod rows date from an earlier ingest against files that hadn't yet gotten the meta tag).
- Checked the one genuinely non-UTF-8 file (`00421001.php`): resolves to windows-1252, so the new branch does not trigger and parsing is byte-identical to before.

## Tests

New:
- `spec/services/lexicon/html_utils_spec.rb` — declared UTF-8, no declaration, and genuinely-windows-1255 files.
- `extract_title_spec.rb` — regression case for a charset-less file.
- `ingest_lexicon_rake_spec.rb` — title refresh for a not-yet-migrated entry whose file changed; `fix_lexicon_titles` repairing a mangled title and leaving a well-formed one alone.

Two fixtures added: `no_charset_declaration.php` (UTF-8, no meta) and `windows_1255_declared.php` (real cp1255 bytes).

```
bundle exec rspec spec/services/lexicon spec/lib/tasks
267 examples, 0 failures
```

RuboCop clean on all changed files (the 2 remaining offences in `html_utils.rb` are pre-existing, in the untouched `next_element_skipping_blank`). Full suite not run — needs approval given the 40+ minute runtime.

## Deployment

Repair is a two-step run in production after merge:
1. `rake ingest_lexicon[<dir>]` — picks up any changed files with correct decoding.
2. `rake fix_lexicon_titles` — re-extracts the already-mangled titles. Prints every change it makes.

Entries that had a charset-less file *and* were already migrated would also have mojibake in their body content, which neither task repairs; those need `reset_ingestion!` + re-migration. The reported entries are all still `raw`, so this may well be an empty set.

Closes `beads_by-qyr`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
