### PR TITLE
Omit the copyrighted checkbox from the /authors intellectual-property filter

### DIFF
--- a/app/views/authors/_browse_filters.html.haml
+++ b/app/views/authors/_browse_filters.html.haml
@@ -20,13 +20,19 @@
                        selected_values: @genders,
                        facet: @gender_facet }
 
-    - labels = Authority.intellectual_properties.keys.reject{|x| x == 'copyrighted'}.index_with { |key| textify_intellectual_property(key) }
-    - icons = Authority.intellectual_properties.keys.reject{|x| x == 'copyrighted'}.index_with { |key| intellectual_property_glyph(key) }
+    -#
+      Copyrighted authorities are deliberately not offered as a filter, so the
+      value must be dropped from the checkbox list itself and not just from the
+      labels/icons -- otherwise an unlabeled checkbox is still rendered.
+    :ruby
+      ip_values = Authority.intellectual_properties.keys.reject { |x| x == 'copyrighted' }
+      labels = ip_values.index_with { |key| textify_intellectual_property(key) }
+      icons = ip_values.index_with { |key| intellectual_property_glyph(key) }
     = render partial: 'shared/filters/checkbox_group',
              locals: { group_name: :intellectual_property,
                        title: Authority.human_attribute_name(:intellectual_property),
                        field_name: :ckb_intellectual_property,
-                       all_values: Authority.intellectual_properties.keys,
+                       all_values: ip_values,
                        labels: labels,
                        selected_values: @intellectual_property_types,
                        facet: @intellectual_property_facet,

--- a/spec/system/authors_intellectual_property_filter_spec.rb
+++ b/spec/system/authors_intellectual_property_filter_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# 'copyrighted' is deliberately not offered as a filter on /authors. The view
+# used to drop it from the labels and icons only, leaving an unlabeled checkbox
+# in the list.
+describe 'Authors intellectual property filter' do
+  before do
+    Chewy.strategy(:atomic) do
+      create(:manifestation, author: create(:authority, intellectual_property: :public_domain))
+      create(:manifestation, author: create(:authority, intellectual_property: :copyrighted))
+    end
+  end
+
+  after do
+    Chewy.massacre
+  end
+
+  it 'offers no checkbox for the copyrighted status' do
+    visit authors_path
+
+    expect(page).to have_css('#intellectual_property_public_domain', visible: :all)
+    expect(page).not_to have_css('#intellectual_property_copyrighted', visible: :all)
+  end
+
+  it 'labels every checkbox it does offer' do
+    visit authors_path
+
+    labels = page.all('#collfcollfintellectual_property .filter-checkbox label', visible: :all)
+    expect(labels).not_to be_empty
+    # Each label carries the status name plus a "(count)" span; a value missing
+    # from the labels hash would leave only the count.
+    labels.each do |label|
+      expect(label.text(:all).sub(/\(.*\)\s*\z/, '').strip).not_to be_empty
+    end
+  end
+end


### PR DESCRIPTION
## Problem

`/authors` deliberately does not offer *copyrighted* as an intellectual-property filter. `app/views/authors/_browse_filters.html.haml` rejected the value from the `labels` and `icons` hashes, but passed the unfiltered `Authority.intellectual_properties.keys` as `all_values` — so `shared/filters/_checkboxes` still rendered a checkbox for it, with a blank label and no icon.

## Change

Derive `all_values`, `labels` and `icons` from a single filtered list, which also removes the duplicated `.reject`.

## Test plan

New `spec/system/authors_intellectual_property_filter_spec.rb`:
- no `#intellectual_property_copyrighted` checkbox is rendered, while `#intellectual_property_public_domain` still is;
- every checkbox the group does render carries a non-empty label (the general form of the bug — a value present in `all_values` but missing from `labels`).

Both examples fail against the unpatched view and pass with it.

Specs run: the new file plus `authors_filter_panel_spec.rb`, `browse_filter_checkbox_alignment_spec.rb`, `filter_label_click_spec.rb`, `authors_controller_spec.rb` — 81 examples, 0 failures. **The full suite was not run** (40+ min) and needs your approval.

Closes beads_by-32o

🤖 Generated with [Claude Code](https://claude.com/claude-code)