### PR TITLE
Mobile header stats: keep showing the works count, not volumes

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1619,3 +1619,19 @@ p.by-genre-name-v02.headline-2-v02 {
   float: left;
   font-weight: normal;
 }
+
+// The header statistics box only has room for a single stat below 992px, so
+// BY_styles_Max991.css keeps `:first-child` and hides the rest. That picked the
+// works count by accident of source order; once the box was reordered the lone
+// mobile stat silently became the volumes count. Select the stat we actually
+// want to keep by marker class instead -- source order also differs between the
+// Hebrew and the LTR variants of the box.
+@media only screen and (max-width: 991px) {
+  .statistics-box-v02 > .statistics-v02 {
+    display: none;
+
+    &.mobile-stat {
+      display: block;
+    }
+  }
+}

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -69,7 +69,7 @@
                   </div>
                   <div class="stat-small-v02"><%= t(:volumes) %></div>
                 </div>
-                <div class="statistics-v02">
+                <div class="statistics-v02 mobile-stat">
                   <div class="stat-big-v02">
                     <%= link_to(Manifestation.cached_count.to_s, all_works_path) %>
                   </div>
@@ -102,7 +102,7 @@
                   </div>
                   <div class="stat-small-v02"><%= t(:authors_neutral_en) %></div>
                 </div>
-                <div class="statistics-v02">
+                <div class="statistics-v02 mobile-stat">
                   <div class="stat-big-v02">
                     <%= link_to(Manifestation.cached_count.to_s, all_works_path) %>
                   </div>

--- a/spec/system/header_stats_mobile_stat_spec.rb
+++ b/spec/system/header_stats_mobile_stat_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# The header statistics box shows four stats on a desktop, but only has room for
+# one below 992px, where BY_styles_Max991.css hides all but the surviving child.
+# That child used to be picked by source order (`:first-child`), so reordering
+# the box quietly swapped the single mobile stat from the works count to the
+# volumes count. The stat to keep is now marked with .mobile-stat.
+RSpec.describe 'Header statistics box', :js, type: :system do
+  before do
+    skip 'WebDriver not available or misconfigured' unless webdriver_available?
+  end
+
+  # Any page in the main layout carries the header; this one is cheap to render.
+  def visit_page_at(width, height)
+    page.driver.browser.manage.window.resize_to(width, height)
+    visit '/pby_volumes'
+    expect(page).to have_css('.statistics-box-v02', visible: :visible, wait: 5)
+  end
+
+  it 'shows only the works count on a phone-sized viewport' do
+    visit_page_at(390, 844)
+
+    expect(page).to have_css('.statistics-box-v02 .statistics-v02.mobile-stat', visible: :visible)
+    expect(page).to have_css('.statistics-box-v02 .statistics-v02:not(.mobile-stat)',
+                             visible: :hidden, count: 3)
+
+    # The one stat left standing is the works count, not the volumes count.
+    expect(page).to have_css('.statistics-box-v02 .statistics-v02.mobile-stat',
+                             text: I18n.t(:works), visible: :visible)
+    expect(page).to have_css(".statistics-box-v02 .statistics-v02.mobile-stat a[href='#{all_works_path}']",
+                             visible: :visible)
+  end
+
+  it 'still shows every stat on a desktop-sized viewport' do
+    visit_page_at(1280, 900)
+
+    expect(page).to have_css('.statistics-box-v02 .statistics-v02', visible: :visible, count: 4)
+  end
+end


### PR DESCRIPTION
## Problem

In mobile view the header statistics box shows a single stat, and it was showing the **volumes** count (כותרים) instead of the **works** count (יצירות).

The box has four stats on desktop, but only room for one below 992px, so `BY_styles_Max991.css` hides everything after `:first-child`:

```css
.statistics-box-v02 > *:not(:first-child){ display: none; }
```

That made the surviving stat depend on source order. When the box was reordered, the lone mobile stat quietly changed from works to volumes.

## Fix

Mark the works entry with a `.mobile-stat` class and select on that class instead of on position, so the mobile stat no longer depends on the order of the box. The class is added in **both** variants of the box in `application.html.erb` — the Hebrew and the LTR one list the stats in different orders, so a positional selector could not have been right for both.

The CSS override lives in `application.scss` (the `BY_*.css` files are read-only per project rules); `require_self` runs after the `BY_*` requires, so it wins on order at equal specificity.

Desktop is untouched: all four stats still show at ≥992px.

## Verification

Checked in headless Chrome against the dev server at 390px, 767px and 1280px:

- 390px / 767px → only `58686 יצירות` visible
- 1280px → all four visible

## Test plan

New system spec `spec/system/header_stats_mobile_stat_spec.rb`:

- at 390×844: exactly one stat visible, it carries `.mobile-stat`, its label is `t(:works)` and it links to `all_works_path`; the other three are hidden
- at 1280×900: all four stats visible

```
bundle exec rspec spec/system/header_stats_mobile_stat_spec.rb
# 2 examples, 0 failures
```

Confirmed the spec fails without the change (stashed the fix, first example fails).

The full suite was **not** run — it takes 40+ minutes and needs explicit approval.

## Note on an unrelated pre-existing breakage

`spec/system/author_toc_mobile_layout_spec.rb` on `lexicon` is a Ruby syntax error (missing `end` at line 46, from commit 950041d9c / #1541):

```
$ ruby -c spec/system/author_toc_mobile_layout_spec.rb
spec/system/author_toc_mobile_layout_spec.rb:84: syntax error, unexpected end-of-input, expecting `end'
```

Left alone here as out of scope, but it will break a full-suite run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)