### PR TITLE
Hide periodicals with no public works; make uncollected-works section collapsible

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -29,6 +29,12 @@
   &.collapsed {
     transform: rotate(0deg); // collapsed state: chevron points down
   }
+
+  // In the uncollected-works card the toggle trails a deliberately small explanation line;
+  // pin its size so it matches the chevrons on the volume cards above it.
+  .cwrapper.uncollected & {
+    font-size: 0.85rem;
+  }
 }
 
 // Staging environment indicator: diagonal stripe overlay

--- a/app/controllers/periodicals_controller.rb
+++ b/app/controllers/periodicals_controller.rb
@@ -3,11 +3,15 @@
 class PeriodicalsController < ApplicationController
   def index
     issue_ids = Collection.where(collection_type: 'periodical_issue').select(:id)
-    @periodicals = Collection.includes(:collection_items)
-                             .where(collection_type: 'periodical')
-                             .where(id: CollectionItem.where(item_type: 'Collection', item_id: issue_ids).select(:collection_id))
-                             .order(:title)
-                             .to_a
+    with_issue_ids = CollectionItem.where(item_type: 'Collection', item_id: issue_ids).select(:collection_id)
+    periodicals = Collection.includes(:collection_items)
+                            .where(collection_type: 'periodical')
+                            .where(id: with_issue_ids)
+                            .order(:title)
+                            .to_a
+    # a periodical whose issues hold nothing publicly accessible would only lead readers to empty pages
+    with_public_works = Collection.ids_with_published_manifestations(periodicals.map(&:id)).to_set
+    @periodicals = periodicals.select { |p| with_public_works.include?(p.id) }
     @periodicals_count = @periodicals.size
     @popular_works = ManifestationsIndex.query(match: { in_periodical: true })
                                         .filter(range: { impressions_count: { gte: 1 } })

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -433,10 +433,12 @@ class Collection < ApplicationRecord
     until ancestors_by_collection.empty? || found.size == roots.size
       items = CollectionItem.where(collection_id: ancestors_by_collection.keys)
                             .pluck(:collection_id, :item_type, :item_id)
-      published = Manifestation.all_published
-                               .where(id: items.filter_map { |_, type, item_id| item_id if type == 'Manifestation' })
-                               .pluck(:id)
-                               .to_set
+      manifestation_ids = items.filter_map { |_, type, item_id| item_id if type == 'Manifestation' }.uniq
+      published = if manifestation_ids.empty?
+                    Set.new
+                  else
+                    Manifestation.all_published.where(id: manifestation_ids).pluck(:id).to_set
+                  end
       next_level = {}
       items.each do |parent_id, item_type, item_id|
         ancestors = ancestors_by_collection[parent_id] - found # roots still looking for a published work

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -417,6 +417,47 @@ class Collection < ApplicationRecord
     return false
   end
 
+  # Bulk equivalent of #any_published_manifestations? for a set of collections: returns the ids of those
+  # whose item tree contains, at any depth, at least one Manifestation in status 'published'.
+  # Traverses the trees one level at a time, so the whole set costs a couple of queries per level of
+  # nesting rather than a query per item. Each (collection, ancestor) pair is visited at most once, so a
+  # sub-collection shared by several ancestors is still attributed to each of them, without rework.
+  def self.ids_with_published_manifestations(collection_ids)
+    roots = collection_ids.to_a.uniq
+    return [] if roots.empty?
+
+    found = Set.new
+    ancestors_by_collection = roots.index_with { |id| Set[id] } # collection being visited => roots it belongs to
+    seen = roots.index_with { |id| Set[id] } # (collection, root) pairs already queued, to avoid rework/cycles
+
+    until ancestors_by_collection.empty? || found.size == roots.size
+      items = CollectionItem.where(collection_id: ancestors_by_collection.keys)
+                            .pluck(:collection_id, :item_type, :item_id)
+      published = Manifestation.all_published
+                               .where(id: items.filter_map { |_, type, item_id| item_id if type == 'Manifestation' })
+                               .pluck(:id)
+                               .to_set
+      next_level = {}
+      items.each do |parent_id, item_type, item_id|
+        ancestors = ancestors_by_collection[parent_id] - found # roots still looking for a published work
+        next if ancestors.empty?
+
+        if item_type == 'Manifestation'
+          found.merge(ancestors) if published.include?(item_id)
+        elsif item_type == 'Collection'
+          fresh = ancestors - (seen[item_id] ||= Set.new)
+          next if fresh.empty?
+
+          seen[item_id].merge(fresh)
+          (next_level[item_id] ||= Set.new).merge(fresh)
+        end
+      end
+      ancestors_by_collection = next_level
+    end
+
+    found.to_a
+  end
+
   def like_count
     return 0
     # TODO: enable after implementing the likings table

--- a/app/views/authors/_toc_node.html.haml
+++ b/app/views/authors/_toc_node.html.haml
@@ -53,7 +53,13 @@
           .cwrapper{ id: "cwrapper_#{collection.id}", 'data-nonce' => nonce, 'data-collection-id' => collection.id, class: uncollected ? 'uncollected' : '' }
             %div{style:'font-size:120%;'}
               - if uncollected
-                %p{style: 'font-size: 0.8rem; color: #222222;'}= t(:uncollected_works_collection_explanation)
+                %p{style: 'font-size: 0.8rem; color: #222222;'}
+                  = t(:uncollected_works_collection_explanation)
+                  -# same chevron toggle the volumes carry, trailing the card's only text line
+                  - if renders_toclist
+                    - toggle_label = t(:toggle_collapse_uncollected)
+                    %span.volume-collapse-toggle{ role: 'button', tabindex: 0, title: toggle_label,
+                                                  aria: { label: toggle_label, expanded: 'true' } } )
               - else
                 %span.ctitle_only{ style: 'display:none;' }= collection.title
                 %span.ctitle

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3213,6 +3213,7 @@ en:
   collapse_all_sections: Collapse all sections
   expand_all_sections: Expand all sections
   toggle_collapse_volume: Collapse or expand this volume
+  toggle_collapse_uncollected: Collapse or expand the uncollected works
   legacy_urls:
     index:
       title: Legacy URL Mappings

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -2469,6 +2469,7 @@ he:
   collapse_all_sections: צמצם הכל
   expand_all_sections: הרחב הכל
   toggle_collapse_volume: צמצם או הרחב כרך זה
+  toggle_collapse_uncollected: צמצם או הרחב את היצירות שלא כונסו
   by_involved_authorities: לפי אישים מעורבים
   works_and_volumes: כותרים ויצירות
   list_all_collections: רשימת כל הכותרים

--- a/spec/models/collection_spec.rb
+++ b/spec/models/collection_spec.rb
@@ -1110,4 +1110,43 @@ expect(html).to include("by-icon-v02\" title=\"#{expected_genre_title}\">t</span
       end
     end
   end
+
+  describe '.ids_with_published_manifestations' do
+    let(:empty) { create(:collection, collection_type: :periodical) }
+    let(:unpublished_only) { create(:collection, collection_type: :periodical) }
+    let(:direct) { create(:collection, collection_type: :periodical) }
+    let(:nested) { create(:collection, collection_type: :periodical) }
+    let(:issue) { create(:collection, collection_type: :periodical_issue) }
+    let(:all_ids) { [empty.id, unpublished_only.id, direct.id, nested.id] }
+
+    before do
+      create(:collection_item, collection: unpublished_only, item: create(:manifestation, status: :unpublished))
+      create(:collection_item, collection: direct, item: create(:manifestation, status: :published))
+      series = create(:collection, collection_type: :series)
+      create(:collection_item, collection: nested, item: issue)
+      create(:collection_item, collection: issue, item: series)
+      create(:collection_item, collection: series, item: create(:manifestation, status: :published))
+    end
+
+    it 'returns only the ids of collections holding a published manifestation at any depth' do
+      expect(Collection.ids_with_published_manifestations(all_ids)).to contain_exactly(direct.id, nested.id)
+    end
+
+    it 'returns an empty array for an empty input' do
+      expect(Collection.ids_with_published_manifestations([])).to eq([])
+    end
+
+    it 'attributes a shared sub-collection to every ancestor that reaches it' do
+      create(:collection_item, collection: empty, item: issue)
+      expect(Collection.ids_with_published_manifestations([empty.id, nested.id]))
+        .to contain_exactly(empty.id, nested.id)
+    end
+
+    it 'agrees with #any_published_manifestations? for each collection' do
+      [empty, unpublished_only, direct, nested].each do |collection|
+        expect(Collection.ids_with_published_manifestations([collection.id]).any?)
+          .to eq(collection.any_published_manifestations?)
+      end
+    end
+  end
 end

--- a/spec/requests/periodicals_spec.rb
+++ b/spec/requests/periodicals_spec.rb
@@ -105,6 +105,8 @@ RSpec.describe 'Periodicals', type: :request do
     before do
       create(:collection_item, collection: periodical, item: issue_no_cover, seqno: 1)
       create(:collection_item, collection: periodical, item: issue_with_cover, seqno: 2)
+      # the index only lists periodicals with publicly accessible works
+      create(:collection_item, collection: issue_no_cover, item: create(:manifestation, status: :published), seqno: 1)
     end
 
     it 'assigns @periodical_first_covers as a hash' do
@@ -131,6 +133,8 @@ RSpec.describe 'Periodicals', type: :request do
 
     before do
       create(:collection_item, collection: periodical, item: issue_no_cover, seqno: 1)
+      # the index only lists periodicals with publicly accessible works
+      create(:collection_item, collection: issue_no_cover, item: create(:manifestation, status: :published), seqno: 1)
     end
 
     it 'maps the periodical to nil when no issues have a cover' do
@@ -155,6 +159,8 @@ RSpec.describe 'Periodicals', type: :request do
 
     before do
       create(:collection_item, collection: periodical_with_issue, item: issue, seqno: 1)
+      # the index only lists periodicals with publicly accessible works
+      create(:collection_item, collection: issue, item: create(:manifestation, status: :published), seqno: 1)
     end
 
     it 'does not include zero-issue periodicals in @periodicals' do
@@ -171,6 +177,68 @@ RSpec.describe 'Periodicals', type: :request do
     it 'sets @periodicals_count to only count periodicals with issues' do
       get '/periodicals'
       expect(assigns(:periodicals_count)).to eq(assigns(:periodicals).size)
+    end
+  end
+
+  describe 'suppression of periodicals without publicly accessible works' do
+    let!(:periodical_with_published) do
+      create(:collection, collection_type: 'periodical', title: 'Published Works Periodical')
+    end
+    let!(:periodical_unpublished_only) do
+      create(:collection, collection_type: 'periodical', title: 'Unpublished Only Periodical')
+    end
+    let!(:periodical_empty_issues) do
+      create(:collection, collection_type: 'periodical', title: 'Empty Issues Periodical')
+    end
+
+    before do
+      %w(published unpublished empty).zip(
+        [periodical_with_published, periodical_unpublished_only, periodical_empty_issues]
+      ).each do |kind, periodical|
+        issue = create(:collection, collection_type: 'periodical_issue')
+        create(:collection_item, collection: periodical, item: issue, seqno: 1)
+        next if kind == 'empty'
+
+        status = kind == 'published' ? :published : :unpublished
+        create(:collection_item, collection: issue, item: create(:manifestation, status: status), seqno: 1)
+      end
+    end
+
+    it 'lists only the periodical holding a published work' do
+      get '/periodicals'
+      expect(assigns(:periodicals)).to include(periodical_with_published)
+      expect(assigns(:periodicals)).not_to include(periodical_unpublished_only, periodical_empty_issues)
+    end
+
+    it 'does not render the suppressed periodicals on the page' do
+      get '/periodicals'
+      expect(response.body).to include('Published Works Periodical')
+      expect(response.body).not_to include('Unpublished Only Periodical')
+      expect(response.body).not_to include('Empty Issues Periodical')
+    end
+
+    it 'counts only the listed periodicals' do
+      get '/periodicals'
+      expect(assigns(:periodicals_count)).to eq(assigns(:periodicals).size)
+    end
+
+    context 'when the published work sits in a sub-collection of the issue' do
+      let!(:periodical_nested) do
+        create(:collection, collection_type: 'periodical', title: 'Nested Works Periodical')
+      end
+
+      before do
+        issue = create(:collection, collection_type: 'periodical_issue')
+        series = create(:collection, collection_type: 'series')
+        create(:collection_item, collection: periodical_nested, item: issue, seqno: 1)
+        create(:collection_item, collection: issue, item: series, seqno: 1)
+        create(:collection_item, collection: series, item: create(:manifestation, status: :published), seqno: 1)
+      end
+
+      it 'still lists the periodical' do
+        get '/periodicals'
+        expect(assigns(:periodicals)).to include(periodical_nested)
+      end
     end
   end
 end

--- a/spec/system/author_toc_uncollected_collapse_toggle_spec.rb
+++ b/spec/system/author_toc_uncollected_collapse_toggle_spec.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# The uncollected-works card in the Authority TOC must be individually collapsible, just like the
+# volume cards above it: it carries the same chevron toggle, which collapses only its own list.
+describe 'Author TOC uncollected-works collapse toggle', :js do
+  # Lazy `let` (not `let!`) so the WebDriver skip in the before hook can
+  # short-circuit without doing any DB/Chewy work when Chrome is unavailable.
+  let(:author) { create(:authority, name: 'Uncollected Toggle Author') }
+  let(:volume) { create(:collection, title: 'A Volume', collection_type: :volume) }
+
+  let(:uncollected_sel) { '#browse_mainlist .cwrapper.uncollected' }
+  let(:uncollected_toggle_sel) { "#{uncollected_sel} .volume-collapse-toggle" }
+  let(:volume_sel) { "#browse_mainlist .cwrapper[data-collection-id='#{volume.id}']" }
+
+  before do
+    skip 'WebDriver not available or misconfigured' unless webdriver_available?
+
+    Chewy.strategy(:atomic) do
+      # Title differs from the volume title, so prune_collections() leaves the volume's toggle in place.
+      work_in_volume = create(:manifestation, title: 'Work In Volume', status: :published, author: author,
+                                              genre: 'poetry', orig_lang: 'he', language: 'he')
+      create(:collection_item, collection: volume, item: work_in_volume)
+      # A standalone work by the author, in no collection -> lands in "uncollected".
+      create(:manifestation, title: 'Solo Uncollected Work', status: :published, author: author,
+                             genre: 'poetry', orig_lang: 'he', language: 'he')
+    end
+    create(:involved_authority, authority: author, item: volume, role: 'editor')
+    RefreshUncollectedWorksCollection.call(author)
+  end
+
+  after { Chewy.massacre }
+
+  it 'collapses and re-expands only the uncollected works list' do
+    visit authority_path(author)
+    expect(page).to have_css(uncollected_toggle_sel)
+
+    toggle = find(uncollected_toggle_sel, match: :first)
+    cwrapper = toggle.find(:xpath, "./ancestor::div[contains(@class, 'cwrapper')][1]")
+    card = toggle.find(:xpath, "./ancestor::li[contains(@class, 'by-card-v02')][1]")
+
+    # Initially expanded
+    expect(card['aria-expanded']).to eq('true')
+    expect(cwrapper).to have_css('ul.toclist', visible: :visible)
+    expect(toggle[:class]).not_to include('collapsed')
+    expect(toggle['aria-expanded']).to eq('true')
+
+    # Collapse: the uncollected list hides, the volume's list is untouched
+    toggle.click
+    expect(cwrapper).to have_css('ul.toclist', visible: :hidden)
+    expect(toggle[:class]).to include('collapsed')
+    expect(card['aria-expanded']).to eq('false')
+    expect(toggle['aria-expanded']).to eq('false')
+    expect(page).to have_css("#{volume_sel} > ul.toclist", visible: :visible)
+
+    # Expand again
+    toggle.click
+    expect(cwrapper).to have_css('ul.toclist', visible: :visible)
+    expect(toggle[:class]).not_to include('collapsed')
+    expect(card['aria-expanded']).to eq('true')
+    expect(toggle['aria-expanded']).to eq('true')
+  end
+
+  it 'keeps the uncollected toggle in sync with the collapse-all / expand-all buttons' do
+    visit authority_path(author)
+    expect(page).to have_css(uncollected_toggle_sel)
+
+    find('#max_collapse').click
+    expect(page).to have_css("#{uncollected_toggle_sel}.collapsed")
+    expect(page).to have_css("#{uncollected_sel} > ul.toclist", visible: :hidden)
+    expect(page).to have_no_css("#{uncollected_toggle_sel}[aria-expanded='true']")
+
+    find('#expand-all').click
+    expect(page).to have_css("#{uncollected_toggle_sel}:not(.collapsed)")
+    expect(page).to have_css("#{uncollected_sel} > ul.toclist", visible: :visible)
+    expect(page).to have_no_css("#{uncollected_toggle_sel}[aria-expanded='false']")
+  end
+end


### PR DESCRIPTION
Two independent fixes.

## 1. Periodicals gateway: exclude periodicals with no publicly accessible works

`/periodicals` listed every periodical that had at least one issue, even when none of those issues contained a **published** manifestation — so readers clicked through to empty pages. (In the current dev DB, 3 of 10 periodicals were in that state.)

Such periodicals are now dropped from the list, the count and the "spotlight" pick.

The check lives in a new `Collection.ids_with_published_manifestations(ids)`: a bulk equivalent of the existing `Collection#any_published_manifestations?`, with the same semantics (status `published`, at any depth of the item tree). It walks all the trees one level at a time — two queries per level of nesting — instead of the per-item queries a plain `select(&:any_published_manifestations?)` would cost. Each (collection, ancestor) pair is visited once, so a sub-collection shared by several periodicals is still attributed to each of them.

## 2. Authority TOC: the uncollected-works section is now collapsible

Volume cards carry a chevron collapse toggle; the uncollected-works card had none. It could therefore be collapsed by *collapse-all* but never re-opened on its own. It now carries the same `.volume-collapse-toggle`, trailing its explanation line, so it collapses/expands independently and stays in sync with collapse-all / expand-all. Its `font-size` is pinned in `application.scss` so it renders at the same visual size as the volume chevrons (the explanation line it sits on is deliberately small).

New i18n key `toggle_collapse_uncollected` in both `he.yml` and `en.yml`.

## Test plan

Specs run (all green, 125 examples):

- `spec/models/collection_spec.rb` — new `.ids_with_published_manifestations` group: published at depth 1, published nested under issue → series, unpublished-only and empty collections excluded, shared sub-collection attributed to every ancestor, and agreement with `#any_published_manifestations?`.
- `spec/requests/periodicals_spec.rb` — new group covering suppression of a periodical whose issue holds only an unpublished work and of one whose issue is empty, plus a periodical whose published work sits in a sub-collection of the issue.
- `spec/system/author_toc_uncollected_collapse_toggle_spec.rb` (new) — the uncollected toggle collapses/re-expands only its own list (the volume's list stays open) and stays in sync with collapse-all / expand-all.
- `spec/system/author_toc_volume_collapse_toggle_spec.rb` — unchanged, still green.

Also re-ran, unchanged and green: `spec/system/author_toc_colls_abc_spec.rb`, `author_toc_filters_spec.rb`, `author_toc_mobile_layout_spec.rb`, `author_navbar_collection_type_filtering_spec.rb`, `author_lex_citations_spec.rb`, `toc_paratext_collapse_spec.rb`, `periodical_toc_display_spec.rb`, `periodicals_whatsnew_spec.rb`.

The layout of the new toggle was verified with a headless-browser screenshot.

**The full suite was not run** (40+ min) — it needs a reviewer's go-ahead.

### Note on pre-existing spec fixtures

Three existing groups in `spec/requests/periodicals_spec.rb` built periodicals whose issues held *no* manifestations at all; under the new rule those periodicals are correctly suppressed, which would have broken assertions unrelated to this change. Each of those fixtures now gets one published manifestation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)