### PR TITLE
Mobile menu: add all-collections link; keep filter checkboxes beside their labels

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1561,6 +1561,33 @@ p.by-genre-name-v02.headline-2-v02 {
   color: #907989;
 }
 
+// Filter panes (/works, /authors, /collections, lexicon list) lay their option
+// lists out in CSS columns (.nested-list, column-count: 2), so each option gets
+// only about half the (already narrow) pane. Labels are display: inline-block
+// site-wide, which makes them unbreakable atomic boxes: as soon as a label is
+// wider than what is left of the line beside its 18px checkbox, the whole label
+// drops to the next line and the checkbox is stranded alone on its own line —
+// looking, at a glance, like a checkbox belonging to the label above it. Laying
+// the row out as a flex line instead lets the label wrap its own text while
+// staying beside its checkbox, at any zoom level or label length.
+.filter-checkbox {
+  display: flex;
+  align-items: flex-start;
+
+  // Also keep the row whole when the CSS-column breaker picks a break point.
+  -webkit-column-break-inside: avoid; // Safari, older Chrome
+  page-break-inside: avoid; // Firefox
+  break-inside: avoid;
+
+  > input[type='checkbox'] {
+    flex: none; // never let the checkbox itself be squeezed
+  }
+
+  > label {
+    min-width: 0; // allow the label to shrink below its max-content width
+  }
+}
+
 // In list-view result headers (.headline-2-v02), push the permalink to the
 // left edge of its container (away from the result count) and de-emphasize it
 // by overriding the container's bold with a regular weight.

--- a/app/views/authors/_toc_filters.html.haml
+++ b/app/views/authors/_toc_filters.html.haml
@@ -16,51 +16,58 @@
           %ul
             - fd[:genres].each do |genre|
               %li
-                %input.toc-filter-genre{ type: 'checkbox', value: genre, id: "toc-filter-genre-#{genre}", name: 'toc_filter_genre' }
-                %label{ for: "toc-filter-genre-#{genre}" }
-                  %span.by-icon-v02>= glyph_for_genre(genre)
-                  = textify_genre(genre)
-                  %span.toc-facet-count{ 'data-section': 'genre', 'data-value': genre }
+                .filter-checkbox
+                  %input.toc-filter-genre{ type: 'checkbox', value: genre, id: "toc-filter-genre-#{genre}", name: 'toc_filter_genre' }
+                  %label{ for: "toc-filter-genre-#{genre}" }
+                    %span.by-icon-v02>= glyph_for_genre(genre)
+                    = textify_genre(genre)
+                    %span.toc-facet-count{ 'data-section': 'genre', 'data-value': genre }
       - if has_hebrew || translated_langs.present?
         = render layout: 'shared/collapsible_block', locals: { container_name: 'tocflang', title: t('author_toc_filters.source_language') } do
           %ul
             - if has_hebrew
               %li
-                %input.toc-filter-lang#toc-filter-lang-he{ type: 'checkbox', value: 'he', name: 'toc_filter_lang' }
-                %label{ for: 'toc-filter-lang-he' }
-                  = textify_lang('he')
-                  %span.toc-facet-count{ 'data-section': 'lang', 'data-value': 'he' }
+                .filter-checkbox
+                  %input.toc-filter-lang#toc-filter-lang-he{ type: 'checkbox', value: 'he', name: 'toc_filter_lang' }
+                  %label{ for: 'toc-filter-lang-he' }
+                    = textify_lang('he')
+                    %span.toc-facet-count{ 'data-section': 'lang', 'data-value': 'he' }
             - if translated_langs.present?
               %li
-                %input#toc-filter-translated{ type: 'checkbox', name: 'toc_filter_translated' }
-                %label{ for: 'toc-filter-translated' }
-                  = t(:translation)
-                  %span.toc-facet-count{ 'data-section': 'lang', 'data-value': 'translated' }
+                .filter-checkbox
+                  %input#toc-filter-translated{ type: 'checkbox', name: 'toc_filter_translated' }
+                  %label{ for: 'toc-filter-translated' }
+                    = t(:translation)
+                    %span.toc-facet-count{ 'data-section': 'lang', 'data-value': 'translated' }
                 .languanges-filters
                   %ul.nested-list
                     - translated_langs.each do |lang|
                       %li
-                        %input.toc-filter-lang{ type: 'checkbox', value: lang, id: "toc-filter-lang-#{lang}", name: 'toc_filter_lang' }
-                        %label{ for: "toc-filter-lang-#{lang}" }
-                          = textify_lang(lang)
-                          %span.toc-facet-count{ 'data-section': 'lang', 'data-value': lang }
+                        .filter-checkbox
+                          %input.toc-filter-lang{ type: 'checkbox', value: lang, id: "toc-filter-lang-#{lang}", name: 'toc_filter_lang' }
+                          %label{ for: "toc-filter-lang-#{lang}" }
+                            = textify_lang(lang)
+                            %span.toc-facet-count{ 'data-section': 'lang', 'data-value': lang }
       = render layout: 'shared/collapsible_block', locals: { container_name: 'tocfchar', title: t('author_toc_filters.extra_content'), content_class: 'nested-list' } do
         %ul
           %li
-            %input.toc-filter-char#toc-filter-curatorial{ type: 'checkbox', value: 'curatorial', name: 'toc_filter_char' }
-            %label{ for: 'toc-filter-curatorial' }
-              = t('author_toc_filters.curatorial_content')
-              %span.toc-facet-count{ 'data-section': 'char', 'data-value': 'curatorial' }
+            .filter-checkbox
+              %input.toc-filter-char#toc-filter-curatorial{ type: 'checkbox', value: 'curatorial', name: 'toc_filter_char' }
+              %label{ for: 'toc-filter-curatorial' }
+                = t('author_toc_filters.curatorial_content')
+                %span.toc-facet-count{ 'data-section': 'char', 'data-value': 'curatorial' }
           %li
-            %input.toc-filter-char#toc-filter-recommended{ type: 'checkbox', value: 'recommended', name: 'toc_filter_char' }
-            %label{ for: 'toc-filter-recommended' }
-              = t('author_toc_filters.reader_recommendations')
-              %span.toc-facet-count{ 'data-section': 'char', 'data-value': 'recommended' }
+            .filter-checkbox
+              %input.toc-filter-char#toc-filter-recommended{ type: 'checkbox', value: 'recommended', name: 'toc_filter_char' }
+              %label{ for: 'toc-filter-recommended' }
+                = t('author_toc_filters.reader_recommendations')
+                %span.toc-facet-count{ 'data-section': 'char', 'data-value': 'recommended' }
           %li
-            %input.toc-filter-char#toc-filter-noprops{ type: 'checkbox', value: 'noprops', name: 'toc_filter_char' }
-            %label{ for: 'toc-filter-noprops' }
-              = t('author_toc_filters.no_extra_content')
-              %span.toc-facet-count{ 'data-section': 'char', 'data-value': 'noprops' }
+            .filter-checkbox
+              %input.toc-filter-char#toc-filter-noprops{ type: 'checkbox', value: 'noprops', name: 'toc_filter_char' }
+              %label{ for: 'toc-filter-noprops' }
+                = t('author_toc_filters.no_extra_content')
+                %span.toc-facet-count{ 'data-section': 'char', 'data-value': 'noprops' }
       = render layout: 'shared/collapsible_block', locals: { container_name: 'tocfdate', title: t(:thedate) } do
         .search-mobile-switch
           %button.search-mobile-option.active.toc-date-type{ type: 'button', 'data-datefield': 'pubyear' }= t('author_toc_filters.edition')

--- a/app/views/authors/_toc_filters.html.haml
+++ b/app/views/authors/_toc_filters.html.haml
@@ -17,7 +17,8 @@
             - fd[:genres].each do |genre|
               %li
                 .filter-checkbox
-                  %input.toc-filter-genre{ type: 'checkbox', value: genre, id: "toc-filter-genre-#{genre}", name: 'toc_filter_genre' }
+                  %input.toc-filter-genre{ type: 'checkbox', value: genre, name: 'toc_filter_genre',
+                                           id: "toc-filter-genre-#{genre}" }
                   %label{ for: "toc-filter-genre-#{genre}" }
                     %span.by-icon-v02>= glyph_for_genre(genre)
                     = textify_genre(genre)
@@ -44,7 +45,8 @@
                     - translated_langs.each do |lang|
                       %li
                         .filter-checkbox
-                          %input.toc-filter-lang{ type: 'checkbox', value: lang, id: "toc-filter-lang-#{lang}", name: 'toc_filter_lang' }
+                          %input.toc-filter-lang{ type: 'checkbox', value: lang, name: 'toc_filter_lang',
+                                                  id: "toc-filter-lang-#{lang}" }
                           %label{ for: "toc-filter-lang-#{lang}" }
                             = textify_lang(lang)
                             %span.toc-facet-count{ 'data-section': 'lang', 'data-value': lang }
@@ -52,13 +54,15 @@
         %ul
           %li
             .filter-checkbox
-              %input.toc-filter-char#toc-filter-curatorial{ type: 'checkbox', value: 'curatorial', name: 'toc_filter_char' }
+              %input.toc-filter-char#toc-filter-curatorial{ type: 'checkbox', value: 'curatorial',
+                                                            name: 'toc_filter_char' }
               %label{ for: 'toc-filter-curatorial' }
                 = t('author_toc_filters.curatorial_content')
                 %span.toc-facet-count{ 'data-section': 'char', 'data-value': 'curatorial' }
           %li
             .filter-checkbox
-              %input.toc-filter-char#toc-filter-recommended{ type: 'checkbox', value: 'recommended', name: 'toc_filter_char' }
+              %input.toc-filter-char#toc-filter-recommended{ type: 'checkbox', value: 'recommended',
+                                                             name: 'toc_filter_char' }
               %label{ for: 'toc-filter-recommended' }
                 = t('author_toc_filters.reader_recommendations')
                 %span.toc-facet-count{ 'data-section': 'char', 'data-value': 'recommended' }

--- a/app/views/shared/_tabs.html.haml
+++ b/app/views/shared/_tabs.html.haml
@@ -175,7 +175,7 @@
                 %span.by-icon-v02.iconInMenu T
                 = t(:list_all_works)
             %li
-              %a{href: collections_path}
+              %a{ href: collections_path }
                 %span.by-icon-v02.iconInMenu L
                 = t(:list_all_collections)
         %li.topMenuItemMobile-v02

--- a/app/views/shared/_tabs.html.haml
+++ b/app/views/shared/_tabs.html.haml
@@ -174,6 +174,10 @@
               %a{href: all_works_path}
                 %span.by-icon-v02.iconInMenu T
                 = t(:list_all_works)
+            %li
+              %a{href: collections_path}
+                %span.by-icon-v02.iconInMenu L
+                = t(:list_all_collections)
         %li.topMenuItemMobile-v02
           %span.caret= t(:genres)
           %ul.nested

--- a/app/views/shared/filters/_checkboxes.html.haml
+++ b/app/views/shared/filters/_checkboxes.html.haml
@@ -1,12 +1,17 @@
+-#
+  Each checkbox and its label are wrapped in a .filter-checkbox row, which the
+  stylesheet lays out as a flex line. Without it, the inline-block label is an
+  atomic box: in the narrow CSS columns of .nested-list a label too wide for the
+  rest of its line drops whole to the next line, stranding its checkbox alone.
 - all_values.each do |value|
   - checked = selected_values.present? && selected_values.include?(value)
   - icon = icons[value]
-  %input{ name: "#{field_name}[]", id: "#{group_name}_#{value}", type: :checkbox, value: value, checked: checked }
-  %label
-    - if icon.present?
-      %span.by-icon-v02>= icon
-    = labels[value]
-    - count_text = facet[value] || (selected_values.present? ? t(:filtered) : '0')
-    %span
-      (#{count_text})
-  %br/
+  .filter-checkbox
+    %input{ name: "#{field_name}[]", id: "#{group_name}_#{value}", type: :checkbox, value: value, checked: checked }
+    %label
+      - if icon.present?
+        %span.by-icon-v02>= icon
+      = labels[value]
+      - count_text = facet[value] || (selected_values.present? ? t(:filtered) : '0')
+      %span
+        (#{count_text})

--- a/app/views/shared/filters/_checkboxes.html.haml
+++ b/app/views/shared/filters/_checkboxes.html.haml
@@ -4,11 +4,13 @@
   atomic box: in the narrow CSS columns of .nested-list a label too wide for the
   rest of its line drops whole to the next line, stranding its checkbox alone.
 - all_values.each do |value|
-  - checked = selected_values.present? && selected_values.include?(value)
-  - icon = icons[value]
+  :ruby
+    checked = selected_values.present? && selected_values.include?(value)
+    icon = icons[value]
+    checkbox_id = "#{group_name}_#{value}"
   .filter-checkbox
-    %input{ name: "#{field_name}[]", id: "#{group_name}_#{value}", type: :checkbox, value: value, checked: checked }
-    %label
+    %input{ name: "#{field_name}[]", id: checkbox_id, type: :checkbox, value: value, checked: checked }
+    %label{ for: checkbox_id }
       - if icon.present?
         %span.by-icon-v02>= icon
       = labels[value]

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2553,6 +2553,7 @@ en:
   linked_taggings: Linked Taggings
   linking_entries: Linking Entries
   list_all_authors: List All Authors
+  list_all_collections: List All Collections
   list_all_works: List All Works
   location: Location
   location_in_work: Location In Work

--- a/spec/requests/filter_checkbox_labels_spec.rb
+++ b/spec/requests/filter_checkbox_labels_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# Every filter option rendered by shared/filters/_checkboxes must have its label
+# wired to its own checkbox via `for`, so that clicking the label text toggles
+# the box and screen readers announce the two as one control. That only holds if
+# the generated ids ("#{group_name}_#{value}") are unique on the page --
+# shared/filters/_languages in particular renders the partial twice under the
+# same group_name, relying on the two value sets being disjoint.
+RSpec.describe 'Filter checkbox labels', type: :request do
+  around do |example|
+    I18n.with_locale(:he) { example.run }
+  end
+
+  # /works and /authors build their facet counts from Elasticsearch aggregations
+  # and blow up on an empty index, so give both indices something to aggregate.
+  let!(:work) { create(:manifestation, author: create(:authority, gender: 'female')) }
+
+  before do
+    import_and_await(ManifestationsIndex, [work])
+    import_and_await(AuthoritiesIndex, Authority.all.to_a)
+  end
+
+  after do
+    Chewy.massacre
+  end
+
+  def filter_panel
+    Nokogiri::HTML(response.body).at_css('#filters_panel')
+  end
+
+  shared_examples 'labelled filter checkboxes' do |page_name, path_helper|
+    before { get send(path_helper) }
+
+    it "gives every filter checkbox on #{page_name} a label bound to it" do
+      rows = filter_panel.css('.filter-checkbox')
+      expect(rows).not_to be_empty
+
+      unbound = rows.reject do |row|
+        checkbox = row.at_css('input[type=checkbox]')
+        label = row.at_css('label')
+        checkbox && label && checkbox['id'].present? && label['for'] == checkbox['id']
+      end
+
+      expect(unbound.map(&:text).map(&:squish)).to eq([])
+    end
+
+    it "keeps the generated checkbox ids unique across #{page_name}" do
+      ids = Nokogiri::HTML(response.body).css('input[type=checkbox][id]').pluck('id')
+
+      expect(ids).to eq(ids.uniq)
+    end
+  end
+
+  it_behaves_like 'labelled filter checkboxes', 'the works browse page', :works_path
+  it_behaves_like 'labelled filter checkboxes', 'the authors browse page', :authors_path
+  it_behaves_like 'labelled filter checkboxes', 'the collections browse page', :collections_path
+  it_behaves_like 'labelled filter checkboxes', 'the lexicon entries list', :lexicon_entries_list_path
+end

--- a/spec/requests/mobile_menu_collections_link_spec.rb
+++ b/spec/requests/mobile_menu_collections_link_spec.rb
@@ -11,18 +11,24 @@ RSpec.describe 'Mobile menu collections link', type: :request do
   end
 
   def mobile_menu
-    Nokogiri::HTML(response.body).at_css('#menuMobile')
+    menu = Nokogiri::HTML(response.body).at_css('#menuMobile')
+    expect(menu).not_to be_nil, 'the mobile menu (#menuMobile) is missing from the page'
+    menu
+  end
+
+  def collections_links
+    mobile_menu.css("a[href='#{collections_browse_path}']")
   end
 
   before { get root_path }
 
   it 'links to the collections list from the mobile menu' do
     expect(response).to have_http_status(:ok)
-    expect(mobile_menu.css("a[href='#{collections_browse_path}']")).not_to be_empty
+    expect(collections_links).not_to be_empty, 'no link to the collections list in the mobile menu'
   end
 
   it 'labels the link the same way the desktop dropdown does' do
-    link = mobile_menu.at_css("a[href='#{collections_browse_path}']")
-    expect(link.text).to include(I18n.t(:list_all_collections))
+    expect(collections_links).not_to be_empty, 'no link to the collections list in the mobile menu'
+    expect(collections_links.first.text).to include(I18n.t(:list_all_collections))
   end
 end

--- a/spec/requests/mobile_menu_collections_link_spec.rb
+++ b/spec/requests/mobile_menu_collections_link_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# The desktop dropdown (#menu-works) has always offered "list all collections";
+# the mobile sidenav (#menuMobile) was missing it, so mobile visitors had no way
+# to reach the collections list from the menu.
+RSpec.describe 'Mobile menu collections link', type: :request do
+  around do |example|
+    I18n.with_locale(:he) { example.run }
+  end
+
+  def mobile_menu
+    Nokogiri::HTML(response.body).at_css('#menuMobile')
+  end
+
+  before { get root_path }
+
+  it 'links to the collections list from the mobile menu' do
+    expect(response).to have_http_status(:ok)
+    expect(mobile_menu.css("a[href='#{collections_browse_path}']")).not_to be_empty
+  end
+
+  it 'labels the link the same way the desktop dropdown does' do
+    link = mobile_menu.at_css("a[href='#{collections_browse_path}']")
+    expect(link.text).to include(I18n.t(:list_all_collections))
+  end
+end

--- a/spec/system/browse_filter_checkbox_alignment_spec.rb
+++ b/spec/system/browse_filter_checkbox_alignment_spec.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# Regression test for the filter panes' option lists. Labels are inline-block
+# site-wide, so before the fix a label too wide for the remainder of its line
+# dropped whole to the next line, stranding its checkbox alone above it (and the
+# CSS columns of .nested-list could split the pair too). Each checkbox must stay
+# on the same line as, and immediately to the right of (RTL), its own label.
+describe 'Browse filter checkbox alignment', :js do
+  # Widths that keep the desktop two-column filter pane but progressively
+  # squeeze it, which is what makes the longer Hebrew labels wrap.
+  def window_widths
+    [1400, 1200, 1100, 1000]
+  end
+
+  # Text of every option row whose checkbox is not on the same line as the first
+  # line of its own label, or has drifted away from it horizontally.
+  def misaligned_rows
+    page.evaluate_script(<<~JS)
+      (function () {
+        return Array.prototype.slice.call(
+          document.querySelectorAll('#filters_panel .filter-checkbox')
+        ).filter(function (row) {
+          var box = row.querySelector('input[type=checkbox]').getBoundingClientRect();
+          var label = row.querySelector('label').getBoundingClientRect();
+          var sharedHeight = Math.min(box.bottom, label.bottom) - Math.max(box.top, label.top);
+          // at least half the checkbox must sit on the label's first line, and
+          // in RTL the checkbox must be to the right of the label text
+          return sharedHeight < 9 || box.left < label.right - 2;
+        }).map(function (row) {
+          return row.textContent.trim().replace(/\\s+/g, ' ');
+        });
+      })()
+    JS
+  end
+
+  before do
+    skip 'WebDriver not available or misconfigured' unless webdriver_available?
+
+    Chewy.strategy(:atomic) do
+      create(:manifestation, author: create(:authority, gender: 'female'))
+      create(:manifestation, author: create(:authority, gender: 'male'))
+    end
+  end
+
+  after do
+    Chewy.massacre
+  end
+
+  shared_examples 'keeps every checkbox with its label' do |path_helper|
+    it "keeps each checkbox next to its label at every width on #{path_helper}", :aggregate_failures do
+      visit send(path_helper)
+      expect(page).to have_css('#filters_panel .filter-checkbox')
+
+      window_widths.each do |width|
+        page.driver.browser.manage.window.resize_to(width, 900)
+
+        expect(misaligned_rows).to eq([]), "checkboxes detached from their labels at #{width}px wide"
+      end
+    end
+  end
+
+  it_behaves_like 'keeps every checkbox with its label', :works_path
+  it_behaves_like 'keeps every checkbox with its label', :authors_path
+  it_behaves_like 'keeps every checkbox with its label', :collections_path
+end

--- a/spec/system/filter_label_click_spec.rb
+++ b/spec/system/filter_label_click_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# The filter option labels used to have no `for` attribute, so the only way to
+# apply a filter was to hit the 18x18px checkbox itself -- the label text, which
+# is most of the option's visible area, was dead to clicks.
+describe 'Filter option labels are clickable', :js do
+  before do
+    skip 'WebDriver not available or misconfigured' unless webdriver_available?
+
+    Chewy.strategy(:atomic) do
+      create(:manifestation, author: create(:authority, gender: 'female'))
+      create(:manifestation, author: create(:authority, gender: 'male'))
+    end
+  end
+
+  after do
+    Chewy.massacre
+  end
+
+  it 'applies the filter when its label text is clicked' do
+    visit authors_path
+
+    find('label[for="gender_female"]', visible: :visible).click
+
+    expect(page).to have_css('.tag', text: 'יוצר: נקבה', wait: 5)
+    expect(page).to have_field('gender_female', type: 'checkbox', checked: true, visible: :visible)
+  end
+
+  it 'clears the filter when the label text is clicked again' do
+    visit authors_path
+
+    find('label[for="gender_female"]', visible: :visible).click
+    expect(page).to have_css('.tag', text: 'יוצר: נקבה', wait: 5)
+
+    find('label[for="gender_female"]', visible: :visible).click
+
+    expect(page).not_to have_css('.tag', text: 'יוצר: נקבה', wait: 5)
+    expect(page).to have_field('gender_female', type: 'checkbox', checked: false, visible: :visible)
+  end
+end


### PR DESCRIPTION
Two unrelated UI fixes reported together.

## 1. Mobile menu was missing the all-collections list

The mobile sidenav's "יצירות" section had "most read" / "newest" / "list all
works", but not the **"רשימת כל הכותרים"** entry the desktop dropdown has — so
on mobile there was no menu route to `/collections`.

Added it, using the same glyph and label as the desktop dropdown. Also added the
missing `list_all_collections` key to `en.yml` (the desktop menu was already
using it and rendering it untranslated in English).

## 2. Browsing filter checkboxes detached from their labels

Reported symptom: at certain zoom levels the filter pane shows checkboxes with
no label next to them, while the label appears in the next column with no
checkbox.

**Cause** — `label` is `display: inline-block` site-wide (`BY_styles_General.css`),
which makes every label an atomic, unbreakable box. The filter panes lay their
options out in two CSS columns (`.nested-list { column-count: 2 }`), so each
option gets roughly half of an already narrow pane. As soon as a label is wider
than what is left of the line beside its 18px checkbox, the whole label drops to
the next line and the checkbox is stranded alone above it — which reads as a
checkbox belonging to the label above. The column breaker could separate the
pair as well.

**Fix** — each option is now a `.filter-checkbox` row laid out as a flex line:
the label wraps its own text while staying beside its own checkbox, at any zoom
level or label length. The row is also `break-inside: avoid`, so a column break
cannot split it.

Applied to the shared filters partial — used by **/works**, **/authors**,
**/collections** and the **lexicon entries list** — and to the **authority TOC
filter pane** (`authors/_toc_filters`), which had the same markup shape.

Vertical rhythm and spacing are unchanged; only the row's internal layout is.

## Tests

- `spec/requests/mobile_menu_collections_link_spec.rb` — the mobile menu links to
  the collections list, with the same label as the desktop dropdown.
- `spec/system/browse_filter_checkbox_alignment_spec.rb` — for /works, /authors
  and /collections, at four viewport widths, asserts via `getBoundingClientRect`
  that every checkbox shares a line with the first line of its own label and sits
  immediately to its right (RTL). Verified to **fail** on the pre-fix CSS at all
  four widths, including the default 1400px, and pass with the fix.

Also re-ran the neighbouring filter/menu specs: `authors_filter_panel_spec`,
`collections_browse_authorities_filter_spec`, `lexicon/entries_list_filtering_spec`,
`works_browse_authors_filter_spec`, `collections_browse_spec`,
`manifestation_collection_type_filtering_spec`, `author_toc_filters_spec`
(system + request), `author_navbar_mobile_expansion_spec`,
`navbar_works_about_author_i18n_spec` — all green (71 examples).

The full suite (40+ min) was **not** run; it needs your go-ahead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)