### PR TITLE
Author TOC: wire up mobile filtering

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -28,11 +28,12 @@ var mobileWidth = 767;
 function isMobile() {
   return window.innerWidth < mobileWidth;
 }
-// Browse lists (/works, /authors, /collections): on narrow screens the
-// sort/filter panel is collapsed by CSS so the list starts in the first
-// screenful, and #mobile_filter_btn is the single control that reveals it.
-// The open state lives on <body> because the panel and the buttons that drive
-// it sit in different subtrees (the buttons are in the fixed page header).
+// Browse lists (/works, /authors, /collections) and the authority TOC: on
+// narrow screens the sort/filter panel is collapsed by CSS so the list starts
+// in the first screenful, and #mobile_filter_btn is the single control that
+// reveals it. The open state lives on <body> because the panel and the buttons
+// that drive it sit in different subtrees (the buttons are in the fixed page
+// header).
 function setMobileFiltersOpen(isOpen) {
   $('body').toggleClass('mobile-filters-open', isOpen);
   var btn = $('#mobile_filter_btn');
@@ -51,12 +52,17 @@ $(document).on('click', '#mobile_filter_btn', function() {
 
 // #apply_mobile_filters submits the filter form (via its `form` attribute) and
 // collapses the panel again, putting the freshly filtered list back on screen.
+// Pages that filter live and have no #thelist card (the authority TOC) scroll
+// to their own list in their own handler.
 $(document).on('click', '#apply_mobile_filters', function() {
   if (typeof resetPagination === 'function') {
     resetPagination();
   }
   closeMobileFilters();
-  $('html').scrollTop($('#thelist').offset().top);
+  var list = $('#thelist');
+  if (list.length) {
+    $('html').scrollTop(list.offset().top);
+  }
 });
 
 function startModal(id) {

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1642,6 +1642,25 @@ p.by-genre-name-v02.headline-2-v02 {
   }
 }
 
+// The mobile filter toggle and its "apply" companion (shared/_mobile_filter_toggle)
+// share one row. That row is inside the fixed page header, so both stay on
+// screen while the user scrolls a long filter panel -- which is the whole point
+// of hoisting "apply" out of the foot of that panel. Both pages that render the
+// partial want this layout, but at different breakpoints, hence a mixin.
+@mixin mobile-filter-toggle-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+
+  // .by-button-v02 is a fixed 32px tall box, so a label that wraps to a
+  // second line spills out of it. As flex items these buttons would happily
+  // be squeezed narrow enough to wrap.
+  button {
+    flex: none;
+    white-space: nowrap;
+  }
+}
+
 // Browse lists (/works, /authors, /collections): below the Bootstrap `md`
 // breakpoint the filter column and the list column stack, and the filter panel
 // comes first in source order -- which pushed the list off the first screenful
@@ -1656,21 +1675,8 @@ p.by-genre-name-v02.headline-2-v02 {
     display: block;
   }
 
-  // Toggle and "apply" share one row. The row is inside the fixed #header, so
-  // both stay on screen while the user scrolls a long filter panel -- which is
-  // the whole point of hoisting "apply" out of the foot of that panel.
   .mobile-filter-toggle {
-    display: flex;
-    align-items: center;
-    gap: 6px;
-
-    // .by-button-v02 is a fixed 32px tall box, so a label that wraps to a
-    // second line spills out of it. As flex items these buttons would happily
-    // be squeezed narrow enough to wrap.
-    button {
-      flex: none;
-      white-space: nowrap;
-    }
+    @include mobile-filter-toggle-row;
   }
 
   // "Apply" only means something while the panel is open.
@@ -1691,5 +1697,64 @@ p.by-genre-name-v02.headline-2-v02 {
 @media only screen and (min-width: 768px) {
   .author-page-top-sort-mobile.mobile-filter-toggle {
     display: none;
+  }
+}
+
+// Authority TOC (/authors/:id) filters pane. Hidden until one of the flat sort
+// orders puts the list into filter mode and adds .pane-visible (showFilterPane
+// in authors/_generated_toc). A class rather than an inline display, so the
+// mobile rules below can override it.
+#toc_filters_pane {
+  display: none;
+}
+
+#toc_filters_pane.pane-visible {
+  display: block;
+}
+
+// The TOC's "mobile" band is everything below 992px: that is where BY CSS
+// swaps .author-page-top-sort-desktop for .author-page-top-sort-mobile and
+// shrinks .author-side-nav-col -- the column holding the pane -- to a 34px
+// rail. (The browse lists' band is below 768px, where their columns stack.)
+@media only screen and (max-width: 991px) {
+  .toc-mobile-filter-toggle {
+    @include mobile-filter-toggle-row;
+  }
+
+  // "Apply" only means something while the pane is open.
+  .toc-mobile-filter-toggle #apply_mobile_filters {
+    display: none;
+  }
+
+  body.mobile-filters-open .toc-mobile-filter-toggle #apply_mobile_filters {
+    display: block;
+  }
+
+  // The pane cannot be shown in place inside that 34px rail, so entering filter
+  // mode is not enough here: reveal it as a fixed full-width sheet below the
+  // page header -- the treatment this page already gives its in-page navbar
+  // when expanded (.book-nav-full.mobile-expanded) -- and only while
+  // #mobile_filter_btn reports it open.
+  //
+  // --toc-sheet-top is measured from the fixed #header at runtime (see
+  // authors/_author_top), because this page's header is both taller than the
+  // literal below and variable: it carries a breadcrumbs and an author row, and
+  // shrinks again once the page is scrolled. The literal is only the pre-JS
+  // fallback. Without it the sheet's own header -- "filter by" and the reset
+  // link -- hides behind the page header.
+  #toc_filters_pane.pane-visible {
+    display: none;
+  }
+
+  body.mobile-filters-open #toc_filters_pane.pane-visible {
+    display: block;
+    position: fixed;
+    top: var(--toc-sheet-top, 120px);
+    right: 0;
+    left: 0;
+    max-height: calc(100vh - var(--toc-sheet-top, 120px));
+    overflow-y: auto;
+    z-index: 1000;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
   }
 }

--- a/app/views/authors/_author_top.html.haml
+++ b/app/views/authors/_author_top.html.haml
@@ -19,8 +19,14 @@
             %button.toggle-background-no#toc-filter-toggle{ type: 'button', title: t(:toggle_filters_tt), 'aria-label': t(:toggle_filters_tt) }
               .toggle-button-no
               .toggle-button-yes{ style: 'display:none' }
-          .author-page-top-sort-mobile
-            %button.btn-small-outline-v02.btn-text-v02.notyet= t(:sort_and_filter)
+          -# Same story on mobile: legacy-TOC authors keep the inert placeholder,
+          -# new-method ones get the toggle + "apply" row used by the browse lists.
+          - if @author.toc.present?
+            .author-page-top-sort-mobile
+              %button.btn-small-outline-v02.btn-text-v02.notyet= t(:sort_and_filter)
+          - else
+            = render partial: 'shared/mobile_filter_toggle',
+                     locals: { wrapper_class: 'toc-mobile-filter-toggle', panel_id: 'toc_filters_pane' }
         .author-page-top-icons-desktop
           .top-left-icons-group
             .linkcolor.pointer.by-icon-v02.notyet{title: t(:author_liked_tt)}= '5'
@@ -96,4 +102,43 @@
     });
     $('#sort_by').on('change', syncSortToggle);
     syncSortToggle();
+
+    // Sort/filter toggle (mobile): the pane itself is revealed by the shared
+    // #mobile_filter_btn handler in application.js; all this adds is the other
+    // half of what the desktop toggle does, putting the list into flat
+    // ("filter") mode, which is the mode the pane filters. Unlike the desktop
+    // toggle, closing the sheet leaves the filtered list in place -- the sort
+    // dropdown is the way back to the grouped view, as it is on the browse
+    // lists. This handler is bound directly, so it runs before the delegated
+    // one and still sees the pre-click open state.
+    $('#mobile_filter_btn').click(function() {
+      var $sort = $('#sort_by');
+      if (!$sort.length) { return; }
+      var opening = !$('body').hasClass('mobile-filters-open');
+      var val = $sort.val();
+      var flat = val !== 'colls' && val !== 'colls_abc';
+      if (opening && !flat) {
+        $sort.val('title').trigger('change');
+      }
+    });
+
+    // The mobile sheet is fixed below the page header, whose height varies with
+    // the breadcrumbs/author rows and shrinks again once the page is scrolled,
+    // so feed the measurement to the stylesheet. Delegated, so it runs after
+    // application.js's own delegated toggle has updated the open state.
+    function positionMobileFilterSheet() {
+      if (!$('body').hasClass('mobile-filters-open')) { return; }
+      document.documentElement.style.setProperty('--toc-sheet-top', ($('#header').outerHeight() || 0) + 'px');
+    }
+    $(document).on('click', '#mobile_filter_btn', positionMobileFilterSheet);
+    $(window).on('scroll resize', positionMobileFilterSheet);
+
+    // "Apply" collapses the sheet (shared handler) over the freshly filtered
+    // list: bring that list into view rather than the top of the author card,
+    // clearing the fixed page header.
+    $('#apply_mobile_filters').click(function() {
+      var $list = $('#browse_mainlist');
+      if (!$list.length) { return; }
+      $('html, body').scrollTop($list.offset().top - ($('#header').outerHeight() || 0));
+    });
   });

--- a/app/views/authors/_generated_toc.html.haml
+++ b/app/views/authors/_generated_toc.html.haml
@@ -244,15 +244,18 @@
       });
     }
 
+    // The pane's visibility is a class, not an inline display, so that the
+    // mobile rules can keep it collapsed until #mobile_filter_btn opens it.
     function showFilterPane(show) {
       var $navs = $('.author-side-nav-col .book-nav-full, .author-side-nav-col .book-nav-thin');
+      $('#toc_filters_pane').toggleClass('pane-visible', show);
       if (show) {
         $navs.hide();
-        $('#toc_filters_pane').show();
       } else {
-        $('#toc_filters_pane').hide();
         // Clear inline display so breakpoint CSS controls which navbar is visible
         $navs.css('display', '');
+        // Leaving filter mode: the mobile sheet has nothing left to show.
+        if (typeof closeMobileFilters === 'function') { closeMobileFilters(); }
       }
     }
 

--- a/app/views/authors/_toc_filters.html.haml
+++ b/app/views/authors/_toc_filters.html.haml
@@ -3,7 +3,11 @@
 - if fd.present?
   - translated_langs = fd[:orig_langs].reject { |l| l == 'he' }.sort_by { |l| textify_lang(l) }
   - has_hebrew = fd[:orig_langs].include?('he')
-  .by-card-v02.author-side-sort#toc_filters_pane{ style: 'display:none;' }
+  -#
+    Hidden until a flat sort adds .pane-visible (see showFilterPane in
+    authors/_generated_toc); display is CSS-driven, not an inline style, so the
+    mobile rules can present it as a sheet instead.
+  .by-card-v02.author-side-sort#toc_filters_pane
     .by-card-content-v02
       .headline-2-v02= t(:filter_by)
       %a.reset#toc-filter-reset{ href: '#' }= t(:reset_filter)

--- a/app/views/shared/_mobile_filter_toggle.html.haml
+++ b/app/views/shared/_mobile_filter_toggle.html.haml
@@ -1,17 +1,23 @@
 -#
-  Mobile-only controls for the sort/filter panel of the browse lists.
-  On narrow screens the panel (#sort_filter_panel) is collapsed by default so
-  that the list itself is in the first screenful; #mobile_filter_btn reveals it.
+  Mobile-only controls for the sort/filter panel of the browse lists and of the
+  authority TOC. On narrow screens the panel is collapsed by default so that the
+  list itself is in the first screenful; #mobile_filter_btn reveals it.
   The "apply" button sits here, beside the toggle, rather than at the foot of
-  the panel: this row is inside the fixed #header, so it stays put while the
+  the panel: this row is inside the fixed page header, so it stays put while the
   user scrolls through a long filter panel. `form:` keeps it submitting the
-  filters form it is no longer nested in.
-- toggle_data = { show_label: t(:sort_and_filter), hide_label: t(:hide_sort_and_filter) }
-.author-page-top-sort-mobile.mobile-filter-toggle
+  filters form it is no longer nested in; pages whose filters apply live (the
+  authority TOC) pass no form_id, and there "apply" only collapses the panel
+  back over the results.
+:ruby
+  form_id = local_assigns[:form_id]
+  panel_id = local_assigns.fetch(:panel_id, 'sort_filter_panel')
+  wrapper_class = local_assigns.fetch(:wrapper_class, 'mobile-filter-toggle')
+  toggle_data = { show_label: t(:sort_and_filter), hide_label: t(:hide_sort_and_filter) }
+%div{ class: "author-page-top-sort-mobile #{wrapper_class}" }
   %button.btn-small-outline-v02.btn-text-v02#mobile_filter_btn{ type: 'button',
-                                                                'aria-controls' => 'sort_filter_panel',
+                                                                'aria-controls' => panel_id,
                                                                 'aria-expanded' => 'false',
                                                                 data: toggle_data }
     = t(:sort_and_filter)
-  %button.by-button-v02#apply_mobile_filters{ type: 'submit', form: form_id }
+  %button.by-button-v02#apply_mobile_filters{ type: form_id.present? ? 'submit' : 'button', form: form_id }
     = t(:apply_mobile_filters)

--- a/spec/system/author_toc_mobile_filter_spec.rb
+++ b/spec/system/author_toc_mobile_filter_spec.rb
@@ -1,0 +1,175 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# Mobile filtering for the authority TOC (/authors/:id). Below 992px the desktop
+# sort/filter toggle is hidden and the filters pane lives in a 34px nav rail, so
+# filtering used to be unreachable there (the mobile button was an inert
+# placeholder). It is now the same toggle + "apply" row the browse lists use,
+# and the pane is revealed as a sheet over the page.
+describe 'Author TOC mobile filtering', :js do
+  # Lazy `let` (not `let!`) so the WebDriver skip in the before hook can
+  # short-circuit without running the DB + Chewy setup when Chrome is unavailable.
+  let(:author) { create(:authority, name: 'Mobile Filter Author') }
+  let(:volume) { create(:collection, title: 'A Volume', collection_type: :volume) }
+
+  let(:poem) do
+    Chewy.strategy(:atomic) do
+      create(:manifestation, title: 'Alpha Poem', status: :published, author: author,
+                             genre: 'poetry', orig_lang: 'he', language: 'he')
+    end
+  end
+  let(:story) do
+    Chewy.strategy(:atomic) do
+      create(:manifestation, title: 'Beta Story', status: :published, author: author,
+                             genre: 'prose', orig_lang: 'he', language: 'he')
+    end
+  end
+
+  before do
+    skip 'WebDriver not available or misconfigured' unless webdriver_available?
+
+    create(:collection_item, collection: volume, item: poem)
+    create(:collection_item, collection: volume, item: story)
+    create(:involved_authority, authority: author, item: volume, role: 'editor')
+    page.driver.browser.manage.window.resize_to(375, 812)
+  end
+
+  after do
+    page.driver.browser.manage.window.resize_to(1400, 900)
+    Chewy.massacre
+  end
+
+  # True when the element is wholly inside the viewport right now.
+  def fully_on_screen?(selector)
+    page.evaluate_script(<<~JS)
+      (function() {
+        var rect = document.getElementById('#{selector}').getBoundingClientRect();
+        return rect.top >= 0 && rect.bottom <= window.innerHeight && rect.height > 0;
+      })()
+    JS
+  end
+
+  it 'starts with the works list showing and the filters collapsed behind the toggle' do
+    visit authority_path(author)
+    expect(page).to have_css('#browse_mainlist', wait: 5)
+
+    expect(page).to have_css('#mobile_filter_btn', visible: :visible)
+    expect(page).to have_css('#toc_filters_pane', visible: :hidden)
+    # The desktop toggle has no place here.
+    expect(page).to have_css('.author-page-top-sort-desktop', visible: :hidden)
+  end
+
+  it 'reveals the filters pane and puts the list into filter mode, then re-hides it' do
+    visit authority_path(author)
+    expect(page).to have_css('#browse_mainlist', wait: 5)
+
+    find('#mobile_filter_btn').click
+
+    expect(page).to have_css('#toc_filters_pane', visible: :visible, wait: 5)
+    # Same logic as the desktop toggle: filtering operates on the flat list.
+    expect(page).to have_css('#sorted_card .manifestation-node', minimum: 2)
+    expect(find('#sort_by').value).to eq('title')
+    expect(find('#mobile_filter_btn')['aria-expanded']).to eq('true')
+    expect(find('#mobile_filter_btn')).to have_text(I18n.t(:hide_sort_and_filter))
+
+    find('#mobile_filter_btn').click
+
+    expect(page).to have_css('#toc_filters_pane', visible: :hidden, wait: 5)
+    expect(find('#mobile_filter_btn')['aria-expanded']).to eq('false')
+    expect(find('#mobile_filter_btn')).to have_text(I18n.t(:sort_and_filter))
+  end
+
+  it 'offers the same filter content as the desktop pane, and filters the list' do
+    visit authority_path(author)
+    expect(page).to have_css('#browse_mainlist', wait: 5)
+
+    find('#mobile_filter_btn').click
+    expect(page).to have_css('#toc_filters_pane', visible: :visible, wait: 5)
+
+    # every section of the desktop pane is here
+    expect(page).to have_css('#toc-filter-name', visible: :visible)
+    expect(page).to have_css('#toc-filter-genre-poetry', visible: :all)
+    expect(page).to have_css('#toc-filter-lang-he', visible: :all)
+    expect(page).to have_css('#toc-filter-curatorial', visible: :all)
+    expect(page).to have_css('#toc-date-histogram', visible: :visible)
+
+    check 'toc-filter-genre-poetry'
+    within '#sorted_card' do
+      expect(page).to have_content('Alpha Poem')
+      expect(page).to have_no_content('Beta Story')
+    end
+  end
+
+  it 'keeps both buttons on screen while the pane is scrolled' do
+    visit authority_path(author)
+    expect(page).to have_css('#browse_mainlist', wait: 5)
+
+    # "Apply" is hidden until there is something to apply.
+    expect(page).to have_css('#apply_mobile_filters', visible: :hidden)
+
+    find('#mobile_filter_btn').click
+    expect(page).to have_css('#apply_mobile_filters', visible: :visible, wait: 5)
+
+    page.execute_script('window.scrollTo(0, 600)')
+    expect(page.evaluate_script('window.scrollY')).to be > 0
+
+    expect(fully_on_screen?('mobile_filter_btn')).to be true
+    expect(fully_on_screen?('apply_mobile_filters')).to be true
+  end
+
+  it 'collapses the pane over the filtered results when apply is clicked' do
+    visit authority_path(author)
+    expect(page).to have_css('#browse_mainlist', wait: 5)
+
+    find('#mobile_filter_btn').click
+    expect(page).to have_css('#apply_mobile_filters', visible: :visible, wait: 5)
+    check 'toc-filter-genre-poetry'
+
+    find('#apply_mobile_filters').click
+
+    expect(page).to have_css('#toc_filters_pane', visible: :hidden, wait: 5)
+    expect(find('#mobile_filter_btn')['aria-expanded']).to eq('false')
+    # The filtering survives the collapse -- as on the browse lists.
+    within '#sorted_card' do
+      expect(page).to have_content('Alpha Poem')
+      expect(page).to have_no_content('Beta Story')
+    end
+  end
+
+  # The sheet covers the sticky sort bar while it is open, so the route back to
+  # the grouped view is: collapse the sheet, then re-sort. The filters pane and
+  # the in-page navbar swap back, exactly as they do on desktop.
+  it 'restores the grouped view and the in-page navbar via the sort dropdown' do
+    visit authority_path(author)
+    expect(page).to have_css('#browse_mainlist', wait: 5)
+
+    find('#mobile_filter_btn').click
+    expect(page).to have_css('#toc_filters_pane', visible: :visible, wait: 5)
+    expect(page).to have_css('#sorted_card')
+
+    find('#apply_mobile_filters').click
+    expect(page).to have_css('#toc_filters_pane', visible: :hidden, wait: 5)
+
+    find("#sort_by option[value='colls']").select_option
+
+    expect(page).to have_no_css('#sorted_card')
+    expect(page).to have_css('#toc_filters_pane', visible: :hidden)
+    expect(find('#mobile_filter_btn')['aria-expanded']).to eq('false')
+    expect(page).to have_css('.book-nav-thin', visible: :visible)
+  end
+
+  context 'when on a desktop viewport' do
+    before { page.driver.browser.manage.window.resize_to(1400, 900) }
+
+    it 'hides the mobile toggle row and keeps the desktop toggle' do
+      visit authority_path(author)
+      expect(page).to have_css('#browse_mainlist', wait: 5)
+
+      expect(page).to have_css('.toc-mobile-filter-toggle', visible: :hidden)
+      expect(page).to have_css('#mobile_filter_btn', visible: :hidden)
+      expect(page).to have_css('#apply_mobile_filters', visible: :hidden)
+      expect(page).to have_css('.author-page-top-sort-desktop', visible: :visible)
+    end
+  end
+end


### PR DESCRIPTION
## What

The authority TOC page (`/authors/:id`) had no working filtering on mobile: the filters pane lives in the sticky nav column, which BY CSS shrinks to a 34px rail below 992px (and `.author-side-sort` is `display:none` there), while the mobile "sort and filter" button in the page header was an inert `.notyet` placeholder. Only the desktop toggle (hidden below 992px) could reach the pane.

That slot now renders the same toggle + "apply" row the browse lists use, and the pane is revealed as a fixed sheet below the page header — the treatment this page already gives its in-page navbar when expanded (`.book-nav-full.mobile-expanded`).

## Design and logic

- **Content**: the desktop pane, unchanged — work title, genre, source language, extra content, date histogram/range, faceted counts, reset.
- **Logic**: opening the sheet puts the list into flat ("filter") mode exactly as the desktop toggle does; filtering stays live.
- **Difference from the desktop toggle**: closing the sheet keeps the filtered list rather than reverting to the grouped view — matching /works and /authors, where the way back is the sort dropdown (still offered on mobile by the sticky sort bar). Note the sheet covers that bar while open, so the flow is: collapse, then re-sort.
- The TOC's mobile band is `<992px` (where BY CSS swaps the desktop toggle for `.author-page-top-sort-mobile`), not the browse lists' `<768px`, hence a separate wrapper class over a shared mixin.
- Legacy-TOC authors have no filters pane at all and keep the placeholder button.

## Notable implementation details

- `shared/_mobile_filter_toggle` gains optional `form_id` (live-filtering pages pass none, so "apply" is a plain button that just collapses the sheet), `panel_id` (for a correct `aria-controls`) and `wrapper_class`.
- `#toc_filters_pane` visibility moves from jQuery `show()`/`hide()` to a `.pane-visible` class, so the mobile rules can override it from CSS.
- The sheet's top is measured from `#header` at runtime into `--toc-sheet-top` (as `lexicon/entries/_navbar` does with `--lexicon-sticky-top`): this page's header is taller than the navbar overlay's literal 120px and shrinks when scrolled, and without the measurement the sheet's own "filter by" headline and reset link hid behind it.
- The shared `#apply_mobile_filters` handler now guards the missing `#thelist` (the TOC has no such card and scrolls to its own list).

## Test plan

New `spec/system/author_toc_mobile_filter_spec.rb` (7 examples, all passing) at a 375x812 viewport: list-first initial state, toggle reveals the pane and enters flat mode, the pane carries every desktop section and filters the list, both buttons stay on screen while the pane is scrolled, apply collapses the sheet keeping the filtering, sort dropdown restores the grouped view and the in-page navbar, and the whole row is hidden on desktop.

Also re-ran, all green: `author_toc_filters_spec`, `browse_mobile_filter_toggle_spec`, `author_toc_mobile_layout_spec`, `requests/author_toc_filters_spec`, `author_toc_colls_abc_spec`, `author_toc_volume_collapse_toggle_spec`, `author_toc_uncollected_collapse_toggle_spec`, `author_navbar_mobile_expansion_spec`, `authors_filter_panel_spec` (52 examples). The full suite was **not** run — it takes 40+ minutes and needs your go-ahead.

Closes beads_by-17s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)