### PR TITLE
Fix syntax error in author TOC mobile layout spec

### DIFF
--- a/spec/system/author_toc_mobile_layout_spec.rb
+++ b/spec/system/author_toc_mobile_layout_spec.rb
@@ -43,6 +43,7 @@ RSpec.describe 'Author TOC mobile layout', :js, type: :system do
     )
 
     expect(overflow).to be <= 1, "page overflows its viewport by #{overflow}px"
+  end
 
   it 'keeps the sort/collapse bar within its card' do
     visit_toc_at_mobile_width


### PR DESCRIPTION
## Problem

`spec/system/author_toc_mobile_layout_spec.rb` does not parse on `lexicon`:

```
$ ruby -c spec/system/author_toc_mobile_layout_spec.rb
spec/system/author_toc_mobile_layout_spec.rb:84: syntax error, unexpected end-of-input, expecting `end' (SyntaxError)
```

Commit 950041d9c (#1541) left the first example (`does not overflow the page horizontally`) unclosed. Ruby then nested the other two examples inside it and consumed the `describe`'s `end`, so the file failed to load — breaking any run that loads `spec/system`.

## Fix

One line: close the first example.

## Test plan

```
$ ruby -c spec/system/author_toc_mobile_layout_spec.rb
Syntax OK

$ bundle exec rspec spec/system/author_toc_mobile_layout_spec.rb
3 examples, 0 failures
```

All three examples now actually run (previously zero of them did), and rubocop is clean on the file.

The full suite was not run — it takes 40+ minutes and needs explicit approval.

🤖 Generated with [Claude Code](https://claude.com/claude-code)