### PR TITLE
Mobile menu: link Lexicon to the public entries list

### DIFF
--- a/app/views/shared/_tabs.html.haml
+++ b/app/views/shared/_tabs.html.haml
@@ -156,7 +156,7 @@
                 = t(:list_all_authors)
             .by-dropdown-divider
             %li
-              %a{href: lexicon_entries_path}
+              %a{href: lexicon_root_path}
                 -# ICON TBD # %span.by-icon-v02.iconInMenu L
                 = t(:lexicon_name)
         %li.topMenuItemMobile-v02

--- a/spec/requests/mobile_menu_lexicon_link_spec.rb
+++ b/spec/requests/mobile_menu_lexicon_link_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# The desktop dropdown (#menu-authors) links the Lexicon item to the public
+# entries list (lexicon_root_path => entries#list). The mobile sidenav
+# (#menuMobile) pointed at lexicon_entries_path (/lex/entries), which is the
+# editor-only backend index: anonymous visitors were bounced to '/' with a
+# "not an editor" error, and editors landed in the lexicon backend instead of
+# the public list.
+RSpec.describe 'Mobile menu Lexicon link', type: :request do
+  around do |example|
+    I18n.with_locale(:he) { example.run }
+  end
+
+  def mobile_menu
+    menu = Nokogiri::HTML(response.body).at_css('#menuMobile')
+    expect(menu).not_to be_nil, 'the mobile menu (#menuMobile) is missing from the page'
+    menu
+  end
+
+  before { get root_path }
+
+  it 'links to the public lexicon entries list, not the editor-only backend' do
+    expect(response).to have_http_status(:ok)
+
+    links = mobile_menu.css('a').select { |a| a.text.include?(I18n.t(:lexicon_name)) }
+    expect(links).not_to be_empty, 'no link to the lexicon in the mobile menu'
+    hrefs = links.pluck('href')
+    expect(hrefs).to include(lexicon_root_path)
+    expect(hrefs).not_to include(lexicon_entries_path)
+  end
+
+  it 'lets an anonymous visitor reach the linked page' do
+    href = mobile_menu.css('a').find { |a| a.text.include?(I18n.t(:lexicon_name)) }['href']
+
+    get href
+    expect(response).to have_http_status(:ok)
+  end
+end

--- a/spec/requests/mobile_menu_lexicon_link_spec.rb
+++ b/spec/requests/mobile_menu_lexicon_link_spec.rb
@@ -32,7 +32,9 @@ RSpec.describe 'Mobile menu Lexicon link', type: :request do
   end
 
   it 'lets an anonymous visitor reach the linked page' do
-    href = mobile_menu.css('a').find { |a| a.text.include?(I18n.t(:lexicon_name)) }['href']
+    link = mobile_menu.css('a').find { |a| a.text.include?(I18n.t(:lexicon_name)) }
+    expect(link).not_to be_nil, 'no link to the lexicon in the mobile menu'
+    href = link['href']
 
     get href
     expect(response).to have_http_status(:ok)


### PR DESCRIPTION
## Problem

On mobile, the Lexicon item in the sidenav menu pointed at `lexicon_entries_path` (`/lex/entries`) — the **editor-only backend index** — instead of the public entries list.

Consequences:
- Not logged in: `require_editor('edit_lexicon')` redirects to `/` with the "not an editor" message.
- Logged in: lands in the lexicon backend (files/admin area) rather than the public entries list.

The desktop dropdown has always used `lexicon_root_path` (`/lex` → `entries#list`, which is explicitly exempt from the editor check).

## Fix

`app/views/shared/_tabs.html.haml:159` — mobile menu now links to `lexicon_root_path`, matching desktop.

## Tests

New regression spec `spec/requests/mobile_menu_lexicon_link_spec.rb`:
- asserts the mobile menu's Lexicon link points at `lexicon_root_path` and *not* at `lexicon_entries_path`
- follows the link as an anonymous visitor and asserts a 200 (would have been a 302 to `/` before)

Verified both examples fail with the fix reverted and pass with it.

```
bundle exec rspec spec/requests/mobile_menu_lexicon_link_spec.rb spec/requests/mobile_menu_collections_link_spec.rb
4 examples, 0 failures
```

RuboCop clean on the new spec; haml-lint on `_tabs.html.haml` reports only pre-existing lints (none on the changed line).

The full suite was **not** run (40+ min) — it needs your approval.

Closes beads_by-omc

🤖 Generated with [Claude Code](https://claude.com/claude-code)