### PR TITLE
Add regression spec for homepage authors card height on mobile

### DIFF
--- a/spec/system/homepage_authors_card_height_spec.rb
+++ b/spec/system/homepage_authors_card_height_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe 'Homepage authors card height', :js, type: :system do
     page.driver.browser.manage.window.resize_to(375, 812)
     visit root_path
     expect(page).to have_css('#works-in-project', wait: 5)
-
+    expect(page).to have_css('#welcome-authors .link-to-all-v02 a', wait: 5)
     expect(gap_below_authors_content).to be < 60
   end
 

--- a/spec/system/homepage_authors_card_height_spec.rb
+++ b/spec/system/homepage_authors_card_height_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# Regression test for the homepage author carousels leaving a large blank area above the
+# "works in the project" (most-read) card on mobile: #welcome-authors had an unconditional
+# min-height of 720px, which only matches the natural content height on wide viewports.
+RSpec.describe 'Homepage authors card height', :js, type: :system do
+  before(:all) do
+    clean_tables
+    Chewy.strategy(:atomic) do
+      create_list(:authority, 3, :with_image)
+      create(:manifestation, title: 'Alpha Work', impressions_count: 100)
+      ManifestationsIndex.reset!
+    end
+  end
+
+  after(:all) do
+    clean_tables
+  end
+
+  before do
+    skip 'WebDriver not available or misconfigured' unless webdriver_available?
+  end
+
+  after do
+    page.driver.browser.manage.window.resize_to(1400, 1400)
+  end
+
+  # Vertical distance in pixels between the last visible content of the authors card (the
+  # "to all authors" link) and the top of the works card. Measuring the card's own bottom would
+  # not catch the bug, since the blank space is *inside* the card.
+  def gap_below_authors_content
+    page.evaluate_script(<<~JS)
+      (function() {
+        var link = document.querySelector('#welcome-authors .link-to-all-v02');
+        var works = document.querySelector('#works-in-project');
+        return works.getBoundingClientRect().top - link.getBoundingClientRect().bottom;
+      })();
+    JS
+  end
+
+  it 'does not leave a large blank area under the carousels on mobile' do
+    page.driver.browser.manage.window.resize_to(375, 812)
+    visit root_path
+    expect(page).to have_css('#works-in-project', wait: 5)
+
+    expect(gap_below_authors_content).to be < 60
+  end
+
+  it 'keeps the CLS-reducing min-height on wide viewports' do
+    page.driver.browser.manage.window.resize_to(1400, 1400)
+    visit root_path
+    expect(page).to have_css('#works-in-project', wait: 5)
+
+    expect(page.evaluate_script("getComputedStyle(document.querySelector('#welcome-authors')).minHeight"))
+      .to eq('720px')
+  end
+end


### PR DESCRIPTION
## Summary

Test-only follow-up to 014df51b2 ("Fixed #1521 mobile extraneous vertical space"), which is already on master. This adds the regression spec for it.

`#welcome-authors` carried an unconditional `min-height: 720px` (added for CLS in #1115). That value only matches the natural content height above 992px, where `#authors-in-project` is a fixed 775px tall. Below that breakpoint the card is `height: auto` and the carousels are much shorter, so the min-height left blank space inside the card, above the works/most-read card:

| viewport | gap before fix | after |
|---|---|---|
| 360 / 390px | 378px | 30px |
| 500px | 234px | 30px |
| 640–991px | 125px | 30px |
| 1000–1400px | 27px | 27px (unchanged) |

## Test plan

`spec/system/homepage_authors_card_height_spec.rb`:

- **mobile (375px)** — asserts the gap between the "to all authors" link and the top of `#works-in-project` is under 60px. It measures from the link rather than the card's own bottom, because the blank space is *inside* the card and a card-bottom measurement does not catch the bug. Verified to fail on the pre-fix CSS (`expected: < 60, got: 378.21875`) and pass with it.
- **desktop (1400px)** — asserts the 720px min-height still applies, so the CLS reservation cannot be silently dropped.

Full suite: 2227 examples, 1 failure, 14 pending. The one failure is `manifestation_edit_ddslick_spec.rb:65`, unrelated and pre-existing — it passes 5/5 when that file is run alone, so it is order/timing dependent. Tracked separately in bead by-ye8.

RuboCop clean on the new file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)